### PR TITLE
Add support for Cursor CLI agent sessions (closes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Inspired by [cursor-chat-browser](https://github.com/thomas-pedersen/cursor-chat
 
 - Browse and search all workspaces with Cursor chat history
 - Support for both workspace-specific and global storage (newer Cursor versions)
+- **Cursor CLI agent sessions** — browses and exports sessions from `cursor agent` (stored in `~/.cursor/chats/`)
 - View AI chat and Composer/Agent logs
 - Organize chats by workspace/project
 - Full-text search with filters for chat/composer logs
@@ -101,7 +102,9 @@ python scripts/export.py --no-composer
 
 - **Zip mode** (default): A single `cursor-export-YYYY-MM-DD.zip` file containing all Markdown files organized by date, workspace, and chat.
 - **File mode** (`--no-zip`): Individual Markdown files at `<out>/YYYY-MM-DD/<workspace>/chat/<timestamp>__<title>__<id>.md`, plus a `manifest.jsonl` index.
-- Each Markdown file includes YAML frontmatter (log ID, title, timestamps, message count, model, token usage, etc.) and the full conversation transcript.
+- Each Markdown file includes YAML frontmatter (log ID, title, timestamps, message count, model, token usage, tool calls, etc.) and the full conversation transcript.
+- IDE chats are written under `<workspace>/chat/`; Cursor CLI agent sessions are written under `<workspace>/cli/`.
+- If the Cursor IDE database is absent (e.g. on a machine with only `cursor agent` installed), only CLI sessions are exported — the script no longer exits with an error.
 
 Export state is saved to `~/.cursor-chat-browser/export_state.json` so that `--since last` works across runs.
 
@@ -119,6 +122,8 @@ The application automatically detects your Cursor workspace storage location:
 
 To override, set the `WORKSPACE_PATH` environment variable or use the Configuration page in the web UI.
 
+Cursor CLI agent sessions are read from `~/.cursor/chats/` (the default path used by the `cursor agent` CLI). Override with the `CLI_CHATS_PATH` environment variable.
+
 ## Project Structure
 
 ```
@@ -134,7 +139,9 @@ cursor-chat-browser-python/
 │   ├── pdf.py              # /api/generate-pdf endpoint
 │   └── config_api.py       # Config-related endpoints
 ├── utils/                  # Utility modules
-│   ├── workspace_path.py   # Workspace path detection
+│   ├── workspace_path.py   # Workspace path detection (IDE + CLI)
+│   ├── cli_chat_reader.py  # Reader for Cursor CLI agent sessions (~/.cursor/chats/)
+│   ├── cursor_md_exporter.py # Markdown exporter for CLI agent sessions
 │   ├── path_helpers.py     # Path normalization helpers
 │   ├── text_extract.py     # Text extraction from bubbles
 │   └── tool_parser.py      # Tool call parsing

--- a/api/search.py
+++ b/api/search.py
@@ -13,9 +13,10 @@ from urllib.parse import unquote as _url_unquote
 from flask import Blueprint, current_app, jsonify, request
 
 from utils.exclusion_rules import build_searchable_text, is_excluded_by_rules
-from utils.workspace_path import resolve_workspace_path
+from utils.workspace_path import resolve_workspace_path, get_cli_chats_path
 from utils.path_helpers import normalize_file_path, get_workspace_folder_paths, to_epoch_ms
 from utils.text_extract import extract_text_from_bubble
+from utils.cli_chat_reader import list_cli_projects, traverse_blobs, messages_to_bubbles
 
 bp = Blueprint("search", __name__)
 
@@ -342,6 +343,82 @@ def search():
                     pass
         except Exception:
             pass
+
+        # ---------------------------------------------------------------
+        # Search Cursor CLI sessions
+        # ---------------------------------------------------------------
+        try:
+            cli_projects = list_cli_projects(get_cli_chats_path())
+            for cp in cli_projects:
+                ws_name = cp["workspace_name"] or cp["project_id"][:12]
+                for session in cp["sessions"]:
+                    meta = session.get("meta", {})
+                    session_id = session["session_id"]
+                    created_ms: int = meta.get("createdAt") or int(datetime.now().timestamp() * 1000)
+                    session_name = meta.get("name") or f"Session {session_id[:8]}"
+
+                    try:
+                        messages = traverse_blobs(session["db_path"])
+                    except Exception:
+                        continue
+
+                    bubbles = messages_to_bubbles(messages, created_ms)
+                    if not bubbles:
+                        continue
+
+                    # Derive title
+                    title = session_name
+                    if not title or title.startswith("New Agent"):
+                        for b in bubbles:
+                            if b["type"] == "user" and b.get("text"):
+                                first_lines = [l for l in b["text"].split("\n") if l.strip()]
+                                if first_lines:
+                                    title = first_lines[0][:100]
+                                break
+
+                    bubble_texts = [b["text"] for b in bubbles if b.get("text")]
+                    exclusion_text = _build_exclusion_searchable(
+                        project_name=ws_name,
+                        chat_title=title,
+                        content_parts=bubble_texts,
+                    )
+                    if is_excluded_by_rules(rules, exclusion_text):
+                        continue
+
+                    has_match = False
+                    matching_text = ""
+
+                    if title and query_lower in title.lower():
+                        has_match = True
+                        matching_text = title
+
+                    if not has_match:
+                        for text in bubble_texts:
+                            if text and query_lower in text.lower():
+                                has_match = True
+                                idx = text.lower().find(query_lower)
+                                start = max(0, idx - 80)
+                                end = min(len(text), idx + len(query) + 120)
+                                matching_text = (
+                                    ("..." if start > 0 else "")
+                                    + text[start:end]
+                                    + ("..." if end < len(text) else "")
+                                )
+                                break
+
+                    if has_match:
+                        results.append({
+                            "workspaceId": f"cli:{cp['project_id']}",
+                            "workspaceFolder": cp.get("workspace_path"),
+                            "chatId": session_id,
+                            "chatTitle": title,
+                            "timestamp": created_ms,
+                            "matchingText": matching_text,
+                            "type": "cli_agent",
+                            "source": "cli",
+                        })
+        except Exception as e:
+            print(f"Error searching CLI sessions: {e}")
 
         # Sort by timestamp descending
         def _ts(r):

--- a/api/search.py
+++ b/api/search.py
@@ -345,80 +345,81 @@ def search():
             pass
 
         # ---------------------------------------------------------------
-        # Search Cursor CLI sessions
+        # Search Cursor CLI sessions (only for type=all)
         # ---------------------------------------------------------------
-        try:
-            cli_projects = list_cli_projects(get_cli_chats_path())
-            for cp in cli_projects:
-                ws_name = cp["workspace_name"] or cp["project_id"][:12]
-                for session in cp["sessions"]:
-                    meta = session.get("meta", {})
-                    session_id = session["session_id"]
-                    created_ms: int = meta.get("createdAt") or int(datetime.now().timestamp() * 1000)
-                    session_name = meta.get("name") or f"Session {session_id[:8]}"
+        if search_type == "all":
+            try:
+                cli_projects = list_cli_projects(get_cli_chats_path())
+                for cp in cli_projects:
+                    ws_name = cp["workspace_name"] or cp["project_id"][:12]
+                    for session in cp["sessions"]:
+                        meta = session.get("meta", {})
+                        session_id = session["session_id"]
+                        created_ms: int = meta.get("createdAt") or int(datetime.now().timestamp() * 1000)
+                        session_name = meta.get("name") or f"Session {session_id[:8]}"
 
-                    try:
-                        messages = traverse_blobs(session["db_path"])
-                    except Exception:
-                        continue
+                        try:
+                            messages = traverse_blobs(session["db_path"])
+                        except Exception:
+                            continue
 
-                    bubbles = messages_to_bubbles(messages, created_ms)
-                    if not bubbles:
-                        continue
+                        bubbles = messages_to_bubbles(messages, created_ms)
+                        if not bubbles:
+                            continue
 
-                    # Derive title
-                    title = session_name
-                    if not title or title.startswith("New Agent"):
-                        for b in bubbles:
-                            if b["type"] == "user" and b.get("text"):
-                                first_lines = [l for l in b["text"].split("\n") if l.strip()]
-                                if first_lines:
-                                    title = first_lines[0][:100]
-                                break
+                        # Derive title
+                        title = session_name
+                        if not title or title.startswith("New Agent"):
+                            for b in bubbles:
+                                if b["type"] == "user" and b.get("text"):
+                                    first_lines = [ln for ln in b["text"].split("\n") if ln.strip()]
+                                    if first_lines:
+                                        title = first_lines[0][:100]
+                                    break
 
-                    bubble_texts = [b["text"] for b in bubbles if b.get("text")]
-                    exclusion_text = _build_exclusion_searchable(
-                        project_name=ws_name,
-                        chat_title=title,
-                        content_parts=bubble_texts,
-                    )
-                    if is_excluded_by_rules(rules, exclusion_text):
-                        continue
+                        bubble_texts = [b["text"] for b in bubbles if b.get("text")]
+                        exclusion_text = _build_exclusion_searchable(
+                            project_name=ws_name,
+                            chat_title=title,
+                            content_parts=bubble_texts,
+                        )
+                        if is_excluded_by_rules(rules, exclusion_text):
+                            continue
 
-                    has_match = False
-                    matching_text = ""
+                        has_match = False
+                        matching_text = ""
 
-                    if title and query_lower in title.lower():
-                        has_match = True
-                        matching_text = title
+                        if title and query_lower in title.lower():
+                            has_match = True
+                            matching_text = title
 
-                    if not has_match:
-                        for text in bubble_texts:
-                            if text and query_lower in text.lower():
-                                has_match = True
-                                idx = text.lower().find(query_lower)
-                                start = max(0, idx - 80)
-                                end = min(len(text), idx + len(query) + 120)
-                                matching_text = (
-                                    ("..." if start > 0 else "")
-                                    + text[start:end]
-                                    + ("..." if end < len(text) else "")
-                                )
-                                break
+                        if not has_match:
+                            for text in bubble_texts:
+                                if text and query_lower in text.lower():
+                                    has_match = True
+                                    idx = text.lower().find(query_lower)
+                                    start = max(0, idx - 80)
+                                    end = min(len(text), idx + len(query) + 120)
+                                    matching_text = (
+                                        ("..." if start > 0 else "")
+                                        + text[start:end]
+                                        + ("..." if end < len(text) else "")
+                                    )
+                                    break
 
-                    if has_match:
-                        results.append({
-                            "workspaceId": f"cli:{cp['project_id']}",
-                            "workspaceFolder": cp.get("workspace_path"),
-                            "chatId": session_id,
-                            "chatTitle": title,
-                            "timestamp": created_ms,
-                            "matchingText": matching_text,
-                            "type": "cli_agent",
-                            "source": "cli",
-                        })
-        except Exception as e:
-            print(f"Error searching CLI sessions: {e}")
+                        if has_match:
+                            results.append({
+                                "workspaceId": f"cli:{cp['project_id']}",
+                                "workspaceFolder": cp.get("workspace_path"),
+                                "chatId": session_id,
+                                "chatTitle": title,
+                                "timestamp": created_ms,
+                                "matchingText": matching_text,
+                                "type": "cli_agent",
+                                "source": "cli",
+                            })
+            except Exception as e:
+                print(f"Error searching CLI sessions: {e}")
 
         # Sort by timestamp descending
         def _ts(r):

--- a/api/search.py
+++ b/api/search.py
@@ -378,10 +378,15 @@ def search():
                                     break
 
                         bubble_texts = [b["text"] for b in bubbles if b.get("text")]
+                        tool_payloads = [
+                            tc.get("input") or tc.get("summary") or ""
+                            for b in bubbles
+                            for tc in (b.get("metadata") or {}).get("toolCalls") or []
+                        ]
                         exclusion_text = _build_exclusion_searchable(
                             project_name=ws_name,
                             chat_title=title,
-                            content_parts=bubble_texts,
+                            content_parts=bubble_texts + tool_payloads,
                         )
                         if is_excluded_by_rules(rules, exclusion_text):
                             continue

--- a/api/workspaces.py
+++ b/api/workspaces.py
@@ -17,7 +17,12 @@ from urllib.parse import unquote, urlparse
 
 from flask import Blueprint, current_app, jsonify
 
-from utils.workspace_path import resolve_workspace_path
+from utils.workspace_path import resolve_workspace_path, get_cli_chats_path
+from utils.cli_chat_reader import (
+    list_cli_projects,
+    traverse_blobs,
+    messages_to_bubbles,
+)
 from utils.path_helpers import (
     normalize_file_path,
     get_workspace_folder_paths,
@@ -712,6 +717,39 @@ def list_workspaces():
                 ),
             })
 
+        # --- Cursor CLI projects ---
+        try:
+            cli_projects = list_cli_projects(get_cli_chats_path())
+            for cp in cli_projects:
+                ws_name = cp["workspace_name"] or cp["project_id"][:12]
+                if is_excluded_by_rules(rules, ws_name):
+                    continue
+                convos = []
+                for s in cp["sessions"]:
+                    session_name = s["meta"].get("name") or f"Session {s['session_id'][:8]}"
+                    searchable = build_searchable_text(
+                        project_name=ws_name,
+                        chat_title=session_name,
+                    )
+                    if not is_excluded_by_rules(rules, searchable):
+                        convos.append(session_name)
+                if not convos:
+                    continue
+                last_ms = cp["last_updated_ms"]
+                projects.append({
+                    "id": f"cli:{cp['project_id']}",
+                    "name": ws_name,
+                    "conversationCount": len(convos),
+                    "lastModified": (
+                        datetime.fromtimestamp(last_ms / 1000, tz=timezone.utc).isoformat()
+                        if last_ms
+                        else datetime.now(tz=timezone.utc).isoformat()
+                    ),
+                    "source": "cli",
+                })
+        except Exception as e:
+            print(f"Failed to load CLI projects: {e}")
+
         projects.sort(key=lambda p: p["lastModified"], reverse=True)
         return jsonify(projects)
 
@@ -735,6 +773,26 @@ def get_workspace(workspace_id):
                 "folder": None,
                 "lastModified": datetime.now(tz=timezone.utc).isoformat(),
             })
+
+        if workspace_id.startswith("cli:"):
+            project_id = workspace_id[4:]
+            cli_projects = list_cli_projects(get_cli_chats_path())
+            for cp in cli_projects:
+                if cp["project_id"] == project_id:
+                    last_ms = cp["last_updated_ms"]
+                    return jsonify({
+                        "id": workspace_id,
+                        "name": cp["workspace_name"] or project_id[:12],
+                        "path": cp["workspace_path"],
+                        "folder": cp["workspace_path"],
+                        "lastModified": (
+                            datetime.fromtimestamp(last_ms / 1000, tz=timezone.utc).isoformat()
+                            if last_ms
+                            else datetime.now(tz=timezone.utc).isoformat()
+                        ),
+                        "source": "cli",
+                    })
+            return jsonify({"error": "CLI project not found"}), 404
 
         workspace_path = resolve_workspace_path()
         db_path = os.path.join(workspace_path, workspace_id, "state.vscdb")
@@ -782,6 +840,97 @@ def get_workspace(workspace_id):
 from utils.tool_parser import parse_tool_call as _parse_tool_call
 
 
+def _get_cli_workspace_tabs(workspace_id: str):
+    """Return tabs for a Cursor CLI project (``workspace_id`` starts with ``cli:``)."""
+    try:
+        project_id = workspace_id[4:]
+        cli_projects = list_cli_projects(get_cli_chats_path())
+        project = next((cp for cp in cli_projects if cp["project_id"] == project_id), None)
+        if project is None:
+            return jsonify({"error": "CLI project not found"}), 404
+
+        rules = current_app.config.get("EXCLUSION_RULES") or []
+        ws_name = project["workspace_name"] or project_id[:12]
+        tabs = []
+
+        for session in project["sessions"]:
+            meta = session.get("meta", {})
+            session_id = session["session_id"]
+            created_ms: int = meta.get("createdAt") or int(datetime.now().timestamp() * 1000)
+            session_name = meta.get("name") or f"Session {session_id[:8]}"
+
+            try:
+                messages = traverse_blobs(session["db_path"])
+            except Exception as e:
+                print(f"CLI: could not read session {session_id}: {e}")
+                continue
+
+            bubbles = messages_to_bubbles(messages, created_ms)
+            if not bubbles:
+                continue
+
+            # Derive title from first user bubble when name is generic
+            title = session_name
+            if not title or title.startswith("New Agent"):
+                for b in bubbles:
+                    if b["type"] == "user" and b.get("text"):
+                        first_lines = [l for l in b["text"].split("\n") if l.strip()]
+                        if first_lines:
+                            title = first_lines[0][:100]
+                            if len(title) == 100:
+                                title += "..."
+                        break
+
+            searchable = build_searchable_text(project_name=ws_name, chat_title=title)
+            if is_excluded_by_rules(rules, searchable):
+                continue
+
+            # Aggregate metadata
+            total_tool_calls = 0
+            tool_breakdown: dict = {}
+            for b in bubbles:
+                tcs = (b.get("metadata") or {}).get("toolCalls") or []
+                total_tool_calls += len(tcs)
+                for tc in tcs:
+                    tn = tc.get("name", "unknown")
+                    tool_breakdown[tn] = tool_breakdown.get(tn, 0) + 1
+
+            tab_meta: dict | None = None
+            if total_tool_calls or tool_breakdown:
+                tab_meta = {"totalToolCalls": total_tool_calls or None}
+                if tool_breakdown:
+                    tab_meta["toolBreakdown"] = tool_breakdown
+
+            tab = {
+                "id": session_id,
+                "title": title,
+                "timestamp": created_ms,
+                "bubbles": [
+                    {
+                        "type": b["type"],
+                        "text": b.get("text", ""),
+                        "timestamp": b.get("timestamp", created_ms),
+                        **({"metadata": b["metadata"]} if b.get("metadata") else {}),
+                    }
+                    for b in bubbles
+                ],
+                "source": "cli",
+            }
+            if tab_meta:
+                tab_meta_clean = {k: v for k, v in tab_meta.items() if v is not None}
+                if tab_meta_clean:
+                    tab["metadata"] = tab_meta_clean
+
+            tabs.append(tab)
+
+        tabs.sort(key=lambda t: t.get("timestamp") or 0, reverse=True)
+        return jsonify({"tabs": tabs})
+
+    except Exception as e:
+        print(f"Failed to get CLI workspace tabs: {e}")
+        return jsonify({"error": "Failed to get CLI workspace tabs"}), 500
+
+
 def _extract_chat_id_from_bubble_key(key: str) -> str | None:
     m = re.match(r"^bubbleId:([^:]+):", key)
     return m.group(1) if m else None
@@ -794,6 +943,9 @@ def _extract_chat_id_from_code_block_diff_key(key: str) -> str | None:
 
 @bp.route("/api/workspaces/<workspace_id>/tabs")
 def get_workspace_tabs(workspace_id):
+    if workspace_id.startswith("cli:"):
+        return _get_cli_workspace_tabs(workspace_id)
+
     global_db = None
     try:
         workspace_path = resolve_workspace_path()

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -30,6 +30,13 @@ from utils.exclusion_rules import (
 )
 from utils.path_helpers import get_workspace_folder_paths as _shared_get_workspace_folder_paths
 from utils.tool_parser import parse_tool_call
+from utils.workspace_path import get_cli_chats_path
+from utils.cli_chat_reader import (
+    list_cli_projects,
+    traverse_blobs,
+    messages_to_bubbles,
+    aggregate_session_stats,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -263,10 +270,6 @@ def main():
     workspace_path = resolve_workspace_path()
     global_path = os.path.normpath(os.path.join(workspace_path, "..", "globalStorage", "state.vscdb"))
 
-    if not os.path.isfile(global_path):
-        print(f"Cursor global storage not found: {global_path}", file=sys.stderr)
-        sys.exit(1)
-
     state_dir = get_global_state_dir()
     state_path = os.path.join(state_dir, "export_state.json")
     last_export = 0
@@ -280,101 +283,128 @@ def main():
         except Exception:
             pass
 
-    conn = sqlite3.connect(f"file:{global_path}?mode=ro", uri=True)
-    conn.row_factory = sqlite3.Row
+    # Pre-initialize IDE data — populated below only if the IDE database is accessible.
+    workspace_entries: list = []
+    workspace_path_to_id: dict = {}
+    project_name_to_ws: dict = {}
+    workspace_id_to_slug: dict = {}
+    workspace_id_to_display_name: dict[str, str] = {}
+    project_layouts_map: dict = {}
+    bubble_map: dict = {}
+    code_block_diff_map: dict = {}
+    ide_composer_rows: list = []
 
-    # Build workspace entries
-    workspace_entries = []
-    try:
-        for name in os.listdir(workspace_path):
-            full = os.path.join(workspace_path, name)
-            if os.path.isdir(full):
-                wp = os.path.join(full, "workspace.json")
-                if os.path.isfile(wp):
-                    workspace_entries.append({"name": name, "workspaceJsonPath": wp})
-    except Exception:
-        pass
-
-    workspace_path_to_id = {}
-    project_name_to_ws = {}
-    workspace_id_to_slug = {}
-    workspace_id_to_display_name: dict[str, str] = {}  # human-readable, URL-decoded folder name
-    for e in workspace_entries:
+    # Load IDE chat data — skipped gracefully when the database is absent or locked.
+    if not os.path.isfile(global_path):
+        print(f"Note: Cursor IDE global storage not found at {global_path} — skipping IDE chats.", file=sys.stderr)
+    else:
+        _conn = None
         try:
-            with open(e["workspaceJsonPath"], "r", encoding="utf-8") as f:
-                wd = json.load(f)
-            folders = get_workspace_folder_paths(wd)
-            first_folder = folders[0] if folders else None
-            if isinstance(first_folder, str) and first_folder:
-                fn = re.sub(r"^file://", "", first_folder).replace("\\", "/").split("/")[-1]
-                if fn:
-                    workspace_id_to_slug[e["name"]] = slug(fn)
-                    workspace_id_to_display_name[e["name"]] = _url_unquote(fn)
-            for folder in get_workspace_folder_paths(wd):
-                norm = normalize_file_path(folder)
-                workspace_path_to_id[norm] = e["name"]
-                fn2 = re.sub(r"^file://", "", folder).replace("\\", "/").split("/")[-1]
-                if fn2:
-                    project_name_to_ws[fn2] = e["name"]
-        except Exception:
-            pass
+            _conn = sqlite3.connect(f"file:{global_path}?mode=ro", uri=True)
+            _conn.row_factory = sqlite3.Row
 
-    # Project layouts
-    project_layouts_map = {}
-    try:
-        for row in conn.execute("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'messageRequestContext:%'"):
-            parts = row["key"].split(":")
-            if len(parts) < 2:
-                continue
-            cid = parts[1]
+            # Build workspace entries
             try:
-                ctx = json.loads(row["value"])
-                layouts = ctx.get("projectLayouts")
-                if isinstance(layouts, list):
-                    project_layouts_map.setdefault(cid, [])
-                    for l in layouts:
+                for name in os.listdir(workspace_path):
+                    full = os.path.join(workspace_path, name)
+                    if os.path.isdir(full):
+                        wp = os.path.join(full, "workspace.json")
+                        if os.path.isfile(wp):
+                            workspace_entries.append({"name": name, "workspaceJsonPath": wp})
+            except Exception:
+                pass
+
+            for e in workspace_entries:
+                try:
+                    with open(e["workspaceJsonPath"], "r", encoding="utf-8") as f:
+                        wd = json.load(f)
+                    folders = get_workspace_folder_paths(wd)
+                    first_folder = folders[0] if folders else None
+                    if isinstance(first_folder, str) and first_folder:
+                        fn = re.sub(r"^file://", "", first_folder).replace("\\", "/").split("/")[-1]
+                        if fn:
+                            workspace_id_to_slug[e["name"]] = slug(fn)
+                            workspace_id_to_display_name[e["name"]] = _url_unquote(fn)
+                    for folder in get_workspace_folder_paths(wd):
+                        norm = normalize_file_path(folder)
+                        workspace_path_to_id[norm] = e["name"]
+                        fn2 = re.sub(r"^file://", "", folder).replace("\\", "/").split("/")[-1]
+                        if fn2:
+                            project_name_to_ws[fn2] = e["name"]
+                except Exception:
+                    pass
+
+            # Project layouts
+            try:
+                for row in _conn.execute("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'messageRequestContext:%'"):
+                    parts = row["key"].split(":")
+                    if len(parts) < 2:
+                        continue
+                    cid = parts[1]
+                    try:
+                        ctx = json.loads(row["value"])
+                        layouts = ctx.get("projectLayouts")
+                        if isinstance(layouts, list):
+                            project_layouts_map.setdefault(cid, [])
+                            for l in layouts:
+                                try:
+                                    o = json.loads(l) if isinstance(l, str) else l
+                                    if isinstance(o, dict) and o.get("rootPath"):
+                                        project_layouts_map[cid].append(o["rootPath"])
+                                except Exception:
+                                    pass
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+
+            # Bubble map
+            try:
+                for row in _conn.execute("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'"):
+                    parts = row["key"].split(":")
+                    if len(parts) >= 3:
+                        bid = parts[2]
                         try:
-                            o = json.loads(l) if isinstance(l, str) else l
-                            if isinstance(o, dict) and o.get("rootPath"):
-                                project_layouts_map[cid].append(o["rootPath"])
+                            b = json.loads(row["value"])
+                            if isinstance(b, dict):
+                                bubble_map[bid] = b
                         except Exception:
                             pass
             except Exception:
                 pass
-    except Exception:
-        pass
 
-    # Bubble map
-    bubble_map = {}
-    for row in conn.execute("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'"):
-        parts = row["key"].split(":")
-        if len(parts) >= 3:
-            bid = parts[2]
+            # Code block diffs
             try:
-                b = json.loads(row["value"])
-                if isinstance(b, dict):
-                    bubble_map[bid] = b
+                for row in _conn.execute("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'codeBlockDiff:%'"):
+                    parts = row["key"].split(":")
+                    cid = parts[1] if len(parts) > 1 else None
+                    if not cid:
+                        continue
+                    try:
+                        d = json.loads(row["value"])
+                        code_block_diff_map.setdefault(cid, []).append({
+                            **d,
+                            "diffId": parts[2] if len(parts) > 2 else None,
+                        })
+                    except Exception:
+                        pass
             except Exception:
                 pass
 
-    # Code block diffs
-    code_block_diff_map = {}
-    try:
-        for row in conn.execute("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'codeBlockDiff:%'"):
-            parts = row["key"].split(":")
-            cid = parts[1] if len(parts) > 1 else None
-            if not cid:
-                continue
-            try:
-                d = json.loads(row["value"])
-                code_block_diff_map.setdefault(cid, []).append({
-                    **d,
-                    "diffId": parts[2] if len(parts) > 2 else None,
-                })
-            except Exception:
-                pass
-    except Exception:
-        pass
+            ide_composer_rows = _conn.execute(
+                "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
+                " AND value LIKE '%fullConversationHeadersOnly%'"
+            ).fetchall()
+
+            _conn.close()
+            _conn = None
+        except Exception as e:
+            print(f"Warning: Could not read Cursor IDE chats ({e}) — skipping.", file=sys.stderr)
+            if _conn is not None:
+                try:
+                    _conn.close()
+                except Exception:
+                    pass
 
     def get_project_from_file_path(fp):
         np = normalize_file_path(fp)
@@ -451,16 +481,12 @@ def main():
                     pass
         return best_id or "global"
 
-    # Process composers
-    composer_rows = conn.execute(
-        "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%' AND value LIKE '%fullConversationHeadersOnly%'"
-    ).fetchall()
-
     today = datetime.now().strftime("%Y-%m-%d")
     exported = []
     count = 0
 
-    for row in composer_rows:
+    # Process IDE composers
+    for row in ide_composer_rows:
         composer_id = row["key"].split(":")[1]
         try:
             cd = json.loads(row["value"])
@@ -794,7 +820,136 @@ def main():
                          "out_path": out_path, "updatedAt": updated_at})
         count += 1
 
-    conn.close()
+    # --- Cursor CLI sessions ---
+    try:
+        cli_projects = list_cli_projects(get_cli_chats_path())
+    except Exception as e:
+        print(f"Warning: Could not enumerate CLI chats ({e}) — skipping.", file=sys.stderr)
+        cli_projects = []
+
+    for cp in cli_projects:
+        ws_name = cp["workspace_name"] or cp["project_id"][:12]
+        ws_slug_cli = slug(ws_name)
+
+        if is_excluded_by_rules(exclusion_rules, build_searchable_text(project_name=ws_name)):
+            continue
+
+        for session in cp["sessions"]:
+            meta = session.get("meta", {})
+            session_id = session["session_id"]
+            created_ms: int = meta.get("createdAt") or int(datetime.now().timestamp() * 1000)
+            session_name = meta.get("name") or f"Session {session_id[:8]}"
+
+            if since == "last" and created_ms <= last_export:
+                continue
+
+            try:
+                messages = traverse_blobs(session["db_path"])
+                bubbles = messages_to_bubbles(messages, created_ms)
+            except Exception as e:
+                print(f"Warning: Could not read CLI session {session_id}: {e}", file=sys.stderr)
+                continue
+
+            if not bubbles:
+                continue
+
+            # Derive title from first user bubble
+            title = session_name
+            if not title or title.startswith("New Agent"):
+                for b in bubbles:
+                    if b["type"] == "user" and b.get("text"):
+                        first_lines = [l for l in b["text"].split("\n") if l.strip()]
+                        if first_lines:
+                            title = first_lines[0][:100]
+                            if len(title) == 100:
+                                title += "..."
+                        break
+
+            bubble_texts = [b["text"] for b in bubbles if b.get("text")]
+            searchable = build_searchable_text(
+                project_name=ws_name,
+                chat_title=title,
+                chat_content_snippet="\n\n".join(bubble_texts[:5]),
+            )
+            if is_excluded_by_rules(exclusion_rules, searchable):
+                continue
+
+            # Aggregate statistics
+            total_tool_calls = 0
+            tool_breakdown: dict = {}
+            for b in bubbles:
+                tcs = (b.get("metadata") or {}).get("toolCalls") or []
+                total_tool_calls += len(tcs)
+                for tc in tcs:
+                    tn = tc.get("name", "unknown")
+                    tool_breakdown[tn] = tool_breakdown.get(tn, 0) + 1
+
+            title_slug = slug(title)
+            ts_str = datetime.fromtimestamp(created_ms / 1000).strftime("%Y-%m-%dT%H-%M-%S")
+            filename = f"{ts_str}__{title_slug}__{session_id[:8]}.md"
+            rel_dir = os.path.join(today, ws_slug_cli, "cli")
+            out_path = os.path.join(out_dir, rel_dir, filename)
+
+            # Frontmatter
+            fm_lines = ["---"]
+            fm_lines.append(f"log_id: {session_id}")
+            fm_lines.append(f"log_type: cli_agent")
+            fm_lines.append(f'title: "{title.replace(chr(34), chr(92)+chr(34))}"')
+            fm_lines.append(f"created_at: {datetime.fromtimestamp(created_ms / 1000).isoformat()}")
+            fm_lines.append(f"workspace: {ws_slug_cli}")
+            fm_lines.append(f'workspace_name: "{ws_name}"')
+            if cp.get("workspace_path"):
+                fm_lines.append(f"workspace_path: {cp['workspace_path']}")
+            fm_lines.append(f"project_id: {cp['project_id']}")
+            fm_lines.append(f"session_id: {session_id}")
+            if meta.get("mode"):
+                fm_lines.append(f"mode: {meta['mode']}")
+            fm_lines.append(f"message_count: {len(bubbles)}")
+            if total_tool_calls:
+                fm_lines.append(f"total_tool_calls: {total_tool_calls}")
+            if tool_breakdown:
+                fm_lines.append("tool_call_breakdown:")
+                for tn, cnt in sorted(tool_breakdown.items(), key=lambda x: -x[1]):
+                    fm_lines.append(f"  {tn}: {cnt}")
+            fm_lines.append("---")
+            fm_str = "\n".join(fm_lines) + "\n\n"
+
+            # Header
+            header_meta = [f"Created: {datetime.fromtimestamp(created_ms / 1000).strftime('%Y-%m-%d %H:%M:%S')}"]
+            if meta.get("mode"):
+                header_meta.append(f"Mode: {meta['mode']}")
+            if total_tool_calls:
+                header_meta.append(f"Tool calls: {total_tool_calls}")
+            header = f"# {title}\n\n_{' | '.join(header_meta)}_\n\n---\n\n"
+
+            # Body
+            body = ""
+            for b in bubbles:
+                role_label = "User" if b["type"] == "user" else "Assistant"
+                body += f"### {role_label}\n\n"
+                body += b.get("text", "") + "\n\n"
+                tool_calls = (b.get("metadata") or {}).get("toolCalls") or []
+                for tc in tool_calls:
+                    summary = tc.get("summary") or tc.get("name") or "unknown"
+                    body += f"> **Tool: {summary}**\n"
+                    if tc.get("input"):
+                        body += "> **INPUT:**\n> ```\n"
+                        for iline in str(tc["input"]).split("\n"):
+                            body += f"> {iline}\n"
+                        body += "> ```\n"
+                    body += "\n"
+                body += "---\n\n"
+
+            md = fm_str + header + body
+            rel_path = os.path.join(today, ws_slug_cli, "cli", filename)
+            exported.append({
+                "id": session_id,
+                "rel_path": rel_path,
+                "content": md,
+                "out_path": out_path,
+                "updatedAt": created_ms,
+            })
+            count += 1
 
     if count == 0:
         label = " since last export" if since == "last" else ""

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -840,7 +840,15 @@ def main():
             created_ms: int = meta.get("createdAt") or int(datetime.now().timestamp() * 1000)
             session_name = meta.get("name") or f"Session {session_id[:8]}"
 
-            if since == "last" and created_ms <= last_export:
+            # Use the store.db mtime as a proxy for "last updated" — createdAt
+            # is immutable and would cause sessions with new turns to be skipped.
+            try:
+                db_mtime_ms = int(os.path.getmtime(session["db_path"]) * 1000)
+            except OSError:
+                db_mtime_ms = created_ms
+            updated_ms = max(created_ms, db_mtime_ms)
+
+            if since == "last" and updated_ms <= last_export:
                 continue
 
             try:
@@ -866,10 +874,15 @@ def main():
                         break
 
             bubble_texts = [b["text"] for b in bubbles if b.get("text")]
+            tool_call_texts = [
+                tc.get("input", "") or tc.get("summary", "")
+                for b in bubbles
+                for tc in (b.get("metadata") or {}).get("toolCalls") or []
+            ]
             searchable = build_searchable_text(
                 project_name=ws_name,
                 chat_title=title,
-                chat_content_snippet="\n\n".join(bubble_texts[:5]),
+                chat_content_snippet="\n\n".join(bubble_texts + tool_call_texts),
             )
             if is_excluded_by_rules(exclusion_rules, searchable):
                 continue
@@ -890,27 +903,27 @@ def main():
             rel_dir = os.path.join(today, ws_slug_cli, "cli")
             out_path = os.path.join(out_dir, rel_dir, filename)
 
-            # Frontmatter
+            # Frontmatter — free-form scalars use json.dumps() for safe YAML quoting.
             fm_lines = ["---"]
-            fm_lines.append(f"log_id: {session_id}")
-            fm_lines.append(f"log_type: cli_agent")
-            fm_lines.append(f'title: "{title.replace(chr(34), chr(92)+chr(34))}"')
+            fm_lines.append(f"log_id: {json.dumps(session_id, ensure_ascii=False)}")
+            fm_lines.append("log_type: cli_agent")
+            fm_lines.append(f"title: {json.dumps(title, ensure_ascii=False)}")
             fm_lines.append(f"created_at: {datetime.fromtimestamp(created_ms / 1000).isoformat()}")
             fm_lines.append(f"workspace: {ws_slug_cli}")
-            fm_lines.append(f'workspace_name: "{ws_name}"')
+            fm_lines.append(f"workspace_name: {json.dumps(ws_name, ensure_ascii=False)}")
             if cp.get("workspace_path"):
-                fm_lines.append(f"workspace_path: {cp['workspace_path']}")
-            fm_lines.append(f"project_id: {cp['project_id']}")
-            fm_lines.append(f"session_id: {session_id}")
+                fm_lines.append(f"workspace_path: {json.dumps(cp['workspace_path'], ensure_ascii=False)}")
+            fm_lines.append(f"project_id: {json.dumps(cp['project_id'], ensure_ascii=False)}")
+            fm_lines.append(f"session_id: {json.dumps(session_id, ensure_ascii=False)}")
             if meta.get("mode"):
-                fm_lines.append(f"mode: {meta['mode']}")
+                fm_lines.append(f"mode: {json.dumps(meta['mode'], ensure_ascii=False)}")
             fm_lines.append(f"message_count: {len(bubbles)}")
             if total_tool_calls:
                 fm_lines.append(f"total_tool_calls: {total_tool_calls}")
             if tool_breakdown:
                 fm_lines.append("tool_call_breakdown:")
                 for tn, cnt in sorted(tool_breakdown.items(), key=lambda x: -x[1]):
-                    fm_lines.append(f"  {tn}: {cnt}")
+                    fm_lines.append(f"  {json.dumps(tn, ensure_ascii=False)}: {cnt}")
             fm_lines.append("---")
             fm_str = "\n".join(fm_lines) + "\n\n"
 
@@ -947,7 +960,7 @@ def main():
                 "rel_path": rel_path,
                 "content": md,
                 "out_path": out_path,
-                "updatedAt": created_ms,
+                "updatedAt": updated_ms,
             })
             count += 1
 

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -37,6 +37,7 @@ from utils.cli_chat_reader import (
     messages_to_bubbles,
     aggregate_session_stats,
 )
