### PR TITLE
ci: add GitHub Actions workflow that runs the unittest suite (closes #13)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,10 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      # Pinned to immutable commit SHAs (not @v4 / @v5) so a compromised tag
+      # cannot silently swap the underlying action code on this CI runner.
+      # When bumping, verify the new SHA via:
+      #   gh api repos/actions/<name>/git/ref/tags/<vN> --jq '.object.sha'
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  unittest:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install runtime + test dependencies
+        # Only what the tests actually exercise. `pywebview` from requirements.txt
+        # is the desktop-launcher dep and pulls GTK / Qt system packages on Linux
+        # — out of scope for the unittest suite, so it's deliberately omitted here.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install 'flask>=3.0' 'fpdf2>=2.7'
+
+      - name: Run unittest suite
+        run: python -m unittest discover tests -v


### PR DESCRIPTION
## Problem

No CI. 137 existing unit tests only run when a developer remembers to run them locally — regressions can land on `master` ungated.

## Change

Add [`.github/workflows/tests.yml`](.github/workflows/tests.yml). Triggers on every push to `master` and every pull request. Single Ubuntu runner, Python 3.12. Installs `flask` + `fpdf2` (omits `pywebview` — desktop-launcher dep, not exercised by the test suite, pulls GTK/Qt system packages). Runs `python -m unittest discover tests -v`.

## Test plan

- Local run with the exact command the workflow uses: **137/137 OK** on Python 3.12.
- YAML parses; 4 steps (checkout → setup-python → install → run tests).
- Once merged, every future PR will show a `Tests / Unit tests` check that must pass before merge.

Closes #13.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added continuous integration to run the unit test suite on pushes and pull requests, installing test dependencies and reporting results to ensure code quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->