### PR TITLE
fix: wrap all production sqlite3.connect() in context managers (closes #17)

### DIFF
--- a/api/composers.py
+++ b/api/composers.py
@@ -7,6 +7,7 @@ API routes for composers — mirrors:
 import json
 import os
 import sqlite3
+from contextlib import closing
 
 from flask import Blueprint, jsonify
 
@@ -45,11 +46,11 @@ def list_composers():
                 pass
 
             try:
-                conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-                row = conn.execute(
-                    "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
-                ).fetchone()
-                conn.close()
+                # closing() guarantees .close() on scope exit (issue #17).
+                with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as conn:
+                    row = conn.execute(
+                        "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
+                    ).fetchone()
 
                 if row and row[0]:
                     data = json.loads(row[0])
@@ -86,11 +87,11 @@ def get_composer(composer_id):
                 continue
 
             try:
-                conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-                row = conn.execute(
-                    "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
-                ).fetchone()
-                conn.close()
+                # closing() guarantees .close() on scope exit (issue #17).
+                with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as conn:
+                    row = conn.execute(
+                        "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
+                    ).fetchone()
 
                 if row and row[0]:
                     data = json.loads(row[0])
@@ -104,12 +105,12 @@ def get_composer(composer_id):
         global_db_path = os.path.normpath(os.path.join(workspace_path, "..", "globalStorage", "state.vscdb"))
         if os.path.isfile(global_db_path):
             try:
-                conn = sqlite3.connect(f"file:{global_db_path}?mode=ro", uri=True)
-                row = conn.execute(
-                    "SELECT value FROM cursorDiskKV WHERE key = ?",
-                    (f"composerData:{composer_id}",),
-                ).fetchone()
-                conn.close()
+                # closing() guarantees .close() on scope exit (issue #17).
+                with closing(sqlite3.connect(f"file:{global_db_path}?mode=ro", uri=True)) as conn:
+                    row = conn.execute(
+                        "SELECT value FROM cursorDiskKV WHERE key = ?",
+                        (f"composerData:{composer_id}",),
+                    ).fetchone()
 
                 if row and row[0]:
                     raw = row[0] if isinstance(row[0], str) else row[0].decode("utf-8")

--- a/api/export_api.py
+++ b/api/export_api.py
@@ -11,6 +11,7 @@ import re
 import sqlite3
 import sys
 import zipfile
+from contextlib import closing
 from datetime import datetime
 from pathlib import Path
 
@@ -78,6 +79,10 @@ def export_chats():
     application startup; an app restart is required to pick up changes to the
     exclusion rules file.
     """
+    # Outer try/finally guarantees the global-storage connection is closed
+    # on every exit path including unexpected exceptions (issue #17). Keeps
+    # the existing function body shape; just ensures cleanup.
+    conn = None
     try:
         body = request.get_json(silent=True) or {}
         since = "last" if body.get("since") == "last" else "all"
@@ -131,17 +136,17 @@ def export_chats():
             if not os.path.isfile(db_path):
                 continue
             try:
-                wconn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-                row = wconn.execute(
-                    "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
-                ).fetchone()
+                # closing() guarantees .close() on scope exit (issue #17).
+                with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as wconn:
+                    row = wconn.execute(
+                        "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
+                    ).fetchone()
                 if row and row[0]:
                     data = json.loads(row[0])
                     for c in (data.get("allComposers") or []):
                         cid = c.get("composerId") if isinstance(c, dict) else None
                         if cid:
                             composer_id_to_ws[cid] = entry["name"]
-                wconn.close()
             except Exception:
                 pass
 
@@ -402,8 +407,6 @@ def export_chats():
             except Exception as e:
                 print(f"Error processing composer {composer_id} for export: {e}")
 
-        conn.close()
-
         count = len(exported)
         if count == 0:
             return jsonify({"error": "No conversations to export" + (
@@ -436,3 +439,8 @@ def export_chats():
         import traceback
         traceback.print_exc()
         return jsonify({"error": f"Export failed: {str(e)}"}), 500
+    finally:
+        # Guaranteed close — fires on success, exception, AND on any
+        # in-body return that doesn't go through except (issue #17).
+        if conn is not None:
+            conn.close()

--- a/api/logs.py
+++ b/api/logs.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sqlite3
+from contextlib import closing
 from datetime import datetime
 
 from flask import Blueprint, jsonify
@@ -32,9 +33,10 @@ def get_logs():
         global_db_path = os.path.normpath(os.path.join(workspace_path, "..", "globalStorage", "state.vscdb"))
         if os.path.isfile(global_db_path):
             try:
-                conn = sqlite3.connect(f"file:{global_db_path}?mode=ro", uri=True)
-                conn.row_factory = sqlite3.Row
-                rows = conn.execute("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'").fetchall()
+                # closing() guarantees .close() on scope exit (issue #17).
+                with closing(sqlite3.connect(f"file:{global_db_path}?mode=ro", uri=True)) as conn:
+                    conn.row_factory = sqlite3.Row
+                    rows = conn.execute("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'").fetchall()
 
                 chat_map: dict[str, list] = {}
                 for row in rows:
@@ -67,7 +69,6 @@ def get_logs():
                         "type": "chat",
                         "messageCount": len(bubbles),
                     })
-                conn.close()
             except Exception as e:
                 print(f"Error reading global storage: {e}")
 
@@ -91,43 +92,42 @@ def get_logs():
                     pass
 
                 try:
-                    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+                    # closing() guarantees .close() on scope exit (issue #17).
+                    with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as conn:
+                        # Chat logs
+                        chat_row = conn.execute(
+                            "SELECT value FROM ItemTable WHERE [key] = 'workbench.panel.aichat.view.aichat.chatdata'"
+                        ).fetchone()
+                        if chat_row and chat_row[0]:
+                            data = json.loads(chat_row[0])
+                            tabs = data.get("tabs") or []
+                            for tab in tabs:
+                                logs.append({
+                                    "id": tab.get("id", ""),
+                                    "workspaceId": name,
+                                    "workspaceFolder": workspace_folder,
+                                    "title": tab.get("title") or f"Chat {(tab.get('id') or '')[:8]}",
+                                    "timestamp": tab.get("timestamp", 0),
+                                    "type": "chat",
+                                    "messageCount": len(tab.get("bubbles") or []),
+                                })
 
-                    # Chat logs
-                    chat_row = conn.execute(
-                        "SELECT value FROM ItemTable WHERE [key] = 'workbench.panel.aichat.view.aichat.chatdata'"
-                    ).fetchone()
-                    if chat_row and chat_row[0]:
-                        data = json.loads(chat_row[0])
-                        tabs = data.get("tabs") or []
-                        for tab in tabs:
-                            logs.append({
-                                "id": tab.get("id", ""),
-                                "workspaceId": name,
-                                "workspaceFolder": workspace_folder,
-                                "title": tab.get("title") or f"Chat {(tab.get('id') or '')[:8]}",
-                                "timestamp": tab.get("timestamp", 0),
-                                "type": "chat",
-                                "messageCount": len(tab.get("bubbles") or []),
-                            })
-
-                    # Composer logs
-                    comp_row = conn.execute(
-                        "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
-                    ).fetchone()
-                    if comp_row and comp_row[0]:
-                        data = json.loads(comp_row[0])
-                        for c in (data.get("allComposers") or []):
-                            logs.append({
-                                "id": c.get("composerId", ""),
-                                "workspaceId": name,
-                                "workspaceFolder": workspace_folder,
-                                "title": c.get("text") or f"Composer {(c.get('composerId') or '')[:8]}",
-                                "timestamp": to_epoch_ms(c.get("lastUpdatedAt")) or to_epoch_ms(c.get("createdAt")) or 0,
-                                "type": "composer",
-                                "messageCount": len(c.get("conversation") or []),
-                            })
-                    conn.close()
+                        # Composer logs
+                        comp_row = conn.execute(
+                            "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
+                        ).fetchone()
+                        if comp_row and comp_row[0]:
+                            data = json.loads(comp_row[0])
+                            for c in (data.get("allComposers") or []):
+                                logs.append({
+                                    "id": c.get("composerId", ""),
+                                    "workspaceId": name,
+                                    "workspaceFolder": workspace_folder,
+                                    "title": c.get("text") or f"Composer {(c.get('composerId') or '')[:8]}",
+                                    "timestamp": to_epoch_ms(c.get("lastUpdatedAt")) or to_epoch_ms(c.get("createdAt")) or 0,
+                                    "type": "composer",
+                                    "messageCount": len(c.get("conversation") or []),
+                                })
                 except Exception:
                     pass
         except Exception:

--- a/api/search.py
+++ b/api/search.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sqlite3
+from contextlib import closing
 from datetime import datetime
 from urllib.parse import unquote as _url_unquote
 
@@ -83,6 +84,11 @@ def search():
         # Search global cursorDiskKV (new Cursor format — primary source)
         # ---------------------------------------------------------------
         if os.path.isfile(global_db_path):
+            # try/finally guarantees .close() on every exit path including
+            # exception (issue #17). Equivalent to wrapping the body in
+            # `with closing(sqlite3.connect(...))`, without the 160-line
+            # indent shift over the search logic that follows.
+            conn = None
             try:
                 conn = sqlite3.connect(f"file:{global_db_path}?mode=ro", uri=True)
                 conn.row_factory = sqlite3.Row
@@ -117,10 +123,11 @@ def search():
                     if not os.path.isfile(db_path):
                         continue
                     try:
-                        wconn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-                        row = wconn.execute(
-                            "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
-                        ).fetchone()
+                        # closing() guarantees .close() on scope exit (issue #17).
+                        with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as wconn:
+                            row = wconn.execute(
+                                "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
+                            ).fetchone()
                         if row and row[0]:
                             data = json.loads(row[0])
                             all_composers = data.get("allComposers")
@@ -129,7 +136,6 @@ def search():
                                     cid = c.get("composerId") if isinstance(c, dict) else None
                                     if cid:
                                         composer_id_to_ws[cid] = entry["name"]
-                        wconn.close()
                     except Exception:
                         pass
 
@@ -244,9 +250,11 @@ def search():
                     except Exception:
                         pass
 
-                conn.close()
             except Exception as e:
                 print(f"Error searching global storage: {e}")
+            finally:
+                if conn is not None:
+                    conn.close()
 
         # ---------------------------------------------------------------
         # Search per-workspace ItemTable (legacy format — fallback)
@@ -270,6 +278,8 @@ def search():
                     pass
                 workspace_name = _workspace_display_name_from_folder(workspace_folder, fallback=name)
 
+                # try/finally guarantees .close() on every exit path (issue #17).
+                conn = None
                 try:
                     conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
 
@@ -338,9 +348,11 @@ def search():
                                         "type": "chat",
                                     })
 
-                    conn.close()
                 except Exception:
                     pass
+                finally:
+                    if conn is not None:
+                        conn.close()
         except Exception:
             pass
 

--- a/api/workspaces.py
+++ b/api/workspaces.py
@@ -12,6 +12,7 @@ import os
 import re
 import sqlite3
 import sys
+from contextlib import closing, contextmanager
 from datetime import datetime, timezone
 from urllib.parse import unquote, urlparse
 
@@ -158,28 +159,27 @@ def _infer_workspace_name_from_context(workspace_path: str, workspace_id: str) -
         return None
     composer_ids: list[str] = []
     try:
-        lconn = sqlite3.connect(f"file:{local_db_path}?mode=ro", uri=True)
-        row = lconn.execute(
-            "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
-        ).fetchone()
+        # closing() guarantees .close() on scope exit (issue #17).
+        with closing(sqlite3.connect(f"file:{local_db_path}?mode=ro", uri=True)) as lconn:
+            row = lconn.execute(
+                "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
+            ).fetchone()
         if row and row[0]:
             data = json.loads(row[0])
             for c in (data.get("allComposers") or []):
                 cid = c.get("composerId") if isinstance(c, dict) else None
                 if cid:
                     composer_ids.append(cid)
-        lconn.close()
     except Exception:
         return None
     if not composer_ids:
         return None
 
     # Gather folder-name hints from global messageRequestContext.projectLayouts
-    gconn, _ = _open_global_db(workspace_path)
-    if not gconn:
-        return None
     counts: dict[str, int] = {}
-    try:
+    with _open_global_db(workspace_path) as (gconn, _):
+        if not gconn:
+            return None
         for cid in composer_ids:
             rows = gconn.execute(
                 "SELECT value FROM cursorDiskKV WHERE key LIKE ?",
@@ -207,8 +207,6 @@ def _infer_workspace_name_from_context(workspace_path: str, workspace_id: str) -
                     hint = _basename_from_pathish(obj.get("rootPath"))
                     if hint:
                         counts[hint] = counts.get(hint, 0) + 1
-    finally:
-        gconn.close()
 
     if not counts:
         return None
@@ -475,10 +473,11 @@ def _build_composer_id_to_workspace_id(workspace_path: str, workspace_entries: l
         if not os.path.isfile(db_path):
             continue
         try:
-            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-            row = conn.execute(
-                "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
-            ).fetchone()
+            # closing() guarantees .close() on scope exit (issue #17).
+            with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as conn:
+                row = conn.execute(
+                    "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
+                ).fetchone()
             if row and row[0]:
                 data = json.loads(row[0])
                 all_composers = data.get("allComposers")
@@ -487,21 +486,31 @@ def _build_composer_id_to_workspace_id(workspace_path: str, workspace_entries: l
                         cid = c.get("composerId")
                         if cid:
                             mapping[cid] = entry["name"]
-            conn.close()
         except Exception:
             pass
     return mapping
 
 
+@contextmanager
 def _open_global_db(workspace_path: str):
-    """Open the global storage database (read-only). Returns (conn, path) or (None, path)."""
+    """Yield (conn, path) for the global-storage SQLite db (read-only).
+
+    Context-managed so the caller writes ``with _open_global_db(...) as (conn, _):``
+    and the connection is guaranteed to close on scope exit, including on
+    exception (issue #17). Yields ``(None, path)`` if the file is missing —
+    callers branch on ``conn is None`` exactly as before.
+    """
     global_db_path = os.path.join(workspace_path, "..", "globalStorage", "state.vscdb")
     global_db_path = os.path.normpath(global_db_path)
     if not os.path.isfile(global_db_path):
-        return None, global_db_path
+        yield None, global_db_path
+        return
     conn = sqlite3.connect(f"file:{global_db_path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
-    return conn, global_db_path
+    try:
+        yield conn, global_db_path
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------
@@ -521,100 +530,98 @@ def list_workspaces():
 
         conversation_map: dict[str, list] = {}
 
-        global_db, _ = _open_global_db(workspace_path)
-        if global_db:
-            try:
-                # composerData rows
-                composer_rows = global_db.execute(
-                    "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%' AND LENGTH(value) > 10"
-                ).fetchall()
+        # closing semantics now baked into the context manager (issue #17).
+        with _open_global_db(workspace_path) as (global_db, _):
+            if global_db:
+                try:
+                    # composerData rows
+                    composer_rows = global_db.execute(
+                        "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%' AND LENGTH(value) > 10"
+                    ).fetchall()
 
-                # messageRequestContext rows -> project layouts
-                ctx_rows = global_db.execute(
-                    "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'messageRequestContext:%'"
-                ).fetchall()
-                project_layouts_map: dict[str, list] = {}
-                for row in ctx_rows:
-                    parts = row["key"].split(":")
-                    if len(parts) < 2:
-                        continue
-                    cid = parts[1]
-                    try:
-                        ctx = json.loads(row["value"])
-                        layouts = ctx.get("projectLayouts")
-                        if isinstance(layouts, list):
-                            if cid not in project_layouts_map:
-                                project_layouts_map[cid] = []
-                            for layout in layouts:
-                                if isinstance(layout, str):
-                                    try:
-                                        obj = json.loads(layout)
-                                        if isinstance(obj, dict) and obj.get("rootPath"):
-                                            project_layouts_map[cid].append(obj["rootPath"])
-                                    except Exception:
-                                        pass
-                    except Exception:
-                        pass
-
-                # bubbleId rows for project detection
-                bubble_rows = global_db.execute(
-                    "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'"
-                ).fetchall()
-                bubble_map: dict[str, dict] = {}
-                for row in bubble_rows:
-                    parts = row["key"].split(":")
-                    if len(parts) >= 3:
-                        bid = parts[2]
+                    # messageRequestContext rows -> project layouts
+                    ctx_rows = global_db.execute(
+                        "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'messageRequestContext:%'"
+                    ).fetchall()
+                    project_layouts_map: dict[str, list] = {}
+                    for row in ctx_rows:
+                        parts = row["key"].split(":")
+                        if len(parts) < 2:
+                            continue
+                        cid = parts[1]
                         try:
-                            b = json.loads(row["value"])
-                            if isinstance(b, dict):
-                                bubble_map[bid] = b
+                            ctx = json.loads(row["value"])
+                            layouts = ctx.get("projectLayouts")
+                            if isinstance(layouts, list):
+                                if cid not in project_layouts_map:
+                                    project_layouts_map[cid] = []
+                                for layout in layouts:
+                                    if isinstance(layout, str):
+                                        try:
+                                            obj = json.loads(layout)
+                                            if isinstance(obj, dict) and obj.get("rootPath"):
+                                                project_layouts_map[cid].append(obj["rootPath"])
+                                        except Exception:
+                                            pass
                         except Exception:
                             pass
 
-                # Process each composer
-                invalid_workspace_aliases = _infer_invalid_workspace_aliases(
-                    composer_rows=composer_rows,
-                    project_layouts_map=project_layouts_map,
-                    project_name_map=project_name_map,
-                    workspace_path_map=workspace_path_map,
-                    workspace_entries=workspace_entries,
-                    bubble_map=bubble_map,
-                    composer_id_to_ws=composer_id_to_ws,
-                    invalid_workspace_ids=invalid_workspace_ids,
-                )
-                for row in composer_rows:
-                    cid = row["key"].split(":")[1]
-                    try:
-                        cd = json.loads(row["value"])
-                        pid = _determine_project_for_conversation(
-                            cd, cid, project_layouts_map,
-                            project_name_map, workspace_path_map,
-                            workspace_entries, bubble_map, composer_id_to_ws, invalid_workspace_ids
-                        )
-                        mapped_ws = composer_id_to_ws.get(cid)
-                        if not pid and mapped_ws in invalid_workspace_ids:
-                            pid = invalid_workspace_aliases.get(mapped_ws)
-                        assigned = pid if pid else "global"
+                    # bubbleId rows for project detection
+                    bubble_rows = global_db.execute(
+                        "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'"
+                    ).fetchall()
+                    bubble_map: dict[str, dict] = {}
+                    for row in bubble_rows:
+                        parts = row["key"].split(":")
+                        if len(parts) >= 3:
+                            bid = parts[2]
+                            try:
+                                b = json.loads(row["value"])
+                                if isinstance(b, dict):
+                                    bubble_map[bid] = b
+                            except Exception:
+                                pass
 
-                        headers = cd.get("fullConversationHeadersOnly") or []
-                        has_bubbles = any(bubble_map.get(h.get("bubbleId")) for h in headers)
-                        if not has_bubbles:
-                            continue
+                    # Process each composer
+                    invalid_workspace_aliases = _infer_invalid_workspace_aliases(
+                        composer_rows=composer_rows,
+                        project_layouts_map=project_layouts_map,
+                        project_name_map=project_name_map,
+                        workspace_path_map=workspace_path_map,
+                        workspace_entries=workspace_entries,
+                        bubble_map=bubble_map,
+                        composer_id_to_ws=composer_id_to_ws,
+                        invalid_workspace_ids=invalid_workspace_ids,
+                    )
+                    for row in composer_rows:
+                        cid = row["key"].split(":")[1]
+                        try:
+                            cd = json.loads(row["value"])
+                            pid = _determine_project_for_conversation(
+                                cd, cid, project_layouts_map,
+                                project_name_map, workspace_path_map,
+                                workspace_entries, bubble_map, composer_id_to_ws, invalid_workspace_ids
+                            )
+                            mapped_ws = composer_id_to_ws.get(cid)
+                            if not pid and mapped_ws in invalid_workspace_ids:
+                                pid = invalid_workspace_aliases.get(mapped_ws)
+                            assigned = pid if pid else "global"
 
-                        conversation_map.setdefault(assigned, []).append({
-                            "composerId": cid,
-                            "name": cd.get("name") or f"Conversation {cid[:8]}",
-                            "lastUpdatedAt": to_epoch_ms(cd.get("lastUpdatedAt")) or to_epoch_ms(cd.get("createdAt")) or 0,
-                            "createdAt": to_epoch_ms(cd.get("createdAt")) or 0,
-                        })
-                    except Exception:
-                        pass
+                            headers = cd.get("fullConversationHeadersOnly") or []
+                            has_bubbles = any(bubble_map.get(h.get("bubbleId")) for h in headers)
+                            if not has_bubbles:
+                                continue
 
-                global_db.close()
-            except Exception:
-                if global_db:
-                    global_db.close()
+                            conversation_map.setdefault(assigned, []).append({
+                                "composerId": cid,
+                                "name": cd.get("name") or f"Conversation {cid[:8]}",
+                                "lastUpdatedAt": to_epoch_ms(cd.get("lastUpdatedAt")) or to_epoch_ms(cd.get("createdAt")) or 0,
+                                "createdAt": to_epoch_ms(cd.get("createdAt")) or 0,
+                            })
+                        except Exception:
+                            pass
+                except Exception:
+                    pass
 
         # Exclusion rules (optional)
         rules = current_app.config.get("EXCLUSION_RULES") or []
@@ -946,6 +953,11 @@ def get_workspace_tabs(workspace_id):
     if workspace_id.startswith("cli:"):
         return _get_cli_workspace_tabs(workspace_id)
 
+    # `global_db` is the long-lived connection used across the ~400-line body
+    # below. Wrap the whole function in try/finally so the connection is
+    # released on every exit path — including unexpected exceptions that
+    # bypass the in-body close calls (issue #17). Equivalent to wrapping the
+    # body in `with closing(sqlite3.connect(...))` without the indent shift.
     global_db = None
     try:
         workspace_path = resolve_workspace_path()
@@ -1388,10 +1400,6 @@ def get_workspace_tabs(workspace_id):
             except Exception as e:
                 print(f"Error parsing composer data for {composer_id}: {e}")
 
-        if global_db:
-            global_db.close()
-            global_db = None
-
         # Sort tabs by timestamp descending (newest first)
         response["tabs"].sort(key=lambda t: t.get("timestamp") or 0, reverse=True)
 
@@ -1399,6 +1407,9 @@ def get_workspace_tabs(workspace_id):
 
     except Exception as e:
         print(f"Failed to get workspace tabs: {e}")
-        if global_db:
-            global_db.close()
         return jsonify({"error": "Failed to get workspace tabs"}), 500
+    finally:
+        # Guaranteed close — fires on success, exception, AND on any
+        # in-body return that doesn't go through except (issue #17).
+        if global_db is not None:
+            global_db.close()

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -396,11 +396,11 @@ def main():
                 "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
                 " AND value LIKE '%fullConversationHeadersOnly%'"
             ).fetchall()
-
-            _conn.close()
-            _conn = None
         except Exception as e:
             print(f"Warning: Could not read Cursor IDE chats ({e}) — skipping.", file=sys.stderr)
+        finally:
+            # Guaranteed close on every exit path (issue #17). Replaces the
+            # previous duplicate close-in-success-and-error pattern.
             if _conn is not None:
                 try:
                     _conn.close()

--- a/utils/cli_chat_reader.py
+++ b/utils/cli_chat_reader.py
@@ -36,6 +36,7 @@ import json
 import os
 import re
 import sqlite3
+from contextlib import closing
 from datetime import datetime, timezone
 from typing import Generator
 
@@ -46,15 +47,14 @@ from typing import Generator
 
 def _read_meta(db_path: str) -> dict:
     """Read and decode the session metadata row from a ``store.db``."""
-    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    try:
-        row = conn.execute("SELECT value FROM meta WHERE key = '0'").fetchone()
-        if row and row[0]:
-            return json.loads(bytes.fromhex(row[0]).decode("utf-8"))
-    except Exception:
-        pass
-    finally:
-        conn.close()
+    # `closing(...)` guarantees .close() on scope exit (issue #17).
+    with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as conn:
+        try:
+            row = conn.execute("SELECT value FROM meta WHERE key = '0'").fetchone()
+            if row and row[0]:
+                return json.loads(bytes.fromhex(row[0]).decode("utf-8"))
+        except Exception:
+            pass
     return {}
 
 
@@ -86,8 +86,11 @@ def traverse_blobs(db_path: str) -> list[dict]:
     conversation order.  ``system`` messages are included; callers may filter
     them as needed.
     """
-    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    try:
+    # `closing(...)` guarantees .close() on scope exit (issue #17). Connection
+    # is only needed to materialise the blob graph; subsequent BFS works on
+    # in-memory dicts, so the connection is released as soon as we're done
+    # reading.
+    with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as conn:
         meta_row = conn.execute("SELECT value FROM meta WHERE key = '0'").fetchone()
         if not meta_row or not meta_row[0]:
             return []
@@ -112,9 +115,6 @@ def traverse_blobs(db_path: str) -> list[dict]:
                 pass
             refs = _extract_blob_refs(data)
             chain_blobs[blob_id] = refs
-
-    finally:
-        conn.close()
 
     # BFS from root (newest-first by nature of the linked-list structure);
     # reverse at the end to restore chronological (oldest→newest) order.

--- a/utils/cursor_md_exporter.py
+++ b/utils/cursor_md_exporter.py
@@ -70,10 +70,13 @@ def cursor_cli_session_to_markdown(
     # Read metadata from the database if not provided.
     if session_meta is None:
         import sqlite3
+        from contextlib import closing
         try:
-            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-            row = conn.execute("SELECT value FROM meta WHERE key = '0'").fetchone()
-            conn.close()
+            # `closing(...)` guarantees .close() on scope exit (including on
+            # exception); sqlite3.Connection's own context manager only handles
+            # commit/rollback, not close. See issue #17.
+            with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as conn:
+                row = conn.execute("SELECT value FROM meta WHERE key = '0'").fetchone()
             session_meta = json.loads(bytes.fromhex(row[0]).decode()) if row else {}
         except Exception:
             session_meta = {}


### PR DESCRIPTION
## Problem

19 production `sqlite3.connect()` call sites in this repo used a bare local variable with no `with` block, no `try/finally`, and no guaranteed `.close()` on exception. On a long-lived Flask process serving many requests, leaks accumulate before the user notices (file descriptors, SQLite read-locks held longer than needed).

## Change

Two patterns, each applied where it fits best:

**`with closing(sqlite3.connect(...)) as conn:` — short-scope (15 sites)**
- `api/composers.py` ×3
- `utils/cli_chat_reader.py` ×2
- `utils/cursor_md_exporter.py` ×1
- `api/workspaces.py` ×2 (small helpers)
- `api/logs.py` ×2
- `api/search.py` ×2 (`wconn` + small `conn`)
- `api/export_api.py` ×1 (`wconn`)

`sqlite3.Connection`'s own context manager only commits / rolls back; it does not `.close()`. `contextlib.closing(...)` is what guarantees release.

**`try / except / finally: if conn is not None: conn.close()` — long-scope (4 sites)**
- `api/workspaces.py:get_workspace_tabs` (~400 lines using `global_db`)
- `api/search.py:search` ×2 deep blocks (~160-line and ~70-line scopes)
- `api/export_api.py:export_chats` (~340 lines)
- `scripts/export.py:_conn` (cleaned up the existing duplicate close-on-success and close-on-error pattern)

Same semantics as wrapping the whole function in `with closing(...)`, without the 100-300-line indent shift.

**`@contextmanager` on the helper that yields a connection — 1 site**

`api/workspaces.py:_open_global_db` previously returned `(conn, path)` to callers, who were responsible for `.close()`. Converted to a `@contextmanager` so callers write `with _open_global_db(...) as (conn, _):`. Both call sites updated.

Test-side `sqlite3.connect` calls are out of scope (per-test fixture lifecycles, short-lived).

## Test plan

- `pytest tests/` → **137 / 137 OK** (zero behaviour change in the test paths).
- AST parses cleanly on all 8 modified files; `from contextlib import closing[, contextmanager]` correctly added everywhere it's used.
- Static guard: every `sqlite3.connect()` call site classified and confirmed protected by either `closing()`, an outer `try/finally` block in the same function, or `@contextmanager`.
- Live HTTP smoke against the running app:
  - `GET /` → HTTP 200
  - `GET /api/workspaces` → HTTP 200 (exercises `with closing()` + `@contextmanager` + small `with closing()` in `_build_composer_id_to_workspace_id`)
  - `GET /api/logs` → HTTP 200 (both `with closing()` paths)
  - `GET /api/composers` → HTTP 200 (all 3 `with closing()` sites)
  - `GET /api/search?q=test&type=all` → HTTP 200 (both `try/finally` sites + small `with closing()`)
  - No Python tracebacks in the server log.

Closes #17.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved internal database connection management across the application to ensure all connections are properly closed in all scenarios, enhancing resource reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->