+from utils.cursor_md_exporter import cursor_cli_session_to_markdown
 
 _logger = logging.getLogger(__name__)
 
@@ -861,12 +862,13 @@ def main():
             if not bubbles:
                 continue
 
-            # Derive title from first user bubble
+            # Derive title for the filename (shared exporter does it too, but
+            # we need it here first to build the output path).
             title = session_name
             if not title or title.startswith("New Agent"):
                 for b in bubbles:
                     if b["type"] == "user" and b.get("text"):
-                        first_lines = [l for l in b["text"].split("\n") if l.strip()]
+                        first_lines = [ln for ln in b["text"].split("\n") if ln.strip()]
                         if first_lines:
                             title = first_lines[0][:100]
                             if len(title) == 100:
@@ -887,73 +889,25 @@ def main():
             if is_excluded_by_rules(exclusion_rules, searchable):
                 continue
 
-            # Aggregate statistics
-            total_tool_calls = 0
-            tool_breakdown: dict = {}
-            for b in bubbles:
-                tcs = (b.get("metadata") or {}).get("toolCalls") or []
-                total_tool_calls += len(tcs)
-                for tc in tcs:
-                    tn = tc.get("name", "unknown")
-                    tool_breakdown[tn] = tool_breakdown.get(tn, 0) + 1
-
             title_slug = slug(title)
             ts_str = datetime.fromtimestamp(created_ms / 1000).strftime("%Y-%m-%dT%H-%M-%S")
             filename = f"{ts_str}__{title_slug}__{session_id[:8]}.md"
             rel_dir = os.path.join(today, ws_slug_cli, "cli")
             out_path = os.path.join(out_dir, rel_dir, filename)
 
