### PR TITLE
fix(ui): theme flash on navigation + search filter button alignment

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}Cursor Chat Browser{% endblock %}</title>
+  <!-- Apply stored theme BEFORE the stylesheet loads to avoid a dark->light
+       flash on every navigation when light is the user's preference. -->
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('theme') || 'dark';
+        document.documentElement.setAttribute('data-theme', t);
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="/static/css/style.css">
   <!-- Highlight.js for code syntax highlighting -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/vs2015.min.css" id="hljs-theme">

--- a/templates/search.html
+++ b/templates/search.html
@@ -4,7 +4,7 @@
 <div class="search-page">
   <div class="page-header">
     <h1>Search</h1>
-    <div class="btn-group">
+    <div class="btn-group" style="align-self:center">
       <button class="btn" id="filter-all" onclick="setFilter('all')">All</button>
       <button class="btn btn-outline" id="filter-chat" onclick="setFilter('chat')">Ask Logs</button>
       <button class="btn btn-outline" id="filter-composer" onclick="setFilter('composer')">Agent Logs</button>


### PR DESCRIPTION
Two small UI fixes.

**Theme flash (closes #37):** add a synchronous IIFE in `<head>` that reads `localStorage.theme` and sets `data-theme` on `documentElement` BEFORE the stylesheet is parsed, so the first paint uses the user's stored palette. Wrapped in `try/catch` for storage-blocked browsers. The existing `applyTheme()` on `DOMContentLoaded` stays as the source of truth for runtime toggles.

**Search button alignment (closes #38):** add `style="align-self:center"` to the `.btn-group` in `templates/search.html` so the filter buttons vertically center with the `<h1>Search</h1>`. Scoped to the search page so other pages using the shared `.page-header` aren't touched.

## Test plan

- [ ] In light mode, click between projects / chats / search — no dark flash on navigation
- [ ] In dark mode, same — no light flash, theme stays dark
- [ ] `/search` — filter buttons centered with the Search heading, not stuck to the top

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme preference now persists across browser sessions with dark theme as the default setting, eliminating theme flash and providing a seamless visual experience when navigating between pages.

* **Style**
  * Improved search interface layout by center-aligning the button group for better visual consistency and enhanced user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/cppa-cursor-browser/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->