### PR TITLE
build: add pyproject.toml and Python packaging infrastructure (closes #45)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       # Pinned to immutable commit SHAs (not @v4 / @v5) so a compromised tag
       # cannot silently swap the underlying action code on this CI runner.

--- a/launcher.py
+++ b/launcher.py
@@ -5,12 +5,18 @@ No HTTP server or port is used; pywebview calls the WSGI app
 directly in-process.
 """
 
-import webview
-
 from app import create_app
 
 
 def main():
+    try:
+        import webview
+    except ImportError:
+        raise SystemExit(
+            "pywebview is not installed. Install the [desktop] extra, e.g.\n"
+            '  pip install -e ".[desktop]"'
+        ) from None
+
     app = create_app()
     webview.create_window(
         "Cursor Chat Browser",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ requires-python = ">=3.10"
 dependencies = [
     "flask>=3.0,<4",
     "fpdf2>=2.7,<3",
+    # Security floor: fpdf2 allows Pillow>=8.3.2, so 9.x can still be resolved.
+    # CVE-2024-28219 (buffer overflow) fixed in Pillow 10.3.0 — https://nvd.nist.gov/vuln/detail/CVE-2024-28219
+    "pillow>=10.3.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,88 @@
+[build-system]
+requires = ["hatchling>=1.21"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cppa-cursor-browser"
+version = "0.1.0"
+description = "Flask web application for browsing and exporting Cursor AI chat histories"
+readme = "README.md"
+license = { file = "LICENSE" }
+authors = [{ name = "C++ Alliance", email = "admin@cppalliance.org" }]
+requires-python = ">=3.11"
+
+# Runtime dependencies — bounded on both sides so CI resolves deterministically
+# and breaking major releases are caught at install time rather than at runtime.
+# Upper bounds are conservative: pin to current known-compatible major version.
+# See also: requirements.txt (backward-compat alias; pyproject.toml is canonical).
+dependencies = [
+    "flask>=3.0,<4",
+    "fpdf2>=2.7,<3",
+]
+
+[project.optional-dependencies]
+# Desktop launcher (pywebview pulls in heavy system libs — GTK/Qt on Linux —
+# so it is intentionally excluded from the web-server and CI installs).
+desktop = ["pywebview>=5.0,<6"]
+
+# Development tooling: testing + type checking.
+dev = [
+    "pytest>=8,<9",
+    "mypy>=1.10,<2",
+]
+
+[project.scripts]
+# Primary CLI: export Cursor chat histories to Markdown / zip.
+# Usage: cursor-chat-export [--since all|last] [--out DIR] [--no-zip] [--help]
+cursor-chat-export = "scripts.export:main"
+
+# Desktop launcher (requires the [desktop] extra to be installed).
+cursor-chat-browser = "launcher:main"
+
+[project.urls]
+Repository = "https://github.com/cppalliance/cppa-cursor-browser"
+Issues = "https://github.com/cppalliance/cppa-cursor-browser/issues"
+
+# ── Build configuration ────────────────────────────────────────────────────────
+# Flat layout (no src/ directory): enumerate every importable package and the
+# two top-level application modules so the installed wheel has the same import
+# surface as the repo checkout.
+[tool.hatch.build.targets.wheel]
+include = [
+    "api/",
+    "models/",
+    "scripts/",
+    "services/",
+    "utils/",
+    "app.py",
+    "launcher.py",
+]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "api/",
+    "models/",
+    "scripts/",
+    "services/",
+    "utils/",
+    "tests/",
+    "templates/",
+    "static/",
+    "app.py",
+    "launcher.py",
+    "requirements.txt",
+    "README.md",
+    "LICENSE",
+    "cursor-browser.spec",
+]
+
+# ── Mypy ──────────────────────────────────────────────────────────────────────
+# Mirrors the flags used in .github/workflows/tests.yml so local `mypy .`
+# and CI produce identical results.
+[tool.mypy]
+ignore_missing_imports = true
+no_strict_optional = true
+pretty = true
+# Exclude virtual-env and build artefact directories so that `mypy .` from the
+# repo root matches CI behaviour (CI runs in a clean runner without a local venv).
+exclude = ["venv/", "\\.venv/", "build/", "dist/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ include = [
     "scripts/",
     "services/",
     "utils/",
+    "templates/",
+    "static/",
     "app.py",
     "launcher.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ requires-python = ">=3.11"
 dependencies = [
     "flask>=3.0,<4",
     "fpdf2>=2.7,<3",
+    # fpdf2 depends on Pillow; declare a floor + cap so resolvers cannot pick
+    # known-vulnerable Pillow releases while staying on Pillow 10.x.
+    "pillow>=10.0.0,<11",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Flask web application for browsing and exporting Cursor AI chat h
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "C++ Alliance", email = "admin@cppalliance.org" }]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 
 # Runtime dependencies — bounded on both sides so CI resolves deterministically
 # and breaking major releases are caught at install time rather than at runtime.
@@ -18,9 +18,6 @@ requires-python = ">=3.11"
 dependencies = [
     "flask>=3.0,<4",
     "fpdf2>=2.7,<3",
-    # fpdf2 depends on Pillow; declare a floor + cap so resolvers cannot pick
-    # known-vulnerable Pillow releases while staying on Pillow 10.x.
-    "pillow>=10.0.0,<11",
 ]
 
 [project.optional-dependencies]
@@ -63,6 +60,7 @@ include = [
     "launcher.py",
 ]
 
+# sdist includes tests + ancillary files; wheel is runtime-only.
 [tool.hatch.build.targets.sdist]
 include = [
     "api/",
@@ -90,4 +88,5 @@ no_strict_optional = true
 pretty = true
 # Exclude virtual-env and build artefact directories so that `mypy .` from the
 # repo root matches CI behaviour (CI runs in a clean runner without a local venv).
-exclude = ["venv/", "\\.venv/", "build/", "dist/"]
+# Anchored regexes — unanchored `venv/` would match any path segment containing "venv/".
+exclude = ["^venv/", "^\\.venv/", "^build/", "^dist/"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,11 @@
+# Backward-compatibility shim — pyproject.toml is the canonical source of
+# truth for dependencies.  This file is retained so that
+# legacy workflows running `pip install -r requirements.txt` keep working,
+# but bounded version specifiers and the lock file live in pyproject.toml.
+#
+# Prefer: pip install -e .           (installs the package + runtime deps)
+#         pip install -e ".[dev]"    (+ pytest and mypy)
+#         pip install -e ".[desktop]" (+ pywebview for the GUI launcher)
 flask>=3.0
 fpdf2>=2.7
 pywebview>=5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,9 @@
-# Backward-compatibility shim — pyproject.toml is the canonical source of
-# truth for dependencies.  This file is retained so that
-# legacy workflows running `pip install -r requirements.txt` keep working,
-# but bounded version specifiers and the lock file live in pyproject.toml.
+# Backward-compatibility shim — mirrors [project.dependencies] in pyproject.toml.
+# Keep version specifiers in sync when runtime deps change.
 #
 # Prefer: pip install -e .           (installs the package + runtime deps)
 #         pip install -e ".[dev]"    (+ pytest and mypy)
 #         pip install -e ".[desktop]" (+ pywebview for the GUI launcher)
-flask>=3.0
-fpdf2>=2.7
+flask>=3.0,<4
+fpdf2>=2.7,<3
 # pywebview is desktop-only — install with: pip install -e ".[desktop]"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@
 #         pip install -e ".[desktop]" (+ pywebview for the GUI launcher)
 flask>=3.0
 fpdf2>=2.7
-pywebview>=5.0
+# pywebview is desktop-only — install with: pip install -e ".[desktop]"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@
 #         pip install -e ".[desktop]" (+ pywebview for the GUI launcher)
 flask>=3.0,<4
 fpdf2>=2.7,<3
+pillow>=10.3.0
 # pywebview is desktop-only — install with: pip install -e ".[desktop]"


### PR DESCRIPTION
Closes #45 . 

## Problem

The project had no `pyproject.toml`, `setup.py`, or `setup.cfg`, making it a non-installable Python package. This forced `scripts/export.py` to use a fragile `sys.path.insert(0, project_root)` hack to import shared modules, and blocked using proper console-script entry points. It also made `pywebview` (a desktop-only system dependency) silently entangled with the web-server install path.

## Changes

**`pyproject.toml` (new)**
- Build backend: `hatchling>=1.21` (modern flat-layout support; no `src/` restructuring needed)
- Project metadata: name, version, description, license, authors, `requires-python = ">=3.11"`
- Runtime deps bounded on both sides: `flask>=3.0,<4`, `fpdf2>=2.7,<3` — deterministic CI resolution and early detection of breaking major releases
- Optional extras:
  - `[desktop]` — `pywebview>=5.0,<6` (heavy system libs intentionally excluded from web-server and CI installs)
  - `[dev]` — `pytest>=8,<9`, `mypy>=1.10,<2`
- Console scripts: `cursor-chat-export = "scripts.export:main"` (primary CLI), `cursor-chat-browser = "launcher:main"` (desktop, requires `[desktop]`)
- Explicit wheel include list: `api/`, `models/`, `scripts/`, `services/`, `utils/`, `app.py`, `launcher.py`
- `[tool.mypy]` config mirroring CI flags; `exclude` for `venv/`/`build/`/`dist/` so local `mypy .` matches CI output

**`requirements.txt` (updated)**
- Added header comment declaring `pyproject.toml` as the canonical source of truth; existing lower-bound pins retained for backward compatibility

## Verification

```
pip install -e ".[dev]"   # → Successfully built cppa-cursor-browser-0.1.0
cursor-chat-export --help  # → prints full usage, exit 0
python -m unittest discover tests -v  # → Ran 262 tests … OK (skipped=2)
mypy --ignore-missing-imports --no-strict-optional --pretty .
# → 1 pre-existing error (os.uname POSIX-only on Windows); zero errors on Linux CI
```

## Notes

- The `sys.path.insert` hack in `scripts/export.py` is **intentionally left in place** for this PR — it will be removed when the export script is refactored to delegate to the service layer (issue #42 , planned Wednesday).
- Upper bounds on `requirements.txt` and the lock file generation are tracked separately in issue #47 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two command-line tools added for export and browser launch

* **Chores**
  * Centralized packaging and build configuration with bundled assets
  * Runtime dependencies bounded and a desktop optional extra
  * Development extras and type-checker configuration added

* **Documentation**
  * Requirements file updated as a compatibility/install guidance shim

* **Tests**
  * CI expanded to include Python 3.10 in test matrix

* **Behavior**
  * Desktop launcher exits with clear guidance if GUI dependency is missing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/cppa-cursor-browser/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->