-            # Frontmatter — free-form scalars use json.dumps() for safe YAML quoting.
-            fm_lines = ["---"]
-            fm_lines.append(f"log_id: {json.dumps(session_id, ensure_ascii=False)}")
-            fm_lines.append("log_type: cli_agent")
-            fm_lines.append(f"title: {json.dumps(title, ensure_ascii=False)}")
-            fm_lines.append(f"created_at: {datetime.fromtimestamp(created_ms / 1000).isoformat()}")
-            fm_lines.append(f"workspace: {ws_slug_cli}")
-            fm_lines.append(f"workspace_name: {json.dumps(ws_name, ensure_ascii=False)}")
-            if cp.get("workspace_path"):
-                fm_lines.append(f"workspace_path: {json.dumps(cp['workspace_path'], ensure_ascii=False)}")
-            fm_lines.append(f"project_id: {json.dumps(cp['project_id'], ensure_ascii=False)}")
-            fm_lines.append(f"session_id: {json.dumps(session_id, ensure_ascii=False)}")
-            if meta.get("mode"):
-                fm_lines.append(f"mode: {json.dumps(meta['mode'], ensure_ascii=False)}")
-            fm_lines.append(f"message_count: {len(bubbles)}")
-            if total_tool_calls:
-                fm_lines.append(f"total_tool_calls: {total_tool_calls}")
-            if tool_breakdown:
-                fm_lines.append("tool_call_breakdown:")
-                for tn, cnt in sorted(tool_breakdown.items(), key=lambda x: -x[1]):
-                    fm_lines.append(f"  {json.dumps(tn, ensure_ascii=False)}: {cnt}")
-            fm_lines.append("---")
-            fm_str = "\n".join(fm_lines) + "\n\n"
-
-            # Header
-            header_meta = [f"Created: {datetime.fromtimestamp(created_ms / 1000).strftime('%Y-%m-%d %H:%M:%S')}"]
-            if meta.get("mode"):
-                header_meta.append(f"Mode: {meta['mode']}")
-            if total_tool_calls:
-                header_meta.append(f"Tool calls: {total_tool_calls}")
-            header = f"# {title}\n\n_{' | '.join(header_meta)}_\n\n---\n\n"
-
-            # Body
-            body = ""
-            for b in bubbles:
-                role_label = "User" if b["type"] == "user" else "Assistant"
-                body += f"### {role_label}\n\n"
-                body += b.get("text", "") + "\n\n"
-                tool_calls = (b.get("metadata") or {}).get("toolCalls") or []
-                for tc in tool_calls:
-                    summary = tc.get("summary") or tc.get("name") or "unknown"
-                    body += f"> **Tool: {summary}**\n"
-                    if tc.get("input"):
-                        body += "> **INPUT:**\n> ```\n"
-                        for iline in str(tc["input"]).split("\n"):
-                            body += f"> {iline}\n"
-                        body += "> ```\n"
-                    body += "\n"
-                body += "---\n\n"
-
-            md = fm_str + header + body
+            # Delegate Markdown generation to the shared exporter.
+            md = cursor_cli_session_to_markdown(
+                session["db_path"],
+                session_meta=meta,
+                workspace_info={
+                    "workspace": ws_slug_cli,
+                    "workspace_name": ws_name,
+                    "workspace_path": cp.get("workspace_path"),
+                    "project_id": cp["project_id"],
+                },
+                bubbles=bubbles,
+                title_override=title,
+            )
             rel_path = os.path.join(today, ws_slug_cli, "cli", filename)
             exported.append({
                 "id": session_id,

--- a/tests/test_cli_chat_reader.py
+++ b/tests/test_cli_chat_reader.py
@@ -1,0 +1,543 @@
+"""Unit tests for utils/cli_chat_reader.py.
+
+Run:
+  python -m unittest tests.test_cli_chat_reader -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_root = Path(__file__).resolve().parent.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+from utils.cli_chat_reader import (
+    _content_to_text,
+    _extract_blob_refs,
+    _extract_tool_calls,
+    _strip_user_info,
+    aggregate_session_stats,
+    extract_workspace_path,
+    iter_sessions,
+    list_cli_projects,
+    messages_to_bubbles,
+    traverse_blobs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build minimal store.db fixtures in a temp directory
+# ---------------------------------------------------------------------------
+
+def _make_meta_value(meta: dict) -> str:
+    """Encode a metadata dict as the hex-encoded JSON string that store.db stores."""
+    return json.dumps(meta).encode("utf-8").hex()
+
+
+def _build_store_db(path: str, meta: dict, json_blobs: dict[str, dict], chain: dict[str, list[str]]) -> None:
+    """Create a store.db fixture at *path*.
+
+    Parameters
+    ----------
+    meta:
+        Session metadata dict (will be hex-encoded as JSON).
+    json_blobs:
+        Mapping of blob_id -> message dict.
+    chain:
+        Mapping of blob_id -> list[ref_blob_id] (chain/pointer blobs).
+    """
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute("CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)")
+
+    conn.execute("INSERT INTO meta VALUES ('0', ?)", (_make_meta_value(meta),))
+
+    for blob_id, msg in json_blobs.items():
+        data = json.dumps(msg).encode("utf-8")
+        conn.execute("INSERT INTO blobs VALUES (?, ?)", (blob_id, data))
+
+    for blob_id, refs in chain.items():
+        # Build binary chain node: for each ref, emit 0x0a 0x20 <32-byte hash>
+        raw = b""
+        for ref in refs:
+            raw += b"\x0a\x20" + bytes.fromhex(ref)
+        conn.execute("INSERT INTO blobs VALUES (?, ?)", (blob_id, raw))
+
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _extract_blob_refs
+# ---------------------------------------------------------------------------
+
+class TestExtractBlobRefs(unittest.TestCase):
+    def test_empty_bytes_returns_empty(self):
+        self.assertEqual(_extract_blob_refs(b""), [])
+
+    def test_single_ref(self):
+        ref = "a" * 64  # 32 bytes as hex
+        raw = b"\x0a\x20" + bytes.fromhex(ref)
+        self.assertEqual(_extract_blob_refs(raw), [ref])
+
+    def test_two_refs(self):
+        ref1 = "a" * 64
+        ref2 = "b" * 64
+        raw = b"\x0a\x20" + bytes.fromhex(ref1) + b"\x0a\x20" + bytes.fromhex(ref2)
+        self.assertEqual(_extract_blob_refs(raw), [ref1, ref2])
+
+    def test_noise_bytes_ignored(self):
+        ref = "c" * 64
+        noise = b"\x00\xff\x01\x02\x03\x04"
+        raw = noise + b"\x0a\x20" + bytes.fromhex(ref) + b"\xde\xad"
+        self.assertIn(ref, _extract_blob_refs(raw))
+
+    def test_partial_tag_at_end_ignored(self):
+        # Only 0x0a without 0x20 immediately following should not produce a ref.
+        raw = b"\x0a" + b"\x00" * 32
+        self.assertEqual(_extract_blob_refs(raw), [])
+
+
+# ---------------------------------------------------------------------------
+# _content_to_text
+# ---------------------------------------------------------------------------
+
+class TestContentToText(unittest.TestCase):
+    def test_string_passthrough(self):
+        self.assertEqual(_content_to_text("hello"), "hello")
+
+    def test_list_with_text_parts(self):
+        content = [{"type": "text", "text": "foo"}, {"type": "text", "text": "bar"}]
+        result = _content_to_text(content)
+        self.assertIn("foo", result)
+        self.assertIn("bar", result)
+
+    def test_list_with_tool_result(self):
+        content = [{"type": "tool-result", "result": "output here"}]
+        self.assertIn("output here", _content_to_text(content))
+
+    def test_empty_list(self):
+        self.assertEqual(_content_to_text([]), "")
+
+    def test_unknown_type_ignored(self):
+        content = [{"type": "image", "url": "http://example.com/img.png"}]
+        self.assertEqual(_content_to_text(content), "")
+
+    def test_non_string_non_list(self):
+        self.assertEqual(_content_to_text(None), "")
+        self.assertEqual(_content_to_text(42), "")
+
+
+# ---------------------------------------------------------------------------
+# _extract_tool_calls
+# ---------------------------------------------------------------------------
+
+class TestExtractToolCalls(unittest.TestCase):
+    def test_non_list_returns_empty(self):
+        self.assertEqual(_extract_tool_calls("text"), [])
+        self.assertEqual(_extract_tool_calls(None), [])
+
+    def test_list_without_tool_call_type(self):
+        content = [{"type": "text", "text": "hello"}]
+        self.assertEqual(_extract_tool_calls(content), [])
+
+    def test_single_tool_call(self):
+        content = [
+            {"type": "tool-call", "toolName": "Shell", "args": {"command": "ls"}, "toolCallId": "tc-1"}
+        ]
+        calls = _extract_tool_calls(content)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["name"], "Shell")
+        self.assertEqual(calls[0]["args"], {"command": "ls"})
+        self.assertEqual(calls[0]["toolCallId"], "tc-1")
+
+    def test_mixed_content(self):
+        content = [
+            {"type": "text", "text": "I will run a command."},
+            {"type": "tool-call", "toolName": "Grep", "args": {"pattern": "foo"}, "toolCallId": "tc-2"},
+        ]
+        calls = _extract_tool_calls(content)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["name"], "Grep")
+
+
+# ---------------------------------------------------------------------------
+# extract_workspace_path
+# ---------------------------------------------------------------------------
+
+class TestExtractWorkspacePath(unittest.TestCase):
+    def test_extracts_from_user_info_preamble(self):
+        messages = [
+            {
+                "role": "user",
+                "content": "<user_info>\nOS Version: linux\nWorkspace Path: /home/user/myproject\n</user_info>\n<user_query>hello</user_query>",
+            }
+        ]
+        self.assertEqual(extract_workspace_path(messages), "/home/user/myproject")
+
+    def test_returns_none_when_absent(self):
+        messages = [{"role": "user", "content": "No preamble here."}]
+        self.assertIsNone(extract_workspace_path(messages))
+
+    def test_skips_non_user_messages(self):
+        messages = [
+            {"role": "system", "content": "Workspace Path: /should/be/ignored"},
+            {"role": "assistant", "content": "Workspace Path: /also/ignored"},
+            {"role": "user", "content": "Workspace Path: /home/user/real"},
+        ]
+        self.assertEqual(extract_workspace_path(messages), "/home/user/real")
+
+    def test_returns_first_match(self):
+        messages = [
+            {"role": "user", "content": "Workspace Path: /first"},
+            {"role": "user", "content": "Workspace Path: /second"},
+        ]
+        self.assertEqual(extract_workspace_path(messages), "/first")
+
+
+# ---------------------------------------------------------------------------
+# _strip_user_info
+# ---------------------------------------------------------------------------
+
+class TestStripUserInfo(unittest.TestCase):
+    def test_extracts_user_query_tag(self):
+        text = "<user_info>some preamble</user_info>\n<user_query>my actual question</user_query>"
+        self.assertEqual(_strip_user_info(text), "my actual question")
+
+    def test_strips_user_info_block_when_no_query_tag(self):
+        text = "<user_info>preamble stuff</user_info>\nActual message here."
+        result = _strip_user_info(text)
+        self.assertNotIn("<user_info>", result)
+        self.assertIn("Actual message here.", result)
+
+    def test_passthrough_when_no_user_info(self):
+        self.assertEqual(_strip_user_info("plain text"), "plain text")
+
+
+# ---------------------------------------------------------------------------
+# messages_to_bubbles
+# ---------------------------------------------------------------------------
+
+class TestMessagesToBubbles(unittest.TestCase):
+    BASE_MS = 1_700_000_000_000
+
+    def test_system_messages_skipped(self):
+        messages = [{"role": "system", "content": "You are an agent."}]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        self.assertEqual(bubbles, [])
+
+    def test_tool_messages_skipped(self):
+        messages = [{"role": "tool", "content": "tool result"}]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        self.assertEqual(bubbles, [])
+
+    def test_pure_preamble_user_message_skipped(self):
+        messages = [{"role": "user", "content": "<user_info>OS: linux</user_info>"}]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        self.assertEqual(bubbles, [])
+
+    def test_user_message_with_query_tag(self):
+        content = "<user_info>OS: linux</user_info>\n<user_query>Fix the bug</user_query>"
+        messages = [{"role": "user", "content": content}]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        self.assertEqual(len(bubbles), 1)
+        self.assertEqual(bubbles[0]["type"], "user")
+        self.assertEqual(bubbles[0]["text"], "Fix the bug")
+
+    def test_assistant_text_bubble(self):
+        messages = [{"role": "assistant", "content": "Here is the fix."}]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        self.assertEqual(len(bubbles), 1)
+        self.assertEqual(bubbles[0]["type"], "ai")
+        self.assertEqual(bubbles[0]["text"], "Here is the fix.")
+
+    def test_assistant_with_tool_calls(self):
+        content = [
+            {"type": "tool-call", "toolName": "Shell", "args": {"command": "ls -la"}, "toolCallId": "tc-1"}
+        ]
+        messages = [{"role": "assistant", "content": content}]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        self.assertEqual(len(bubbles), 1)
+        self.assertIn("toolCalls", bubbles[0].get("metadata", {}))
+        calls = bubbles[0]["metadata"]["toolCalls"]
+        self.assertEqual(calls[0]["name"], "Shell")
+
+    def test_tool_call_summary_shell(self):
+        content = [{"type": "tool-call", "toolName": "Shell", "args": {"command": "echo hi"}, "toolCallId": "tc"}]
+        messages = [{"role": "assistant", "content": content}]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        summary = bubbles[0]["metadata"]["toolCalls"][0]["summary"]
+        self.assertIn("echo hi", summary)
+
+    def test_tool_call_summary_read(self):
+        content = [{"type": "tool-call", "toolName": "Read", "args": {"path": "/foo/bar.py"}, "toolCallId": "tc"}]
+        messages = [{"role": "assistant", "content": content}]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        summary = bubbles[0]["metadata"]["toolCalls"][0]["summary"]
+        self.assertIn("bar.py", summary)
+
+    def test_tool_call_summary_grep(self):
+        content = [{"type": "tool-call", "toolName": "Grep", "args": {"pattern": "TODO"}, "toolCallId": "tc"}]
+        messages = [{"role": "assistant", "content": content}]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        summary = bubbles[0]["metadata"]["toolCalls"][0]["summary"]
+        self.assertIn("TODO", summary)
+
+    def test_tool_call_summary_glob(self):
+        content = [{"type": "tool-call", "toolName": "Glob", "args": {"glob_pattern": "**/*.py"}, "toolCallId": "tc"}]
+        messages = [{"role": "assistant", "content": content}]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        summary = bubbles[0]["metadata"]["toolCalls"][0]["summary"]
+        self.assertIn("*.py", summary)
+
+    def test_tool_call_summary_web_search(self):
+        content = [{"type": "tool-call", "toolName": "WebSearch", "args": {"search_term": "Python async"}, "toolCallId": "tc"}]
+        messages = [{"role": "assistant", "content": content}]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        summary = bubbles[0]["metadata"]["toolCalls"][0]["summary"]
+        self.assertIn("Python async", summary)
+
+    def test_timestamps_increment(self):
+        messages = [
+            {"role": "user", "content": "<user_query>Q1</user_query>"},
+            {"role": "assistant", "content": "A1"},
+        ]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        self.assertEqual(len(bubbles), 2)
+        self.assertLess(bubbles[0]["timestamp"], bubbles[1]["timestamp"])
+
+    def test_empty_assistant_message_skipped(self):
+        messages = [{"role": "assistant", "content": "   "}]
+        bubbles = messages_to_bubbles(messages, self.BASE_MS)
+        self.assertEqual(bubbles, [])
+
+    def test_empty_messages_returns_empty(self):
+        self.assertEqual(messages_to_bubbles([], self.BASE_MS), [])
+
+
+# ---------------------------------------------------------------------------
+# traverse_blobs (requires temporary store.db files)
+# ---------------------------------------------------------------------------
+
+class TestTraverseBlobs(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _db(self, name: str) -> str:
+        return os.path.join(self.tmpdir, name)
+
+    def test_empty_meta_returns_empty(self):
+        path = self._db("empty.db")
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
+        conn.execute("CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)")
+        conn.commit()
+        conn.close()
+        self.assertEqual(traverse_blobs(path), [])
+
+    def test_missing_root_returns_empty(self):
+        path = self._db("no_root.db")
+        _build_store_db(path, {"latestRootBlobId": ""}, {}, {})
+        self.assertEqual(traverse_blobs(path), [])
+
+    def test_single_json_message(self):
+        msg = {"role": "user", "content": "Hello"}
+        blob_id = "a" * 64
+        path = self._db("single.db")
+        _build_store_db(path, {"latestRootBlobId": blob_id}, {blob_id: msg}, {})
+        result = traverse_blobs(path)
+        self.assertEqual(result, [msg])
+
+    def test_chain_to_json_blobs(self):
+        """Chain blob references two JSON message blobs."""
+        root_id = "0" * 64
+        msg1_id = "1" * 64
+        msg2_id = "2" * 64
+        msg1 = {"role": "user", "content": "first"}
+        msg2 = {"role": "assistant", "content": "second"}
+        path = self._db("chain.db")
+        _build_store_db(
+            path,
+            {"latestRootBlobId": root_id},
+            {msg1_id: msg1, msg2_id: msg2},
+            {root_id: [msg1_id, msg2_id]},
+        )
+        result = traverse_blobs(path)
+        self.assertIn(msg1, result)
+        self.assertIn(msg2, result)
+
+    def test_no_cycle_in_traversal(self):
+        """Cyclic references must not loop forever."""
+        a = "a" * 64
+        b = "b" * 64
+        path = self._db("cycle.db")
+        _build_store_db(path, {"latestRootBlobId": a}, {}, {a: [b], b: [a]})
+        result = traverse_blobs(path)
+        self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# iter_sessions and list_cli_projects
+# ---------------------------------------------------------------------------
+
+class TestIterSessions(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.chats_dir = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _make_session(self, project_id: str, session_id: str, meta: dict) -> str:
+        """Create a minimal session directory under chats_dir and return db_path."""
+        session_dir = os.path.join(self.chats_dir, project_id, session_id)
+        os.makedirs(session_dir, exist_ok=True)
+        db_path = os.path.join(session_dir, "store.db")
+        _build_store_db(db_path, meta, {}, {})
+        return db_path
+
+    def test_empty_dir_yields_nothing(self):
+        self.assertEqual(list(iter_sessions(self.chats_dir)), [])
+
+    def test_nonexistent_dir_yields_nothing(self):
+        self.assertEqual(list(iter_sessions("/nonexistent/path")), [])
+
+    def test_session_without_store_db_skipped(self):
+        project_dir = os.path.join(self.chats_dir, "proj1")
+        os.makedirs(os.path.join(project_dir, "sess1"), exist_ok=True)
+        self.assertEqual(list(iter_sessions(self.chats_dir)), [])
+
+    def test_yields_single_session(self):
+        self._make_session("proj1", "sess1", {"name": "My session", "createdAt": 1000})
+        sessions = list(iter_sessions(self.chats_dir))
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(sessions[0]["project_id"], "proj1")
+        self.assertEqual(sessions[0]["session_id"], "sess1")
+        self.assertEqual(sessions[0]["meta"].get("name"), "My session")
+
+    def test_yields_multiple_sessions_across_projects(self):
+        self._make_session("proj1", "sess1", {"name": "A"})
+        self._make_session("proj1", "sess2", {"name": "B"})
+        self._make_session("proj2", "sess3", {"name": "C"})
+        sessions = list(iter_sessions(self.chats_dir))
+        self.assertEqual(len(sessions), 3)
+
+
+class TestListCliProjects(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.chats_dir = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _make_session(self, project_id: str, session_id: str, meta: dict, msg_content: str | None = None) -> str:
+        session_dir = os.path.join(self.chats_dir, project_id, session_id)
+        os.makedirs(session_dir, exist_ok=True)
+        db_path = os.path.join(session_dir, "store.db")
+        json_blobs: dict = {}
+        chain: dict = {}
+        if msg_content:
+            blob_id = session_id[:64].ljust(64, "0")
+            json_blobs[blob_id] = {"role": "user", "content": msg_content}
+            meta = dict(meta, latestRootBlobId=blob_id)
+        _build_store_db(db_path, meta, json_blobs, chain)
+        return db_path
+
+    def test_empty_dir_returns_empty_list(self):
+        self.assertEqual(list_cli_projects(self.chats_dir), [])
+
+    def test_sessions_grouped_by_project(self):
+        self._make_session("proj1", "sess1", {"createdAt": 1000})
+        self._make_session("proj1", "sess2", {"createdAt": 2000})
+        self._make_session("proj2", "sess3", {"createdAt": 3000})
+        projects = list_cli_projects(self.chats_dir)
+        self.assertEqual(len(projects), 2)
+        ids = {p["project_id"] for p in projects}
+        self.assertIn("proj1", ids)
+        self.assertIn("proj2", ids)
+
+    def test_last_updated_ms_uses_max_created_at(self):
+        self._make_session("proj1", "sess1", {"createdAt": 1000})
+        self._make_session("proj1", "sess2", {"createdAt": 5000})
+        projects = list_cli_projects(self.chats_dir)
+        proj = next(p for p in projects if p["project_id"] == "proj1")
+        self.assertEqual(proj["last_updated_ms"], 5000)
+
+    def test_workspace_name_extracted_from_user_info(self):
+        ws_path = "/home/user/my-project"
+        preamble = (
+            f"<user_info>\nOS Version: linux\nWorkspace Path: {ws_path}\n</user_info>\n"
+            "<user_query>hello</user_query>"
+        )
+        self._make_session("proj1", "sess1", {"createdAt": 1000, "latestRootBlobId": "s" * 64}, msg_content=preamble)
+        projects = list_cli_projects(self.chats_dir)
+        proj = projects[0]
+        self.assertEqual(proj["workspace_path"], ws_path)
+        self.assertEqual(proj["workspace_name"], "my-project")
+
+    def test_workspace_name_falls_back_to_project_id_prefix(self):
+        self._make_session("proj1abcdef123456", "sess1", {"createdAt": 1000})
+        projects = list_cli_projects(self.chats_dir)
+        proj = projects[0]
+        # list_cli_projects uses pid[:12] as fallback
+        self.assertEqual(proj["workspace_name"], "proj1abcdef1")
+
+
+# ---------------------------------------------------------------------------
+# aggregate_session_stats
+# ---------------------------------------------------------------------------
+
+class TestAggregateSessionStats(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_returns_created_ms_and_empty_messages_on_bad_db(self):
+        session = {"db_path": "/nonexistent/store.db", "meta": {"createdAt": 42000}}
+        stats = aggregate_session_stats(session)
+        self.assertEqual(stats["created_ms"], 42000)
+        self.assertEqual(stats["messages"], [])
+
+    def test_counts_tool_calls(self):
+        blob_id = "a" * 64
+        msg = {
+            "role": "assistant",
+            "content": [
+                {"type": "tool-call", "toolName": "Shell", "args": {"command": "ls"}, "toolCallId": "tc1"},
+                {"type": "tool-call", "toolName": "Read", "args": {"path": "/foo"}, "toolCallId": "tc2"},
+            ],
+        }
+        db_path = os.path.join(self.tmpdir, "sess.db")
+        _build_store_db(db_path, {"latestRootBlobId": blob_id, "createdAt": 9000}, {blob_id: msg}, {})
+        session = {"db_path": db_path, "meta": {"createdAt": 9000}}
+        stats = aggregate_session_stats(session)
+        self.assertEqual(stats["total_tool_calls"], 2)
+        self.assertEqual(stats["tool_breakdown"].get("Shell"), 1)
+        self.assertEqual(stats["tool_breakdown"].get("Read"), 1)
+
+    def test_mode_and_session_name_from_meta(self):
+        db_path = os.path.join(self.tmpdir, "sess2.db")
+        _build_store_db(db_path, {}, {}, {})
+        session = {"db_path": db_path, "meta": {"mode": "agent", "name": "My session", "createdAt": 1000}}
+        stats = aggregate_session_stats(session)
+        self.assertEqual(stats["mode"], "agent")
+        self.assertEqual(stats["session_name"], "My session")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_chat_reader.py
+++ b/tests/test_cli_chat_reader.py
@@ -359,11 +359,16 @@ class TestTraverseBlobs(unittest.TestCase):
         result = traverse_blobs(path)
         self.assertEqual(result, [msg])
 
-    def test_chain_to_json_blobs(self):
-        """Chain blob references two JSON message blobs."""
-        root_id = "0" * 64
-        msg1_id = "1" * 64
-        msg2_id = "2" * 64
+    def test_chain_preserves_chronological_order(self):
+        """Linked-list chain (newest root -> prev node -> oldest msg) must produce oldest-first output.
+
+        Mirrors the real CLI storage layout: latestRootBlobId is newest, and
+        each chain node points to an older node/message.
+        """
+        root_id = "0" * 64    # latest chain node (newest end)
+        prev_id = "f" * 64    # older chain node
+        msg1_id = "1" * 64    # oldest message (user)
+        msg2_id = "2" * 64    # newest message (assistant)
         msg1 = {"role": "user", "content": "first"}
         msg2 = {"role": "assistant", "content": "second"}
         path = self._db("chain.db")
@@ -371,11 +376,12 @@ class TestTraverseBlobs(unittest.TestCase):
             path,
             {"latestRootBlobId": root_id},
             {msg1_id: msg1, msg2_id: msg2},
-            {root_id: [msg1_id, msg2_id]},
+            # root (latest) references the newest message and a pointer to the older node;
+            # prev node references the oldest message.
+            {root_id: [msg2_id, prev_id], prev_id: [msg1_id]},
         )
         result = traverse_blobs(path)
-        self.assertIn(msg1, result)
-        self.assertIn(msg2, result)
+        self.assertEqual(result, [msg1, msg2])
 
     def test_no_cycle_in_traversal(self):
         """Cyclic references must not loop forever."""

--- a/tests/test_cli_chat_reader.py
+++ b/tests/test_cli_chat_reader.py
@@ -474,12 +474,15 @@ class TestListCliProjects(unittest.TestCase):
         self.assertIn("proj1", ids)
         self.assertIn("proj2", ids)
 
-    def test_last_updated_ms_uses_max_created_at(self):
+    def test_last_updated_ms_is_at_least_max_created_at(self):
+        # last_updated_ms = max(createdAt, store.db mtime) across all sessions.
+        # Since test files are freshly created, mtime >= createdAt always; we only
+        # assert the floor: the value must be >= max(createdAt) and > 0.
         self._make_session("proj1", "sess1", {"createdAt": 1000})
         self._make_session("proj1", "sess2", {"createdAt": 5000})
         projects = list_cli_projects(self.chats_dir)
         proj = next(p for p in projects if p["project_id"] == "proj1")
-        self.assertEqual(proj["last_updated_ms"], 5000)
+        self.assertGreaterEqual(proj["last_updated_ms"], 5000)
 
     def test_workspace_name_extracted_from_user_info(self):
         ws_path = "/home/user/my-project"

--- a/tests/test_cursor_md_exporter.py
+++ b/tests/test_cursor_md_exporter.py
@@ -1,0 +1,239 @@
+"""Unit tests for utils/cursor_md_exporter.py.
+
+Run:
+  python -m unittest tests.test_cursor_md_exporter -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_root = Path(__file__).resolve().parent.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+from utils.cursor_md_exporter import cursor_cli_session_to_markdown
+
+
+def _make_meta_hex(meta: dict) -> str:
+    return json.dumps(meta).encode("utf-8").hex()
+
+
+def _build_store_db(path: str, meta: dict, json_blobs: dict[str, dict]) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute("CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)")
+    conn.execute("INSERT INTO meta VALUES ('0', ?)", (_make_meta_hex(meta),))
+    for blob_id, msg in json_blobs.items():
+        conn.execute("INSERT INTO blobs VALUES (?, ?)", (blob_id, json.dumps(msg).encode("utf-8")))
+    conn.commit()
+    conn.close()
+
+
+class TestCursorCliSessionToMarkdown(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _db_path(self, name: str = "store.db") -> str:
+        return os.path.join(self.tmpdir, name)
+
+    def _simple_session(self, name: str = "My Session", mode: str = "agent") -> tuple[str, dict]:
+        """Build a store.db with one user message and one assistant reply.
+
+        The root is a chain blob pointing to both message blobs so BFS reaches both.
+        """
+        root_id = "0" * 64
+        blob_user = "a" * 64
+        blob_asst = "b" * 64
+        meta = {
+            "agentId": "test-agent-id",
+            "latestRootBlobId": root_id,
+            "name": name,
+            "mode": mode,
+            "createdAt": 1_700_000_000_000,
+        }
+        db_path = self._db_path()
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
+        conn.execute("CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)")
+        conn.execute("INSERT INTO meta VALUES ('0', ?)", (json.dumps(meta).encode("utf-8").hex(),))
+        # Chain blob pointing to both message blobs
+        chain_data = b"\x0a\x20" + bytes.fromhex(blob_user) + b"\x0a\x20" + bytes.fromhex(blob_asst)
+        conn.execute("INSERT INTO blobs VALUES (?, ?)", (root_id, chain_data))
+        conn.execute("INSERT INTO blobs VALUES (?, ?)", (
+            blob_user, json.dumps({"role": "user", "content": "<user_query>Write a sort function</user_query>"}).encode("utf-8")
+        ))
+        conn.execute("INSERT INTO blobs VALUES (?, ?)", (
+            blob_asst, json.dumps({"role": "assistant", "content": "Here is a sort function."}).encode("utf-8")
+        ))
+        conn.commit()
+        conn.close()
+        return db_path, meta
+
+    def test_returns_string(self):
+        db_path, _ = self._simple_session()
+        result = cursor_cli_session_to_markdown(db_path)
+        self.assertIsInstance(result, str)
+
+    def test_contains_yaml_frontmatter(self):
+        db_path, _ = self._simple_session()
+        result = cursor_cli_session_to_markdown(db_path)
+        self.assertTrue(result.startswith("---\n"))
+        self.assertIn("\n---\n", result)
+
+    def test_frontmatter_includes_session_id(self):
+        db_path, _ = self._simple_session()
+        result = cursor_cli_session_to_markdown(db_path)
+        self.assertIn("log_id: test-agent-id", result)
+
+    def test_frontmatter_includes_log_type(self):
+        db_path, _ = self._simple_session()
+        result = cursor_cli_session_to_markdown(db_path)
+        self.assertIn("log_type: cli_agent", result)
+
+    def test_frontmatter_includes_mode(self):
+        db_path, _ = self._simple_session(mode="agent")
+        result = cursor_cli_session_to_markdown(db_path)
+        self.assertIn("mode: agent", result)
+
+    def test_frontmatter_title_from_session_name(self):
+        db_path, _ = self._simple_session(name="My Custom Title")
+        result = cursor_cli_session_to_markdown(db_path)
+        self.assertIn("My Custom Title", result)
+
+    def test_title_derived_from_first_user_message_when_generic(self):
+        blob_user = "a" * 64
+        meta = {
+            "agentId": "agent-x",
+            "latestRootBlobId": blob_user,
+            "name": "New Agent Session",
+            "createdAt": 1_700_000_000_000,
+        }
+        json_blobs = {
+            blob_user: {"role": "user", "content": "<user_query>Refactor the parser module</user_query>"},
+        }
+        db_path = self._db_path()
+        _build_store_db(db_path, meta, json_blobs)
+        result = cursor_cli_session_to_markdown(db_path)
+        self.assertIn("Refactor the parser module", result)
+
+    def test_body_contains_user_and_assistant_headings(self):
+        db_path, _ = self._simple_session()
+        result = cursor_cli_session_to_markdown(db_path)
+        self.assertIn("### User", result)
+        self.assertIn("### Assistant", result)
+
+    def test_body_contains_message_text(self):
+        db_path, _ = self._simple_session()
+        result = cursor_cli_session_to_markdown(db_path)
+        self.assertIn("Write a sort function", result)
+        self.assertIn("Here is a sort function.", result)
+
+    def test_tool_calls_rendered_in_body(self):
+        blob_asst = "a" * 64
+        meta = {
+            "agentId": "ag1",
+            "latestRootBlobId": blob_asst,
+            "name": "Tool session",
+            "createdAt": 1_700_000_000_000,
+        }
+        json_blobs = {
+            blob_asst: {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool-call", "toolName": "Shell", "args": {"command": "git status"}, "toolCallId": "tc1"}
+                ],
+            }
+        }
+        db_path = self._db_path()
+        _build_store_db(db_path, meta, json_blobs)
+        result = cursor_cli_session_to_markdown(db_path)
+        self.assertIn("**Tool:", result)
+        self.assertIn("git status", result)
+
+    def test_tool_call_count_in_frontmatter(self):
+        blob_asst = "a" * 64
+        meta = {
+            "agentId": "ag2",
+            "latestRootBlobId": blob_asst,
+            "name": "Tool count session",
+            "createdAt": 1_700_000_000_000,
+        }
+        json_blobs = {
+            blob_asst: {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool-call", "toolName": "Read", "args": {"path": "/foo"}, "toolCallId": "tc1"},
+                    {"type": "tool-call", "toolName": "Read", "args": {"path": "/bar"}, "toolCallId": "tc2"},
+                ],
+            }
+        }
+        db_path = self._db_path()
+        _build_store_db(db_path, meta, json_blobs)
+        result = cursor_cli_session_to_markdown(db_path)
+        self.assertIn("total_tool_calls: 2", result)
+        self.assertIn("tool_call_breakdown:", result)
+        self.assertIn("Read: 2", result)
+
+    def test_with_session_meta_kwarg(self):
+        """session_meta kwarg skips reading from the database."""
+        blob_user = "a" * 64
+        meta = {
+            "agentId": "override-id",
+            "latestRootBlobId": blob_user,
+            "name": "Provided Meta Session",
+            "createdAt": 1_700_000_000_000,
+        }
+        json_blobs = {blob_user: {"role": "user", "content": "<user_query>Hello</user_query>"}}
+        db_path = self._db_path()
+        _build_store_db(db_path, meta, json_blobs)
+
+        provided_meta = {
+            "agentId": "override-id",
+            "name": "Provided Meta Session",
+            "mode": "custom",
+            "createdAt": 1_700_000_000_000,
+        }
+        result = cursor_cli_session_to_markdown(db_path, session_meta=provided_meta)
+        self.assertIn("mode: custom", result)
+        self.assertIn("Provided Meta Session", result)
+
+    def test_empty_session_produces_valid_markdown(self):
+        db_path = self._db_path()
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
+        conn.execute("CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)")
+        conn.commit()
+        conn.close()
+        result = cursor_cli_session_to_markdown(db_path)
+        self.assertIsInstance(result, str)
+        self.assertIn("---", result)
+
+    def test_title_quoting_with_special_chars(self):
+        blob_user = "a" * 64
+        meta = {
+            "agentId": "agent-q",
+            "latestRootBlobId": blob_user,
+            'name': 'He said "hello"',
+            "createdAt": 1_700_000_000_000,
+        }
+        json_blobs = {blob_user: {"role": "user", "content": "<user_query>test</user_query>"}}
+        db_path = self._db_path()
+        _build_store_db(db_path, meta, json_blobs)
+        result = cursor_cli_session_to_markdown(db_path)
+        # Frontmatter title line must be valid YAML (escaped quotes)
+        self.assertIn('title: "', result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cursor_md_exporter.py
+++ b/tests/test_cursor_md_exporter.py
@@ -50,9 +50,13 @@ class TestCursorCliSessionToMarkdown(unittest.TestCase):
     def _simple_session(self, name: str = "My Session", mode: str = "agent") -> tuple[str, dict]:
         """Build a store.db with one user message and one assistant reply.
 
-        The root is a chain blob pointing to both message blobs so BFS reaches both.
+        Models the real CLI linked-list layout: root (latest chain node) references
+        the newest message (assistant) and a pointer to an older chain node which
+        holds the older message (user).  After traverse_blobs() reverses, callers
+        receive [user, assistant] in chronological order.
         """
-        root_id = "0" * 64
+        root_id = "0" * 64   # latest chain node
+        prev_id = "f" * 64   # older chain node
         blob_user = "a" * 64
         blob_asst = "b" * 64
         meta = {
@@ -67,9 +71,12 @@ class TestCursorCliSessionToMarkdown(unittest.TestCase):
         conn.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
         conn.execute("CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)")
         conn.execute("INSERT INTO meta VALUES ('0', ?)", (json.dumps(meta).encode("utf-8").hex(),))
-        # Chain blob pointing to both message blobs
-        chain_data = b"\x0a\x20" + bytes.fromhex(blob_user) + b"\x0a\x20" + bytes.fromhex(blob_asst)
-        conn.execute("INSERT INTO blobs VALUES (?, ?)", (root_id, chain_data))
+        # root -> [newest msg (asst), prev chain node]
+        root_chain = b"\x0a\x20" + bytes.fromhex(blob_asst) + b"\x0a\x20" + bytes.fromhex(prev_id)
+        conn.execute("INSERT INTO blobs VALUES (?, ?)", (root_id, root_chain))
+        # prev chain node -> [oldest msg (user)]
+        prev_chain = b"\x0a\x20" + bytes.fromhex(blob_user)
+        conn.execute("INSERT INTO blobs VALUES (?, ?)", (prev_id, prev_chain))
         conn.execute("INSERT INTO blobs VALUES (?, ?)", (
             blob_user, json.dumps({"role": "user", "content": "<user_query>Write a sort function</user_query>"}).encode("utf-8")
         ))
@@ -94,7 +101,7 @@ class TestCursorCliSessionToMarkdown(unittest.TestCase):
     def test_frontmatter_includes_session_id(self):
         db_path, _ = self._simple_session()
         result = cursor_cli_session_to_markdown(db_path)
-        self.assertIn("log_id: test-agent-id", result)
+        self.assertIn('log_id: "test-agent-id"', result)
 
     def test_frontmatter_includes_log_type(self):
         db_path, _ = self._simple_session()
@@ -104,7 +111,7 @@ class TestCursorCliSessionToMarkdown(unittest.TestCase):
     def test_frontmatter_includes_mode(self):
         db_path, _ = self._simple_session(mode="agent")
         result = cursor_cli_session_to_markdown(db_path)
-        self.assertIn("mode: agent", result)
+        self.assertIn('mode: "agent"', result)
 
     def test_frontmatter_title_from_session_name(self):
         db_path, _ = self._simple_session(name="My Custom Title")
@@ -183,7 +190,7 @@ class TestCursorCliSessionToMarkdown(unittest.TestCase):
         result = cursor_cli_session_to_markdown(db_path)
         self.assertIn("total_tool_calls: 2", result)
         self.assertIn("tool_call_breakdown:", result)
-        self.assertIn("Read: 2", result)
+        self.assertIn('"Read": 2', result)
 
     def test_with_session_meta_kwarg(self):
         """session_meta kwarg skips reading from the database."""
@@ -205,7 +212,7 @@ class TestCursorCliSessionToMarkdown(unittest.TestCase):
             "createdAt": 1_700_000_000_000,
         }
         result = cursor_cli_session_to_markdown(db_path, session_meta=provided_meta)
-        self.assertIn("mode: custom", result)
+        self.assertIn('mode: "custom"', result)
         self.assertIn("Provided Meta Session", result)
 
     def test_empty_session_produces_valid_markdown(self):
@@ -231,8 +238,8 @@ class TestCursorCliSessionToMarkdown(unittest.TestCase):
         db_path = self._db_path()
         _build_store_db(db_path, meta, json_blobs)
         result = cursor_cli_session_to_markdown(db_path)
-        # Frontmatter title line must be valid YAML (escaped quotes)
-        self.assertIn('title: "', result)
+        # Frontmatter title must have embedded quotes escaped as \"
+        self.assertIn('title: "He said \\"hello\\""', result)
 
 
 if __name__ == "__main__":

--- a/tests/test_search_exclusion_filtering.py
+++ b/tests/test_search_exclusion_filtering.py
@@ -51,6 +51,12 @@ class TestSearchExclusionFiltering(unittest.TestCase):
         self._old_workspace_path = os.environ.get("WORKSPACE_PATH")
         os.environ["WORKSPACE_PATH"] = self.workspace_path
 
+        # Point CLI chats path at an empty temp dir so real sessions don't leak in.
+        self._cli_chats_path = os.path.join(self.base_dir, "cli_chats")
+        os.makedirs(self._cli_chats_path, exist_ok=True)
+        self._old_cli_chats_path = os.environ.get("CLI_CHATS_PATH")
+        os.environ["CLI_CHATS_PATH"] = self._cli_chats_path
+
         app = Flask(__name__)
         app.config["TESTING"] = True
         app.config["EXCLUSION_RULES"] = []
@@ -63,6 +69,10 @@ class TestSearchExclusionFiltering(unittest.TestCase):
             os.environ.pop("WORKSPACE_PATH", None)
         else:
             os.environ["WORKSPACE_PATH"] = self._old_workspace_path
+        if self._old_cli_chats_path is None:
+            os.environ.pop("CLI_CHATS_PATH", None)
+        else:
+            os.environ["CLI_CHATS_PATH"] = self._old_cli_chats_path
         self._tmp.cleanup()
 
     def _build_workspace_dbs(self):

--- a/utils/cli_chat_reader.py
+++ b/utils/cli_chat_reader.py
@@ -1,0 +1,432 @@
+"""
+Reader for Cursor CLI (``agent``) chat sessions.
+
+Storage layout:
+  ~/.cursor/chats/{project_id}/{session_id}/store.db
+
+Each ``store.db`` is a SQLite database with two tables:
+
+``meta``
+    One row, key ``"0"``, value is a hex-encoded JSON string:
+    ``{"agentId": "...", "latestRootBlobId": "...", "name": "...",
+       "mode": "...", "createdAt": <ms>}``
+
+``blobs``
+    Content-addressed store keyed by SHA-256 hex.  Blobs are either:
+
+    * **JSON messages** — raw UTF-8 bytes that parse as a dict with a
+      ``"role"`` field.  Roles: ``system``, ``user``, ``assistant``,
+      ``tool``.  Content follows the Vercel AI SDK format (string or array
+      of typed parts).
+    * **Binary chain nodes** — protobuf-like bytes where each 32-byte
+      run prefixed by ``0a 20`` is a SHA-256 reference to another blob.
+      These form the linked-list structure of the conversation.
+
+Conversation reconstruction: BFS from ``latestRootBlobId``, collecting
+JSON-decodable blobs in traversal order.
+
+User messages contain a ``<user_info>..Workspace Path: ..</user_info>``
+preamble injected by the CLI.  This is used to derive the workspace name
+for a project.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+from datetime import datetime, timezone
+from typing import Generator
+
+
+# ---------------------------------------------------------------------------
+# Low-level store.db helpers
+# ---------------------------------------------------------------------------
+
+def _read_meta(db_path: str) -> dict:
+    """Read and decode the session metadata row from a ``store.db``."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        row = conn.execute("SELECT value FROM meta WHERE key = '0'").fetchone()
+        if row and row[0]:
+            return json.loads(bytes.fromhex(row[0]).decode("utf-8"))
+    except Exception:
+        pass
+    finally:
+        conn.close()
+    return {}
+
+
+def _extract_blob_refs(data: bytes) -> list[str]:
+    """Extract all 32-byte (SHA-256) blob references from a binary chain node.
+
+    The encoding is: tag ``0x0a`` (field 1, length-delimited) followed by
+    ``0x20`` (length = 32), followed by the 32-byte hash.
+    """
+    refs: list[str] = []
+    i = 0
+    while i + 33 < len(data):
+        if data[i] == 0x0A and data[i + 1] == 0x20:
+            refs.append(data[i + 2 : i + 34].hex())
+            i += 34
+        else:
+            i += 1
+    return refs
+
+
+def traverse_blobs(db_path: str) -> list[dict]:
+    """Reconstruct the conversation from a ``store.db`` blob graph.
+
+    Starting from ``latestRootBlobId``, performs BFS over the blob DAG:
+    - JSON blobs  → collected as conversation messages (preserving order)
+    - Binary blobs → their SHA-256 references are queued for further traversal
+
+    Returns a list of message dicts ``{"role": ..., "content": ...}`` in
+    conversation order.  ``system`` messages are included; callers may filter
+    them as needed.
+    """
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        meta_row = conn.execute("SELECT value FROM meta WHERE key = '0'").fetchone()
+        if not meta_row or not meta_row[0]:
+            return []
+        meta = json.loads(bytes.fromhex(meta_row[0]).decode("utf-8"))
+        root_id: str = meta.get("latestRootBlobId", "")
+        if not root_id:
+            return []
+
+        # Load all blobs, classifying each as JSON or binary
+        json_blobs: dict[str, dict] = {}
+        chain_blobs: dict[str, list[str]] = {}
+
+        for blob_id, data in conn.execute("SELECT id, data FROM blobs"):
+            if not isinstance(data, bytes):
+                continue
+            try:
+                msg = json.loads(data.decode("utf-8"))
+                if isinstance(msg, dict) and "role" in msg:
+                    json_blobs[blob_id] = msg
+                    continue
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                pass
+            refs = _extract_blob_refs(data)
+            chain_blobs[blob_id] = refs
+
+    finally:
+        conn.close()
+
+    # BFS from root
+    visited: set[str] = set()
+    queue: list[str] = [root_id]
+    messages: list[dict] = []
+
+    while queue:
+        bid = queue.pop(0)
+        if bid in visited:
+            continue
+        visited.add(bid)
+
+        if bid in json_blobs:
+            messages.append(json_blobs[bid])
+        elif bid in chain_blobs:
+            for ref in chain_blobs[bid]:
+                if ref not in visited:
+                    queue.append(ref)
+
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Content extraction helpers
+# ---------------------------------------------------------------------------
+
+_USER_INFO_RE = re.compile(r"<user_info>.*?</user_info>", re.DOTALL)
+_USER_QUERY_RE = re.compile(r"<user_query>(.*?)</user_query>", re.DOTALL)
+_WORKSPACE_PATH_RE = re.compile(r"Workspace Path:\s*(.+?)(?:\n|$)")
+
+
+def _content_to_text(content) -> str:
+    """Flatten Vercel AI SDK content (string or typed-part array) to plain text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                if part.get("type") == "text":
+                    parts.append(part.get("text", ""))
+                elif part.get("type") == "tool-result":
+                    result = part.get("result", "")
+                    parts.append(str(result) if result else "")
+        return "\n".join(p for p in parts if p)
+    return ""
+
+
+def _extract_tool_calls(content) -> list[dict]:
+    """Extract tool-call parts from assistant message content."""
+    if not isinstance(content, list):
+        return []
+    calls: list[dict] = []
+    for part in content:
+        if isinstance(part, dict) and part.get("type") == "tool-call":
+            calls.append({
+                "name": part.get("toolName", "unknown"),
+                "args": part.get("args", {}),
+                "toolCallId": part.get("toolCallId", ""),
+            })
+    return calls
+
+
+def extract_workspace_path(messages: list[dict]) -> str | None:
+    """Extract the workspace path from the ``<user_info>`` preamble in the
+    first user message that contains one."""
+    for msg in messages:
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content", "")
+        text = content if isinstance(content, str) else _content_to_text(content)
+        m = _WORKSPACE_PATH_RE.search(text)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def _strip_user_info(text: str) -> str:
+    """Remove the ``<user_info>`` preamble and return only the query text.
+
+    If a ``<user_query>`` tag is present, its content is returned directly.
+    Otherwise the user_info block is stripped and the remainder is returned.
+    """
+    qm = _USER_QUERY_RE.search(text)
+    if qm:
+        return qm.group(1).strip()
+    return _USER_INFO_RE.sub("", text).strip()
+
+
+def messages_to_bubbles(messages: list[dict], created_at_ms: int) -> list[dict]:
+    """Convert CLI message dicts to the bubble format used by the browser UI.
+
+    Each bubble has:
+    ``{"type": "user"|"ai", "text": str, "timestamp": int, "metadata": dict|None}``
+
+    Conversion rules:
+    - ``system`` messages are skipped.
+    - ``user`` messages: strip ``<user_info>`` preamble, keep query text.
+    - ``assistant`` messages with text parts → ``type: "ai"`` bubble.
+    - ``assistant`` messages with ``tool-call`` parts → ``type: "ai"`` bubble
+      with ``metadata.toolCalls``.
+    - ``tool`` (result) messages are skipped; their content is not separately
+      surfaced (tool call IDs link them to the preceding assistant bubble).
+
+    Per-message timestamps are unavailable in CLI sessions; ``created_at_ms``
+    is used for all bubbles with a 1 ms sequence offset so UI sorting is stable.
+    """
+    bubbles: list[dict] = []
+    seq = 0
+
+    for msg in messages:
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+
+        if role == "system":
+            continue
+
+        if role == "tool":
+            continue
+
+        ts = created_at_ms + seq
+        seq += 1
+
+        if role == "user":
+            text = _content_to_text(content) if isinstance(content, list) else (content or "")
+            # Skip pure preamble messages (contain <user_info> but no <user_query>).
+            if "<user_info>" in text and "<user_query>" not in text:
+                continue
+            text = _strip_user_info(text)
+            if not text:
+                continue
+            bubbles.append({"type": "user", "text": text, "timestamp": ts})
+
+        elif role == "assistant":
+            text = _content_to_text(content) if isinstance(content, list) else (content or "")
+            tool_calls = _extract_tool_calls(content)
+
+            if not text.strip() and not tool_calls:
+                continue
+
+            bubble: dict = {"type": "ai", "text": text, "timestamp": ts}
+            if tool_calls:
+                # Convert to the format parse_tool_call returns
+                formatted_calls = []
+                for tc in tool_calls:
+                    args = tc.get("args", {})
+                    name = tc.get("name", "unknown")
+                    # Build a human-readable summary
+                    if name in ("Glob", "glob_file_search"):
+                        pattern = args.get("glob_pattern") or args.get("pattern") or ""
+                        summary = f"Glob: {pattern}"
+                        input_display = pattern
+                    elif name in ("Read", "read_file_v2"):
+                        fp = args.get("path") or args.get("targetFile") or ""
+                        summary = f"Read: {fp}"
+                        input_display = fp
+                    elif name in ("Shell", "run_terminal_command_v2"):
+                        cmd = args.get("command") or ""
+                        summary = f"Terminal: {cmd[:80]}"
+                        input_display = cmd
+                    elif name in ("Grep",):
+                        pattern = args.get("pattern") or ""
+                        summary = f"Search: /{pattern}/"
+                        input_display = pattern
+                    elif name in ("WebSearch", "web_search"):
+                        q = args.get("search_term") or args.get("query") or ""
+                        summary = f"Web search: {q[:60]}"
+                        input_display = q
+                    elif name in ("WebFetch", "web_fetch"):
+                        url = args.get("url") or ""
+                        summary = f"Fetch: {url[:60]}"
+                        input_display = url
+                    else:
+                        summary = name
+                        input_display = json.dumps(args, indent=2) if args else ""
+                    formatted_calls.append({
+                        "name": name,
+                        "status": "",
+                        "summary": summary,
+                        "input": input_display,
+                        "output": "",
+                        "toolCallId": tc.get("toolCallId", ""),
+                    })
+                if not text.strip():
+                    tc0 = formatted_calls[0]
+                    bubble["text"] = f"**Tool: {tc0['summary']}**"
+                bubble["metadata"] = {"toolCalls": formatted_calls}
+            bubbles.append(bubble)
+
+    return bubbles
+
+
+# ---------------------------------------------------------------------------
+# Project / session enumeration
+# ---------------------------------------------------------------------------
+
+def iter_sessions(chats_path: str) -> Generator[dict, None, None]:
+    """Yield one dict per CLI session under ``chats_path``.
+
+    Each dict contains:
+    ``{"project_id", "session_id", "db_path", "meta"}``
+    where ``meta`` is the decoded session metadata (may be ``{}`` on error).
+    """
+    if not os.path.isdir(chats_path):
+        return
+    for project_id in os.listdir(chats_path):
+        project_path = os.path.join(chats_path, project_id)
+        if not os.path.isdir(project_path):
+            continue
+        for session_id in os.listdir(project_path):
+            session_path = os.path.join(project_path, session_id)
+            db_path = os.path.join(session_path, "store.db")
+            if not os.path.isfile(db_path):
+                continue
+            try:
+                meta = _read_meta(db_path)
+            except Exception:
+                meta = {}
+            yield {
+                "project_id": project_id,
+                "session_id": session_id,
+                "db_path": db_path,
+                "meta": meta,
+            }
+
+
+def list_cli_projects(chats_path: str) -> list[dict]:
+    """Return one dict per CLI project (unique ``project_id``).
+
+    Each dict:
+    ``{"project_id", "workspace_path", "workspace_name", "sessions", "last_updated_ms"}``
+
+    where ``sessions`` is a list of session dicts (``project_id``,
+    ``session_id``, ``db_path``, ``meta``), ``workspace_path`` is extracted
+    from the first user message found, and ``workspace_name`` is the last
+    path segment of ``workspace_path``.
+    """
+    projects: dict[str, dict] = {}
+
+    for session in iter_sessions(chats_path):
+        pid = session["project_id"]
+        if pid not in projects:
+            projects[pid] = {
+                "project_id": pid,
+                "workspace_path": None,
+                "workspace_name": None,
+                "sessions": [],
+                "last_updated_ms": 0,
+            }
+        projects[pid]["sessions"].append(session)
+
+        created = session["meta"].get("createdAt") or 0
+        if created > projects[pid]["last_updated_ms"]:
+            projects[pid]["last_updated_ms"] = created
+
+    # Resolve workspace path / name from a session's messages
+    for pid, proj in projects.items():
+        if proj["workspace_path"]:
+            continue
+        for session in proj["sessions"]:
+            try:
+                msgs = traverse_blobs(session["db_path"])
+                ws_path = extract_workspace_path(msgs)
+                if ws_path:
+                    proj["workspace_path"] = ws_path
+                    parts = ws_path.replace("\\", "/").rstrip("/").split("/")
+                    proj["workspace_name"] = parts[-1] if parts else ws_path
+                    break
+            except Exception:
+                continue
+
+        if not proj["workspace_name"]:
+            proj["workspace_name"] = pid[:12]
+
+    return list(projects.values())
+
+
+# ---------------------------------------------------------------------------
+# Aggregate statistics for a project's sessions
+# ---------------------------------------------------------------------------
+
+def aggregate_session_stats(session: dict) -> dict:
+    """Return aggregate statistics for one CLI session.
+
+    Reads and converts blobs, then counts tool calls and computes wall-clock
+    duration.  Returns a dict suitable for embedding in Markdown frontmatter.
+    """
+    meta = session.get("meta", {})
+    created_ms: int = meta.get("createdAt") or int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+
+    try:
+        messages = traverse_blobs(session["db_path"])
+    except Exception:
+        return {"created_ms": created_ms, "messages": []}
+
+    bubbles = messages_to_bubbles(messages, created_ms)
+
+    total_tool_calls = 0
+    tool_breakdown: dict[str, int] = {}
+    for b in bubbles:
+        tcs = (b.get("metadata") or {}).get("toolCalls") or []
+        total_tool_calls += len(tcs)
+        for tc in tcs:
+            tn = tc.get("name", "unknown")
+            tool_breakdown[tn] = tool_breakdown.get(tn, 0) + 1
+
+    return {
+        "created_ms": created_ms,
+        "messages": messages,
+        "bubbles": bubbles,
+        "total_tool_calls": total_tool_calls,
+        "tool_breakdown": tool_breakdown,
+        "mode": meta.get("mode", ""),
+        "session_name": meta.get("name", ""),
+    }

--- a/utils/cli_chat_reader.py
+++ b/utils/cli_chat_reader.py
@@ -116,13 +116,16 @@ def traverse_blobs(db_path: str) -> list[dict]:
     finally:
         conn.close()
 
-    # BFS from root
+    # BFS from root (newest-first by nature of the linked-list structure);
+    # reverse at the end to restore chronological (oldest→newest) order.
+    from collections import deque
+
     visited: set[str] = set()
-    queue: list[str] = [root_id]
+    queue: deque[str] = deque([root_id])
     messages: list[dict] = []
 
     while queue:
-        bid = queue.pop(0)
+        bid = queue.popleft()
         if bid in visited:
             continue
         visited.add(bid)
@@ -134,6 +137,7 @@ def traverse_blobs(db_path: str) -> list[dict]:
                 if ref not in visited:
                     queue.append(ref)
 
+    messages.reverse()
     return messages
 
 

--- a/utils/cli_chat_reader.py
+++ b/utils/cli_chat_reader.py
@@ -219,13 +219,35 @@ def messages_to_bubbles(messages: list[dict], created_at_ms: int) -> list[dict]:
     - ``user`` messages: strip ``<user_info>`` preamble, keep query text.
     - ``assistant`` messages with text parts → ``type: "ai"`` bubble.
     - ``assistant`` messages with ``tool-call`` parts → ``type: "ai"`` bubble
-      with ``metadata.toolCalls``.
-    - ``tool`` (result) messages are skipped; their content is not separately
-      surfaced (tool call IDs link them to the preceding assistant bubble).
+      with ``metadata.toolCalls``.  The ``output`` field of each tool call is
+      populated from the corresponding ``role: "tool"`` result message (matched
+      by ``toolCallId``).
+    - ``tool`` (result) messages are used only to populate tool-call outputs;
+      they are not emitted as separate bubbles.
 
     Per-message timestamps are unavailable in CLI sessions; ``created_at_ms``
     is used for all bubbles with a 1 ms sequence offset so UI sorting is stable.
     """
+    # Pre-scan: build toolCallId → output text map from role=="tool" messages.
+    tool_outputs: dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") != "tool":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") == "tool-result":
+                    tid = part.get("toolCallId", "")
+                    result = part.get("result", "")
+                    if tid:
+                        tool_outputs[tid] = str(result) if result else ""
+        elif isinstance(content, str) and content:
+            # Plain string result with no toolCallId — store under empty key
+            # only if not already set, to avoid clobbering a keyed entry.
+            tool_outputs.setdefault("", content)
+
     bubbles: list[dict] = []
     seq = 0
 
@@ -233,10 +255,7 @@ def messages_to_bubbles(messages: list[dict], created_at_ms: int) -> list[dict]:
         role = msg.get("role", "")
         content = msg.get("content", "")
 
-        if role == "system":
-            continue
-
-        if role == "tool":
+        if role in ("system", "tool"):
             continue
 
         ts = created_at_ms + seq
@@ -266,6 +285,7 @@ def messages_to_bubbles(messages: list[dict], created_at_ms: int) -> list[dict]:
                 for tc in tool_calls:
                     args = tc.get("args", {})
                     name = tc.get("name", "unknown")
+                    tid = tc.get("toolCallId", "")
                     # Build a human-readable summary
                     if name in ("Glob", "glob_file_search"):
                         pattern = args.get("glob_pattern") or args.get("pattern") or ""
@@ -299,8 +319,8 @@ def messages_to_bubbles(messages: list[dict], created_at_ms: int) -> list[dict]:
                         "status": "",
                         "summary": summary,
                         "input": input_display,
-                        "output": "",
-                        "toolCallId": tc.get("toolCallId", ""),
+                        "output": tool_outputs.get(tid, ""),
+                        "toolCallId": tid,
                     })
                 if not text.strip():
                     tc0 = formatted_calls[0]
