### PR TITLE
Refactor: Deduplicate normalize_file_path and to_epoch_ms in export script (closes #46)

### DIFF
--- a/scripts/export.py
+++ b/scripts/export.py
@@ -30,7 +30,11 @@ from utils.exclusion_rules import (  # noqa: E402
     build_searchable_text,
     is_excluded_by_rules,
 )
-from utils.path_helpers import get_workspace_folder_paths as _shared_get_workspace_folder_paths  # noqa: E402
+from utils.path_helpers import (  # noqa: E402
+    get_workspace_folder_paths as _shared_get_workspace_folder_paths,
+    normalize_file_path,
+    to_epoch_ms,
+)
 from utils.tool_parser import parse_tool_call  # noqa: E402
 from utils.workspace_path import get_cli_chats_path  # noqa: E402
 from utils.cli_chat_reader import (  # noqa: E402
@@ -139,45 +143,6 @@ def get_global_state_dir() -> str:
     if xdg:
         return os.path.join(xdg, "cursor-chat-browser")
     return os.path.join(str(Path.home()), ".cursor-chat-browser")
-
-
-def normalize_file_path(p: str) -> str:
-    n = re.sub(r"^file:///", "", p or "")
-    n = re.sub(r"^file://", "", n)
-    try:
-        from urllib.parse import unquote
-        n = unquote(n)
-    except Exception:
-        pass
-    if sys.platform == "win32":
-        n = n.replace("/", "\\")
-        n = re.sub(r"^\\([a-zA-Z]:)", r"\1", n)
-        n = n.lower()
-    return n
-
-
-def to_epoch_ms(value) -> int:
-    """Convert a timestamp (int, float, or ISO-8601 string) to epoch ms."""
-    if value is None:
-        return 0
-    if isinstance(value, (int, float)):
-        if value > 1e12:
-            return int(value)
-        if value > 0:
-            return int(value * 1000)
-        return 0
-    if isinstance(value, str):
-        try:
-            cleaned = value.rstrip("Z") + "+00:00" if value.endswith("Z") else value
-            dt = datetime.fromisoformat(cleaned)
-            return int(dt.timestamp() * 1000)
-        except Exception:
-            pass
-        try:
-            return to_epoch_ms(float(value))
-        except Exception:
-            pass
-    return 0
 
 
 def slug(s: str) -> str:

--- a/tests/test_normalize_file_path.py
+++ b/tests/test_normalize_file_path.py
@@ -1,22 +1,20 @@
-"""Tests for utils.path_helpers.normalize_file_path.
+"""Tests for utils.path_helpers path/timestamp helpers (closes #46).
 
-Covers the shared implementation that was previously duplicated in
-scripts/export.py (closes #46). All call-sites in both the web app and the
-CLI export script now use this single copy.
+Covers ``normalize_file_path`` and ``to_epoch_ms``, both previously duplicated
+in scripts/export.py. All call-sites in the web app and CLI export script now
+use the shared implementations in utils.path_helpers.
 
-Edge-case matrix:
-  - file:/// and file:// URI schemes
-  - Percent-encoded characters: spaces (%20), colons (%3A), hashes (%23)
-  - Windows-style drive paths (backslash and forward-slash) on all platforms
-  - Drive-letter lowercasing on win32
-  - Plain POSIX paths pass through unchanged
-  - Empty / None-like input
+Test inventory (this module only): 21 cases — 12 ``normalize_file_path``,
+9 ``to_epoch_ms``. On win32, 2 cases skip (POSIX passthrough in
+``TestNormalizeFilePathPosixPassthrough`` only). A full-suite run may report
+more skips (e.g. ``skipped=4``) from other test modules, not this file.
 """
 
 import sys
 import unittest
+from datetime import datetime, timezone
 
-from utils.path_helpers import normalize_file_path
+from utils.path_helpers import normalize_file_path, to_epoch_ms
 
 
 class TestNormalizeFilePathUriStripping(unittest.TestCase):
@@ -48,9 +46,14 @@ class TestNormalizeFilePathPercentEncoding(unittest.TestCase):
     def test_percent_encoded_colon_in_uri_prefix(self) -> None:
         """URI-style /d%3A/... path: %3A is decoded to ':'.
 
-        On win32 the backslash branch is entered (leading slash removed
-        and path lowercased). On other platforms the leading slash prevents
-        the Windows-drive branch, so the path is returned as decoded only.
+        Only test that exercises the leading-``/`` + drive-letter shape end-to-end
+        (Cursor sometimes stores ``/d%3A/...`` URIs). Other drive-path tests use
+        ``D:/...`` or ``D:\\...`` without a leading slash.
+
+        On win32 the win32 branch strips the leading slash, lowercases, and
+        normalises to backslashes. On other platforms the leading ``/`` prevents
+        the ``^[a-zA-Z]:[/\\]`` cross-platform branch in ``path_helpers``, so the
+        path is returned as percent-decoded only (no slash flip / lowercasing).
         """
         out = normalize_file_path("/d%3A/_Work/project")
         self.assertNotIn("%3A", out)
@@ -79,9 +82,8 @@ class TestNormalizeFilePathWindowsDrives(unittest.TestCase):
 
     def test_file_uri_with_windows_drive(self) -> None:
         out = normalize_file_path("file:///C:/Users/Dev/project")
-        self.assertIn("users", out)
-        self.assertIn("dev", out)
-        self.assertTrue(out.startswith("c:"))
+        # file:/// stripped, then same drive-letter branch as D:/ and D:\ inputs.
+        self.assertEqual(out, r"c:\users\dev\project")
 
     def test_mixed_case_drive_lowercased(self) -> None:
         out = normalize_file_path(r"E:\Mixed\Case\Path")
@@ -101,6 +103,38 @@ class TestNormalizeFilePathPosixPassthrough(unittest.TestCase):
             self.skipTest("plain relative path behaviour differs on win32")
         out = normalize_file_path("relative/path/file.py")
         self.assertEqual(out, "relative/path/file.py")
+
+
+class TestToEpochMs(unittest.TestCase):
+    def test_none_returns_zero(self) -> None:
+        self.assertEqual(to_epoch_ms(None), 0)
+
+    def test_ms_int_passthrough(self) -> None:
+        self.assertEqual(to_epoch_ms(1_700_000_000_000), 1_700_000_000_000)
+
+    def test_seconds_int_converted_to_ms(self) -> None:
+        self.assertEqual(to_epoch_ms(1_700_000_000), 1_700_000_000_000)
+
+    def test_seconds_float_converted_to_ms(self) -> None:
+        self.assertEqual(to_epoch_ms(1_700_000_000.5), 1_700_000_000_500)
+
+    def test_zero_returns_zero(self) -> None:
+        self.assertEqual(to_epoch_ms(0), 0)
+
+    def test_iso8601_zulu(self) -> None:
+        expected = int(
+            datetime(2026, 2, 3, 20, 39, 54, 17_000, tzinfo=timezone.utc).timestamp() * 1000
+        )
+        self.assertEqual(to_epoch_ms("2026-02-03T20:39:54.017Z"), expected)
+
+    def test_numeric_string_already_ms(self) -> None:
+        self.assertEqual(to_epoch_ms("1700000000000"), 1_700_000_000_000)
+
+    def test_numeric_string_seconds(self) -> None:
+        self.assertEqual(to_epoch_ms("1700000000"), 1_700_000_000_000)
+
+    def test_unrecognised_string_returns_zero(self) -> None:
+        self.assertEqual(to_epoch_ms("not-a-timestamp"), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_normalize_file_path.py
+++ b/tests/test_normalize_file_path.py
@@ -81,7 +81,7 @@ class TestNormalizeFilePathWindowsDrives(unittest.TestCase):
         out = normalize_file_path("file:///C:/Users/Dev/project")
         self.assertIn("users", out)
         self.assertIn("dev", out)
-        self.assertTrue(out.startswith("c:") or out.startswith("C:"))
+        self.assertTrue(out.startswith("c:"))
 
     def test_mixed_case_drive_lowercased(self) -> None:
         out = normalize_file_path(r"E:\Mixed\Case\Path")

--- a/tests/test_normalize_file_path.py
+++ b/tests/test_normalize_file_path.py
@@ -1,0 +1,107 @@
+"""Tests for utils.path_helpers.normalize_file_path.
+
+Covers the shared implementation that was previously duplicated in
+scripts/export.py (closes #46). All call-sites in both the web app and the
+CLI export script now use this single copy.
+
+Edge-case matrix:
+  - file:/// and file:// URI schemes
+  - Percent-encoded characters: spaces (%20), colons (%3A), hashes (%23)
+  - Windows-style drive paths (backslash and forward-slash) on all platforms
+  - Drive-letter lowercasing on win32
+  - Plain POSIX paths pass through unchanged
+  - Empty / None-like input
+"""
+
+import sys
+import unittest
+
+from utils.path_helpers import normalize_file_path
+
+
+class TestNormalizeFilePathUriStripping(unittest.TestCase):
+    def test_file_triple_slash_stripped(self) -> None:
+        out = normalize_file_path("file:///home/user/project")
+        self.assertFalse(out.startswith("file:"))
+        self.assertIn("home", out)
+
+    def test_file_double_slash_stripped(self) -> None:
+        out = normalize_file_path("file://server/share/file.txt")
+        self.assertFalse(out.startswith("file:"))
+        self.assertIn("share", out)
+
+    def test_empty_string(self) -> None:
+        self.assertEqual(normalize_file_path(""), "")
+
+
+class TestNormalizeFilePathPercentEncoding(unittest.TestCase):
+    def test_space_decoded(self) -> None:
+        out = normalize_file_path("file:///C:/My%20Documents/file.txt")
+        self.assertNotIn("%20", out)
+        self.assertIn("My Documents" if sys.platform != "win32" else "my documents", out)
+
+    def test_hash_decoded(self) -> None:
+        out = normalize_file_path("file:///C:/repo/src%23internal/mod.py")
+        self.assertNotIn("%23", out)
+        self.assertIn("#", out)
+
+    def test_percent_encoded_colon_in_uri_prefix(self) -> None:
+        """URI-style /d%3A/... path: %3A is decoded to ':'.
+
+        On win32 the backslash branch is entered (leading slash removed
+        and path lowercased). On other platforms the leading slash prevents
+        the Windows-drive branch, so the path is returned as decoded only.
+        """
+        out = normalize_file_path("/d%3A/_Work/project")
+        self.assertNotIn("%3A", out)
+        if sys.platform == "win32":
+            self.assertEqual(out, r"d:\_work\project")
+        else:
+            self.assertEqual(out, "/d:/_Work/project")
+
+
+class TestNormalizeFilePathWindowsDrives(unittest.TestCase):
+    """Paths with Windows-style drive letters are normalised on all platforms.
+
+    On win32 the win32 branch handles them natively.  On Linux/macOS the
+    ``^[a-zA-Z]:[/\\]`` regex branch converts forward-slashes to backslashes
+    and lowercases the path so cross-platform reads of Cursor's Windows
+    workspaceStorage produce consistent keys.
+    """
+
+    def test_backslash_drive_path_lowercased(self) -> None:
+        out = normalize_file_path(r"D:\Work\Boost")
+        self.assertEqual(out, r"d:\work\boost")
+
+    def test_forward_slash_drive_path_converted(self) -> None:
+        out = normalize_file_path("D:/Work/Boost")
+        self.assertEqual(out, r"d:\work\boost")
+
+    def test_file_uri_with_windows_drive(self) -> None:
+        out = normalize_file_path("file:///C:/Users/Dev/project")
+        self.assertIn("users", out)
+        self.assertIn("dev", out)
+        self.assertTrue(out.startswith("c:") or out.startswith("C:"))
+
+    def test_mixed_case_drive_lowercased(self) -> None:
+        out = normalize_file_path(r"E:\Mixed\Case\Path")
+        self.assertTrue(out.startswith("e:"))
+        self.assertEqual(out, r"e:\mixed\case\path")
+
+
+class TestNormalizeFilePathPosixPassthrough(unittest.TestCase):
+    def test_plain_posix_path_unchanged_on_non_windows(self) -> None:
+        if sys.platform == "win32":
+            self.skipTest("POSIX path semantics differ on win32")
+        out = normalize_file_path("/home/user/project")
+        self.assertEqual(out, "/home/user/project")
+
+    def test_path_without_scheme_unchanged(self) -> None:
+        if sys.platform == "win32":
+            self.skipTest("plain relative path behaviour differs on win32")
+        out = normalize_file_path("relative/path/file.py")
+        self.assertEqual(out, "relative/path/file.py")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_normalize_file_path.py
+++ b/tests/test_normalize_file_path.py
@@ -38,7 +38,7 @@ class TestNormalizeFilePathPercentEncoding(unittest.TestCase):
     def test_space_decoded(self) -> None:
         out = normalize_file_path("file:///C:/My%20Documents/file.txt")
         self.assertNotIn("%20", out)
-        self.assertIn("My Documents" if sys.platform != "win32" else "my documents", out)
+        self.assertIn("my documents", out)
 
     def test_hash_decoded(self) -> None:
         out = normalize_file_path("file:///C:/repo/src%23internal/mod.py")


### PR DESCRIPTION
Closes #46

## Problem

`scripts/export.py` maintained private copies of `normalize_file_path` and `to_epoch_ms` that already existed in `utils/path_helpers.py`. The two `normalize_file_path` copies had diverged: the export copy was missing the non-Windows cross-platform branch that handles Windows-style drive paths (`D:/...`, `D:\...`) on Linux/macOS — meaning cross-platform reads of Cursor's Windows workspaceStorage could produce inconsistent path keys depending on which code path was used.

## Changes

**`scripts/export.py`**
- Removed local `normalize_file_path` (~13 lines) and `to_epoch_ms` (~22 lines)
- Expanded the `utils.path_helpers` import to include both functions alongside the existing `get_workspace_folder_paths` alias

**`tests/test_normalize_file_path.py`** (new)
- 21 test cases in this file (12 `normalize_file_path`, 9 `to_epoch_ms`; 2 skip on win32 for POSIX passthrough only) covering the shared implementation:
  - `file:///` and `file://` URI stripping
  - Percent-encoded characters: `%20` (space), `%23` (#), `%3A` (colon in URI-style prefix)
  - Windows drive paths with backslashes and forward-slashes on all platforms
  - Drive-letter lowercasing
  - Plain POSIX path passthrough
  - Empty string

## Notes

- The canonical implementation in `utils/path_helpers.py` is a strict superset of the old export copy — it adds the non-Windows `^[a-zA-Z]:[/\\]` branch for Windows-style paths on Linux/macOS, which the export copy lacked.
- The `sys.path.insert` block in `scripts/export.py` is intentionally left in place; removing it is part of the larger export-script-to-service-layer refactor (issue #1).
- `samples/example_chat_export.md` quotes the old function definitions as documentation; not touched.

## Verification

```
python -m unittest tests.test_normalize_file_path -v
# Ran 21 tests … OK (skipped=2)   # win32: 2 POSIX-only cases skip

python -m unittest discover tests -q
# Ran 274 tests in 2.1s
# OK (skipped=4)   # suite-wide; includes skips from other modules
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated utility functions into shared modules.

* **Tests**
  * Significantly expanded test coverage for path normalization and timestamp conversion utilities. Added comprehensive test cases covering cross-platform compatibility, percent-decoding, URI handling, and various timestamp input formats including ISO-8601 and numeric values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/cppa-cursor-browser/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->