@@ -371,8 +391,13 @@ def list_cli_projects(chats_path: str) -> list[dict]:
         projects[pid]["sessions"].append(session)
 
         created = session["meta"].get("createdAt") or 0
-        if created > projects[pid]["last_updated_ms"]:
-            projects[pid]["last_updated_ms"] = created
+        try:
+            mtime_ms = int(os.path.getmtime(session["db_path"]) * 1000)
+        except OSError:
+            mtime_ms = 0
+        session_ts = max(created, mtime_ms)
+        if session_ts > projects[pid]["last_updated_ms"]:
+            projects[pid]["last_updated_ms"] = session_ts
 
     # Resolve workspace path / name from a session's messages
     for pid, proj in projects.items():

--- a/utils/cursor_md_exporter.py
+++ b/utils/cursor_md_exporter.py
@@ -1,0 +1,144 @@
+"""Markdown export for Cursor CLI agent sessions.
+
+Exposes ``cursor_cli_session_to_markdown`` — a reusable function that
+generates a complete Markdown document (YAML frontmatter + body) from a
+Cursor CLI ``store.db`` session.  The logic is extracted from
+``scripts/export.py`` so it can be called programmatically without running
+the full export CLI.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from utils.cli_chat_reader import traverse_blobs, messages_to_bubbles
+
+
+def _slug(s: str) -> str:
+    """Simple slug: collapse whitespace and special chars to dashes."""
+    import re
+    s = re.sub(r'[<>:"/\\|?*]', "_", s or "")
+    s = re.sub(r"\s+", "-", s)
+    s = re.sub(r"-+", "-", s)
+    return s.strip("-")[:80] or "untitled"
+
+
+def cursor_cli_session_to_markdown(
+    db_path: str | Path,
+    session_meta: dict | None = None,
+) -> str:
+    """Generate a complete Markdown document from a Cursor CLI store.db session.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the ``store.db`` SQLite file for the session.
+    session_meta:
+        Optional dict with pre-read session metadata (keys: ``agentId``,
+        ``createdAt``, ``name``, ``mode``).  If omitted, metadata is read
+        from ``db_path`` automatically.
+
+    Returns
+    -------
+    str
+        Full Markdown text including YAML frontmatter and conversation body.
+    """
+    db_path = Path(db_path)
+
+    # Read metadata from the database if not provided.
+    if session_meta is None:
+        import sqlite3
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+            row = conn.execute("SELECT value FROM meta WHERE key = '0'").fetchone()
+            conn.close()
+            session_meta = json.loads(bytes.fromhex(row[0]).decode()) if row else {}
+        except Exception:
+            session_meta = {}
+
+    session_id: str = session_meta.get("agentId", db_path.parent.name)
+    created_ms: int = session_meta.get("createdAt") or int(datetime.now().timestamp() * 1000)
+    session_name: str = session_meta.get("name") or f"Session {session_id[:8]}"
+    mode: str = session_meta.get("mode", "")
+
+    # Reconstruct conversation.
+    try:
+        messages = traverse_blobs(str(db_path))
+        bubbles = messages_to_bubbles(messages, created_ms)
+    except Exception:
+        bubbles = []
+
+    # Derive title.
+    title = session_name
+    if not title or title.startswith("New Agent"):
+        for b in bubbles:
+            if b["type"] == "user" and b.get("text"):
+                first_lines = [ln for ln in b["text"].split("\n") if ln.strip()]
+                if first_lines:
+                    title = first_lines[0][:100]
+                    if len(title) == 100:
+                        title += "..."
+                break
+
+    # Aggregate statistics.
+    total_tool_calls = 0
+    tool_breakdown: dict[str, int] = {}
+    for b in bubbles:
+        tcs = (b.get("metadata") or {}).get("toolCalls") or []
+        total_tool_calls += len(tcs)
+        for tc in tcs:
+            tn = tc.get("name", "unknown")
+            tool_breakdown[tn] = tool_breakdown.get(tn, 0) + 1
+
+    # Frontmatter.
+    fm_lines = ["---"]
+    fm_lines.append(f"log_id: {session_id}")
+    fm_lines.append(f"log_type: cli_agent")
+    fm_lines.append(f'title: "{title.replace(chr(34), chr(92) + chr(34))}"')
+    fm_lines.append(
+        f"created_at: {datetime.fromtimestamp(created_ms / 1000).isoformat()}"
+    )
+    fm_lines.append(f"session_id: {session_id}")
+    if mode:
+        fm_lines.append(f"mode: {mode}")
+    fm_lines.append(f"message_count: {len(bubbles)}")
+    if total_tool_calls:
+        fm_lines.append(f"total_tool_calls: {total_tool_calls}")
+    if tool_breakdown:
+        fm_lines.append("tool_call_breakdown:")
+        for tn, cnt in sorted(tool_breakdown.items(), key=lambda x: -x[1]):
+            fm_lines.append(f"  {tn}: {cnt}")
+    fm_lines.append("---")
+    fm_str = "\n".join(fm_lines) + "\n\n"
+
+    # Header.
+    header_meta_parts = [
+        f"Created: {datetime.fromtimestamp(created_ms / 1000).strftime('%Y-%m-%d %H:%M:%S')}"
+    ]
+    if mode:
+        header_meta_parts.append(f"Mode: {mode}")
+    if total_tool_calls:
+        header_meta_parts.append(f"Tool calls: {total_tool_calls}")
+    header = f"# {title}\n\n_{' | '.join(header_meta_parts)}_\n\n---\n\n"
+
+    # Body.
+    body = ""
+    for b in bubbles:
+        role_label = "User" if b["type"] == "user" else "Assistant"
+        body += f"### {role_label}\n\n"
+        body += b.get("text", "") + "\n\n"
+        tool_calls = (b.get("metadata") or {}).get("toolCalls") or []
+        for tc in tool_calls:
+            summary = tc.get("summary") or tc.get("name") or "unknown"
+            body += f"> **Tool: {summary}**\n"
+            if tc.get("input"):
+                body += "> **INPUT:**\n> ```\n"
+                for iline in str(tc["input"]).split("\n"):
+                    body += f"> {iline}\n"
+                body += "> ```\n"
+            body += "\n"
+        body += "---\n\n"
+
+    return fm_str + header + body

--- a/utils/cursor_md_exporter.py
+++ b/utils/cursor_md_exporter.py
@@ -92,24 +92,26 @@ def cursor_cli_session_to_markdown(
             tn = tc.get("name", "unknown")
             tool_breakdown[tn] = tool_breakdown.get(tn, 0) + 1
 
-    # Frontmatter.
+    # Frontmatter.  Free-form string scalars are serialized with json.dumps()
+    # so that backslashes, newlines, and embedded quotes are all escaped safely
+    # (JSON strings are a valid YAML double-quoted scalar subset).
     fm_lines = ["---"]
-    fm_lines.append(f"log_id: {session_id}")
-    fm_lines.append(f"log_type: cli_agent")
-    fm_lines.append(f'title: "{title.replace(chr(34), chr(92) + chr(34))}"')
+    fm_lines.append(f"log_id: {json.dumps(session_id, ensure_ascii=False)}")
+    fm_lines.append("log_type: cli_agent")
+    fm_lines.append(f"title: {json.dumps(title, ensure_ascii=False)}")
     fm_lines.append(
         f"created_at: {datetime.fromtimestamp(created_ms / 1000).isoformat()}"
     )
-    fm_lines.append(f"session_id: {session_id}")
+    fm_lines.append(f"session_id: {json.dumps(session_id, ensure_ascii=False)}")
     if mode:
-        fm_lines.append(f"mode: {mode}")
+        fm_lines.append(f"mode: {json.dumps(mode, ensure_ascii=False)}")
     fm_lines.append(f"message_count: {len(bubbles)}")
     if total_tool_calls:
         fm_lines.append(f"total_tool_calls: {total_tool_calls}")
     if tool_breakdown:
         fm_lines.append("tool_call_breakdown:")
         for tn, cnt in sorted(tool_breakdown.items(), key=lambda x: -x[1]):
-            fm_lines.append(f"  {tn}: {cnt}")
+            fm_lines.append(f"  {json.dumps(tn, ensure_ascii=False)}: {cnt}")
     fm_lines.append("---")
     fm_str = "\n".join(fm_lines) + "\n\n"
 

--- a/utils/cursor_md_exporter.py
+++ b/utils/cursor_md_exporter.py
@@ -2,9 +2,8 @@
 
 Exposes ``cursor_cli_session_to_markdown`` — a reusable function that
 generates a complete Markdown document (YAML frontmatter + body) from a
-Cursor CLI ``store.db`` session.  The logic is extracted from
-``scripts/export.py`` so it can be called programmatically without running
-the full export CLI.
+Cursor CLI ``store.db`` session.  The logic is shared between
+``scripts/export.py`` and any programmatic caller.
 """
 
 from __future__ import annotations
@@ -12,6 +11,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from utils.cli_chat_reader import traverse_blobs, messages_to_bubbles
 
@@ -28,6 +28,9 @@ def _slug(s: str) -> str:
 def cursor_cli_session_to_markdown(
     db_path: str | Path,
     session_meta: dict | None = None,
+    workspace_info: dict | None = None,
+    bubbles: list[dict] | None = None,
+    title_override: str | None = None,
 ) -> str:
     """Generate a complete Markdown document from a Cursor CLI store.db session.
 
@@ -39,11 +42,28 @@ def cursor_cli_session_to_markdown(
         Optional dict with pre-read session metadata (keys: ``agentId``,
         ``createdAt``, ``name``, ``mode``).  If omitted, metadata is read
         from ``db_path`` automatically.
+    workspace_info:
+        Optional dict with workspace-level fields to include in frontmatter.
+        Recognised keys: ``workspace`` (slug), ``workspace_name``,
+        ``workspace_path``, ``project_id``.
+    bubbles:
+        Pre-computed bubble list from ``messages_to_bubbles()``.  When
+        provided the database is not re-read, avoiding a redundant SQL query.
+    title_override:
+        Caller-supplied title (e.g. already derived for a filename).  When
+        set, skips the first-user-message derivation heuristic.
 
     Returns
     -------
     str
         Full Markdown text including YAML frontmatter and conversation body.
+
+    Raises
+    ------
+    Exception
+        Re-raises any exception from ``traverse_blobs`` / ``messages_to_bubbles``
+        so callers can detect unreadable databases rather than silently receiving
+        an empty document.
     """
     db_path = Path(db_path)
 
@@ -63,15 +83,14 @@ def cursor_cli_session_to_markdown(
     session_name: str = session_meta.get("name") or f"Session {session_id[:8]}"
     mode: str = session_meta.get("mode", "")
 
-    # Reconstruct conversation.
-    try:
+    # Reconstruct conversation — callers may pass pre-computed bubbles to
+    # avoid a redundant DB read.  Errors propagate; caller decides how to handle.
+    if bubbles is None:
         messages = traverse_blobs(str(db_path))
         bubbles = messages_to_bubbles(messages, created_ms)
-    except Exception:
-        bubbles = []
 
     # Derive title.
-    title = session_name
+    title = title_override or session_name
     if not title or title.startswith("New Agent"):
         for b in bubbles:
             if b["type"] == "user" and b.get("text"):
@@ -102,6 +121,16 @@ def cursor_cli_session_to_markdown(
     fm_lines.append(
         f"created_at: {datetime.fromtimestamp(created_ms / 1000).isoformat()}"
     )
+    # Workspace-level fields (only when caller provides them).
+    ws_info = workspace_info or {}
+    if ws_info.get("workspace"):
+        fm_lines.append(f"workspace: {ws_info['workspace']}")
+    if ws_info.get("workspace_name"):
+        fm_lines.append(f"workspace_name: {json.dumps(ws_info['workspace_name'], ensure_ascii=False)}")
+    if ws_info.get("workspace_path"):
+        fm_lines.append(f"workspace_path: {json.dumps(ws_info['workspace_path'], ensure_ascii=False)}")
+    if ws_info.get("project_id"):
+        fm_lines.append(f"project_id: {json.dumps(ws_info['project_id'], ensure_ascii=False)}")
     fm_lines.append(f"session_id: {json.dumps(session_id, ensure_ascii=False)}")
     if mode:
         fm_lines.append(f"mode: {json.dumps(mode, ensure_ascii=False)}")
@@ -139,6 +168,11 @@ def cursor_cli_session_to_markdown(
                 body += "> **INPUT:**\n> ```\n"
                 for iline in str(tc["input"]).split("\n"):
                     body += f"> {iline}\n"
+                body += "> ```\n"
+            if tc.get("output"):
+                body += "> **OUTPUT:**\n> ```\n"
+                for oline in str(tc["output"]).split("\n"):
+                    body += f"> {oline}\n"
                 body += "> ```\n"
             body += "\n"
         body += "---\n\n"

--- a/utils/path_helpers.py
+++ b/utils/path_helpers.py
@@ -40,11 +40,17 @@ def normalize_file_path(file_path: str) -> str:
     except Exception:
         pass
 
-    # Platform-specific normalization
+    # Normalize Windows-style paths: lowercase and unify slashes.
+    # Done unconditionally for paths that look like Windows absolute paths
+    # (e.g. "d:\foo" or "d:/foo") so that cross-platform reads (WSL, Linux
+    # reading Cursor's Windows storage) get the same result as native Win32.
     if sys.platform == "win32":
         normalized = normalized.replace("/", "\\")
-        # Remove leading backslash before drive letter
         normalized = re.sub(r"^\\([a-zA-Z]:)", r"\1", normalized)
+        normalized = normalized.lower()
+    elif re.match(r"^[a-zA-Z]:[/\\]", normalized):
+        # Windows-style absolute path on a non-Windows host.
+        normalized = normalized.replace("/", "\\")
         normalized = normalized.lower()
 
     return normalized

--- a/utils/workspace_path.py
+++ b/utils/workspace_path.py
@@ -65,3 +65,17 @@ def resolve_workspace_path() -> str:
     if env_path:
         return expand_tilde_path(env_path)
     return get_default_workspace_path()
+
+
+def get_cli_chats_path() -> str:
+    """Return the Cursor CLI chats directory (~/.cursor/chats).
+
+    This is where the ``agent`` CLI stores chat sessions, independent of
+    platform and completely separate from the IDE workspace storage.
+
+    Override with the ``CLI_CHATS_PATH`` environment variable (useful in tests).
+    """
+    env_path = os.environ.get("CLI_CHATS_PATH")
+    if env_path:
+        return env_path
+    return os.path.join(os.path.expanduser("~"), ".cursor", "chats")

--- a/utils/workspace_path.py
+++ b/utils/workspace_path.py
@@ -75,7 +75,7 @@ def get_cli_chats_path() -> str:
 
     Override with the ``CLI_CHATS_PATH`` environment variable (useful in tests).
     """
-    env_path = os.environ.get("CLI_CHATS_PATH")
+    env_path = os.environ.get("CLI_CHATS_PATH", "").strip()
     if env_path:
-        return env_path
+        return expand_tilde_path(env_path)
     return os.path.join(os.path.expanduser("~"), ".cursor", "chats")


### PR DESCRIPTION
Read, browse, search, and export sessions stored in ~/.cursor/chats/ by the `cursor agent` CLI — independent of the Cursor IDE.

New modules:
- utils/cli_chat_reader.py: reconstructs conversations from the store.db blob-graph (BFS over SHA-256 content-addressed blobs), extracts workspace path from <user_info> preamble, converts messages to the bubble format used by the rest of the app.
- utils/cursor_md_exporter.py: reusable Markdown exporter for CLI sessions (YAML frontmatter + conversation body).

Web UI:
- api/workspaces.py: CLI projects appear in the workspaces list (id: "cli:<project_id>"); workspace detail and tabs endpoints handle cli:-prefixed IDs.
- api/search.py: full-text search now includes CLI sessions.

CLI export:
- scripts/export.py: exports CLI sessions alongside IDE chats (written to <workspace>/cli/). IDE database is now optional — export works gracefully when only cursor agent is installed.

Config:
- utils/workspace_path.py: get_cli_chats_path() defaults to ~/.cursor/chats/; overrideable via CLI_CHATS_PATH env var.

Tests:
- tests/test_cli_chat_reader.py: 53 unit tests (blob parsing, content extraction, message conversion, session enumeration, project grouping, stats aggregation).
- tests/test_cursor_md_exporter.py: 15 tests (frontmatter fields, body rendering, tool calls, edge cases).
- tests/test_search_exclusion_filtering.py: isolate CLI path via CLI_CHATS_PATH to prevent real sessions leaking into tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browse, search, and export Cursor CLI agent sessions alongside IDE chats; CLI sessions show in search with matching snippets and source metadata.
  * Generate Markdown exports for CLI sessions with YAML frontmatter, session summaries, and per-tool-call breakdowns; supports incremental exports.

* **Documentation**
  * Updated Quick Start/CLI Export, export frontmatter, output layout, export-state persistence, and overridable CLI chats path.

* **Tests**
  * Added comprehensive unit tests for CLI chat reading and Markdown export, plus env isolation for CLI path.

* **Bug Fixes**
  * Export/search gracefully handle missing IDE DBs and nonfatal CLI read errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->