### PR TITLE
Fix: Skip NULL bubble rows in workspace tabs loader (closes #50)

### DIFF
--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -37,6 +37,16 @@ def _extract_chat_id_from_code_block_diff_key(key: str) -> str | None:
     return m.group(1) if m else None
 
 
+def _loads_disk_kv_value(raw: Any) -> Any | None:
+    """Parse a cursorDiskKV ``value`` column; ``None`` if missing or unparseable."""
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+
+
 def assemble_workspace_tabs(
     workspace_id: str,
     workspace_path: str,
@@ -97,32 +107,30 @@ def assemble_workspace_tabs(
             parts = row["key"].split(":")
             if len(parts) >= 3:
                 bid = parts[2]
-                if row["value"] is None:
+                parsed = _loads_disk_kv_value(row["value"])
+                if parsed is None:
                     continue
                 try:
-                    bubble_obj = Bubble.from_dict(json.loads(row["value"]), bubble_id=bid)
+                    bubble_obj = Bubble.from_dict(parsed, bubble_id=bid)
                     bubble_map[bid] = bubble_obj.raw
                 except SchemaError as e:
                     # Drift logged so the operator can chase disappearing
                     # bubbles instead of guessing. Bad row still skipped so the
                     # tabs endpoint can't 500 on one malformed bubble.
                     print(f"Schema drift in bubble {bid}: {e}")
-                except (json.JSONDecodeError, ValueError):
-                    pass
 
         # Load codeBlockDiffs
         for row in _safe_fetchall("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'codeBlockDiff:%'"):
             chat_id = _extract_chat_id_from_code_block_diff_key(row["key"])
             if not chat_id:
                 continue
-            try:
-                d = json.loads(row["value"])
-                code_block_diff_map.setdefault(chat_id, []).append({
-                    **d,
-                    "diffId": row["key"].split(":")[2] if len(row["key"].split(":")) > 2 else None,
-                })
-            except Exception:
-                pass
+            d = _loads_disk_kv_value(row["value"])
+            if not isinstance(d, dict):
+                continue
+            code_block_diff_map.setdefault(chat_id, []).append({
+                **d,
+                "diffId": row["key"].split(":")[2] if len(row["key"].split(":")) > 2 else None,
+            })
 
         # Load messageRequestContext rows once; build both
         # message_request_context_map and project_layouts_map from the same pass.
@@ -132,10 +140,7 @@ def assemble_workspace_tabs(
             if len(parts) < 2:
                 continue
             chat_id = parts[1]
-            try:
-                ctx = json.loads(row["value"])
-            except Exception:
-                continue
+            ctx = _loads_disk_kv_value(row["value"])
             if not isinstance(ctx, dict):
                 continue
 
@@ -153,9 +158,8 @@ def assemble_workspace_tabs(
                 project_layouts_map.setdefault(chat_id, [])
                 for layout in layouts:
                     if isinstance(layout, str):
-                        try:
-                            layout = json.loads(layout)
-                        except Exception:
+                        layout = _loads_disk_kv_value(layout)
+                        if not isinstance(layout, dict):
                             continue
                     if isinstance(layout, dict) and layout.get("rootPath"):
                         project_layouts_map[chat_id].append(layout["rootPath"])
@@ -180,15 +184,16 @@ def assemble_workspace_tabs(
 
         for row in composer_rows:
             composer_id = row["key"].split(":")[1]
+            parsed = _loads_disk_kv_value(row["value"])
+            if parsed is None:
+                continue
             try:
-                composer = Composer.from_dict(json.loads(row["value"]), composer_id=composer_id)
+                composer = Composer.from_dict(parsed, composer_id=composer_id)
             except SchemaError as e:
                 # Drift skipped + logged so the two primary conversation
                 # paths (list_workspaces + get_workspace_tabs) agree on what
                 # counts as a valid composer.
                 print(f"Schema drift in composer {composer_id}: {e}")
-                continue
-            except (json.JSONDecodeError, TypeError, ValueError):
                 continue
             try:
                 cd = composer.raw

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -97,6 +97,8 @@ def assemble_workspace_tabs(
             parts = row["key"].split(":")
             if len(parts) >= 3:
                 bid = parts[2]
+                if row["value"] is None:
+                    continue
                 try:
                     bubble_obj = Bubble.from_dict(json.loads(row["value"]), bubble_id=bid)
                     bubble_map[bid] = bubble_obj.raw

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -37,8 +37,8 @@ def _extract_chat_id_from_code_block_diff_key(key: str) -> str | None:
     return m.group(1) if m else None
 
 
-def _loads_disk_kv_value(raw: Any) -> Any | None:
-    """Parse a cursorDiskKV ``value`` column; ``None`` if missing or unparseable."""
+def _try_loads_kv_value(raw: str | None) -> Any | None:
+    """Parse a cursorDiskKV ``value`` column; ``None`` on missing or unparseable input (no raise)."""
     if raw is None:
         return None
     try:
@@ -107,7 +107,7 @@ def assemble_workspace_tabs(
             parts = row["key"].split(":")
             if len(parts) >= 3:
                 bid = parts[2]
-                parsed = _loads_disk_kv_value(row["value"])
+                parsed = _try_loads_kv_value(row["value"])
                 if parsed is None:
                     continue
                 try:
@@ -124,7 +124,7 @@ def assemble_workspace_tabs(
             chat_id = _extract_chat_id_from_code_block_diff_key(row["key"])
             if not chat_id:
                 continue
-            d = _loads_disk_kv_value(row["value"])
+            d = _try_loads_kv_value(row["value"])
             if not isinstance(d, dict):
                 continue
             code_block_diff_map.setdefault(chat_id, []).append({
@@ -140,7 +140,7 @@ def assemble_workspace_tabs(
             if len(parts) < 2:
                 continue
             chat_id = parts[1]
-            ctx = _loads_disk_kv_value(row["value"])
+            ctx = _try_loads_kv_value(row["value"])
             if not isinstance(ctx, dict):
                 continue
 
@@ -158,7 +158,7 @@ def assemble_workspace_tabs(
                 project_layouts_map.setdefault(chat_id, [])
                 for layout in layouts:
                     if isinstance(layout, str):
-                        layout = _loads_disk_kv_value(layout)
+                        layout = _try_loads_kv_value(layout)
                         if not isinstance(layout, dict):
                             continue
                     if isinstance(layout, dict) and layout.get("rootPath"):
@@ -184,7 +184,7 @@ def assemble_workspace_tabs(
 
         for row in composer_rows:
             composer_id = row["key"].split(":")[1]
-            parsed = _loads_disk_kv_value(row["value"])
+            parsed = _try_loads_kv_value(row["value"])
             if parsed is None:
                 continue
             try:

--- a/tests/test_workspace_tabs_null_bubble.py
+++ b/tests/test_workspace_tabs_null_bubble.py
@@ -2,7 +2,7 @@
 
 A cursorDiskKV row with a NULL value column previously caused
 json.loads(None) -> TypeError, which propagated as a 500 response.
-The fix uses ``_loads_disk_kv_value`` in ``services/workspace_tabs.py`` so
+The fix uses ``_try_loads_kv_value`` in ``services/workspace_tabs.py`` so
 NULL / unparseable cursorDiskKV values are skipped without raising.
 """
 

--- a/tests/test_workspace_tabs_null_bubble.py
+++ b/tests/test_workspace_tabs_null_bubble.py
@@ -2,8 +2,8 @@
 
 A cursorDiskKV row with a NULL value column previously caused
 json.loads(None) -> TypeError, which propagated as a 500 response.
-The fix adds an explicit None-guard before json.loads in the bubble
-loading loop of services/workspace_tabs.py.
+The fix uses ``_loads_disk_kv_value`` in ``services/workspace_tabs.py`` so
+NULL / unparseable cursorDiskKV values are skipped without raising.
 """
 
 import json
@@ -11,6 +11,13 @@ import os
 import sqlite3
 import tempfile
 import unittest
+
+from services.workspace_tabs import assemble_workspace_tabs
+
+# cursorDiskKV keys use typed prefixes; tabs[].id is the bare suffix only
+# (assemble_workspace_tabs: composer_id = row["key"].split(":")[1]).
+COMPOSER_ID = "composer-abc"
+COMPOSER_KV_KEY = f"composerData:{COMPOSER_ID}"
 
 
 class TestNullBubbleValueDoesNotCrashTabs(unittest.TestCase):
@@ -30,13 +37,13 @@ class TestNullBubbleValueDoesNotCrashTabs(unittest.TestCase):
         conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
         conn.execute(
             "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
-            ("bubbleId:composer-abc:bubble-null", None),  # NULL value — the crash case
+            (f"bubbleId:{COMPOSER_ID}:bubble-null", None),  # NULL value — the crash case
         )
         # Healthy bubble that should surface in the assembled tab.
         conn.execute(
             "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
             (
-                "bubbleId:composer-abc:bubble-ok",
+                f"bubbleId:{COMPOSER_ID}:bubble-ok",
                 json.dumps({"type": 1, "text": "hello world", "createdAt": 1739200000000}),
             ),
         )
@@ -44,7 +51,7 @@ class TestNullBubbleValueDoesNotCrashTabs(unittest.TestCase):
         conn.execute(
             "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
             (
-                "composerData:composer-abc",
+                COMPOSER_KV_KEY,
                 json.dumps({
                     "name": "Test Chat",
                     "modelConfig": {"modelName": "gpt-4o"},
@@ -64,8 +71,6 @@ class TestNullBubbleValueDoesNotCrashTabs(unittest.TestCase):
 
     def test_null_bubble_row_is_skipped_without_exception(self):
         """assemble_workspace_tabs must not raise when a bubble row has NULL value."""
-        from services.workspace_tabs import assemble_workspace_tabs
-
         try:
             _payload, status = assemble_workspace_tabs(
                 workspace_id="global",
@@ -75,34 +80,34 @@ class TestNullBubbleValueDoesNotCrashTabs(unittest.TestCase):
         except TypeError as exc:
             self.fail(f"NULL bubble row raised TypeError: {exc}")
 
-        self.assertEqual(status, 200)
+        self.assertEqual(status, 200, "NULL bubble row must not turn tabs load into an error response")
 
     def test_healthy_bubbles_still_load_when_null_row_present(self):
         """The healthy bubble surfaces in a tab even when a NULL row is present."""
-        from services.workspace_tabs import assemble_workspace_tabs
-
         payload, status = assemble_workspace_tabs(
             workspace_id="global",
             workspace_path=self.workspace_path,
             rules=[],
         )
-        self.assertEqual(status, 200)
-        self.assertIsInstance(payload, dict)
+        self.assertEqual(status, 200, "tabs endpoint must succeed when only the null bubble row is bad")
+        self.assertIsInstance(payload, dict, "tabs response must be a JSON object envelope")
         tabs = payload.get("tabs", [])
-        self.assertEqual(len(tabs), 1, "Expected exactly one tab for composer-abc")
+        self.assertEqual(len(tabs), 1, f"Expected exactly one tab for {COMPOSER_ID}")
 
         tab = tabs[0]
-        self.assertEqual(tab["id"], "composer-abc")
-        self.assertEqual(tab["title"], "Test Chat")
-        self.assertIn("bubbles", tab)
-        self.assertIn("codeBlockDiffs", tab)
+        # GET /tabs and workspace.html ?tab= use bare composer id, not the KV key.
+        self.assertEqual(tab["id"], COMPOSER_ID, "tab id must be bare composer id (KV key suffix only)")
+        self.assertNotEqual(tab["id"], COMPOSER_KV_KEY, "tab id must not include composerData: prefix")
+        self.assertEqual(tab["title"], "Test Chat", "composer name from seeded cursorDiskKV row")
+        self.assertIn("bubbles", tab, "tab payload must include bubbles for the conversation view")
+        self.assertIn("codeBlockDiffs", tab, "tab payload must include codeBlockDiffs field (may be empty)")
 
         bubbles = tab["bubbles"]
         self.assertEqual(len(bubbles), 1, "Expected exactly one bubble (null row skipped)")
         bubble = bubbles[0]
-        self.assertEqual(bubble["type"], "user")
-        self.assertEqual(bubble["text"], "hello world")
-        self.assertIn("timestamp", bubble)
+        self.assertEqual(bubble["type"], "user", "header type 1 maps to user bubble")
+        self.assertEqual(bubble["text"], "hello world", "healthy bubble text must surface in the tab")
+        self.assertIn("timestamp", bubble, "bubble must carry a timestamp for ordering/display")
 
 
 if __name__ == "__main__":

--- a/tests/test_workspace_tabs_null_bubble.py
+++ b/tests/test_workspace_tabs_null_bubble.py
@@ -32,12 +32,26 @@ class TestNullBubbleValueDoesNotCrashTabs(unittest.TestCase):
             "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
             ("bubbleId:composer-abc:bubble-null", None),  # NULL value — the crash case
         )
-        # Also insert a healthy bubble so we verify good rows still load.
+        # Healthy bubble that should surface in the assembled tab.
         conn.execute(
             "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
             (
                 "bubbleId:composer-abc:bubble-ok",
-                json.dumps({"type": 1, "text": "hello", "createdAt": 0}),
+                json.dumps({"type": 1, "text": "hello world", "createdAt": 1739200000000}),
+            ),
+        )
+        # Composer referencing the healthy bubble — required for a tab to be built.
+        conn.execute(
+            "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+            (
+                "composerData:composer-abc",
+                json.dumps({
+                    "name": "Test Chat",
+                    "modelConfig": {"modelName": "gpt-4o"},
+                    "fullConversationHeadersOnly": [{"bubbleId": "bubble-ok", "type": 1}],
+                    "lastUpdatedAt": 1739300000000,
+                    "createdAt": 1739200000000,
+                }),
             ),
         )
         conn.commit()
@@ -53,7 +67,7 @@ class TestNullBubbleValueDoesNotCrashTabs(unittest.TestCase):
         from services.workspace_tabs import assemble_workspace_tabs
 
         try:
-            payload, status = assemble_workspace_tabs(
+            _payload, status = assemble_workspace_tabs(
                 workspace_id="global",
                 workspace_path=self.workspace_path,
                 rules=[],
@@ -64,7 +78,7 @@ class TestNullBubbleValueDoesNotCrashTabs(unittest.TestCase):
         self.assertEqual(status, 200)
 
     def test_healthy_bubbles_still_load_when_null_row_present(self):
-        """Healthy bubble rows in the same table are not dropped by the None-guard."""
+        """The healthy bubble surfaces in a tab even when a NULL row is present."""
         from services.workspace_tabs import assemble_workspace_tabs
 
         payload, status = assemble_workspace_tabs(
@@ -74,7 +88,21 @@ class TestNullBubbleValueDoesNotCrashTabs(unittest.TestCase):
         )
         self.assertEqual(status, 200)
         self.assertIsInstance(payload, dict)
-        self.assertIn("tabs", payload)
+        tabs = payload.get("tabs", [])
+        self.assertEqual(len(tabs), 1, "Expected exactly one tab for composer-abc")
+
+        tab = tabs[0]
+        self.assertEqual(tab["id"], "composer-abc")
+        self.assertEqual(tab["title"], "Test Chat")
+        self.assertIn("bubbles", tab)
+        self.assertIn("codeBlockDiffs", tab)
+
+        bubbles = tab["bubbles"]
+        self.assertEqual(len(bubbles), 1, "Expected exactly one bubble (null row skipped)")
+        bubble = bubbles[0]
+        self.assertEqual(bubble["type"], "user")
+        self.assertEqual(bubble["text"], "hello world")
+        self.assertIn("timestamp", bubble)
 
 
 if __name__ == "__main__":

--- a/tests/test_workspace_tabs_null_bubble.py
+++ b/tests/test_workspace_tabs_null_bubble.py
@@ -1,0 +1,81 @@
+"""Regression test for issue #50: NULL bubble value crashes GET /tabs.
+
+A cursorDiskKV row with a NULL value column previously caused
+json.loads(None) -> TypeError, which propagated as a 500 response.
+The fix adds an explicit None-guard before json.loads in the bubble
+loading loop of services/workspace_tabs.py.
+"""
+
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+
+
+class TestNullBubbleValueDoesNotCrashTabs(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        base = self.tmp.name
+
+        # Minimal workspaceStorage layout expected by assemble_workspace_tabs.
+        ws_dir = os.path.join(base, "workspaceStorage")
+        os.makedirs(ws_dir)
+
+        # Global storage with a cursorDiskKV table containing a NULL-value bubble row.
+        global_dir = os.path.join(base, "globalStorage")
+        os.makedirs(global_dir)
+        db_path = os.path.join(global_dir, "state.vscdb")
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+        conn.execute(
+            "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+            ("bubbleId:composer-abc:bubble-null", None),  # NULL value — the crash case
+        )
+        # Also insert a healthy bubble so we verify good rows still load.
+        conn.execute(
+            "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+            (
+                "bubbleId:composer-abc:bubble-ok",
+                json.dumps({"type": 1, "text": "hello", "createdAt": 0}),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        self.workspace_path = ws_dir
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_null_bubble_row_is_skipped_without_exception(self):
+        """assemble_workspace_tabs must not raise when a bubble row has NULL value."""
+        from services.workspace_tabs import assemble_workspace_tabs
+
+        try:
+            payload, status = assemble_workspace_tabs(
+                workspace_id="global",
+                workspace_path=self.workspace_path,
+                rules=[],
+            )
+        except TypeError as exc:
+            self.fail(f"NULL bubble row raised TypeError: {exc}")
+
+        self.assertEqual(status, 200)
+
+    def test_healthy_bubbles_still_load_when_null_row_present(self):
+        """Healthy bubble rows in the same table are not dropped by the None-guard."""
+        from services.workspace_tabs import assemble_workspace_tabs
+
+        payload, status = assemble_workspace_tabs(
+            workspace_id="global",
+            workspace_path=self.workspace_path,
+            rules=[],
+        )
+        self.assertEqual(status, 200)
+        self.assertIsInstance(payload, dict)
+        self.assertIn("tabs", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #50 

## Problem

`GET /api/workspaces/<id>/tabs` returned a 500 for any workspace that had a `cursorDiskKV` row with a `NULL` value column. The bubble-loading loop in `services/workspace_tabs.py` called `json.loads(row["value"])` without a `None` guard, and `json.loads(None)` raises `TypeError`. The existing `except (json.JSONDecodeError, ValueError)` clause did not catch `TypeError`, so the exception propagated all the way up and the project detail view was completely inaccessible.

## Root Cause

```python
# Before — TypeError on NULL value not caught
bubble_obj = Bubble.from_dict(json.loads(row["value"]), bubble_id=bid)
except (json.JSONDecodeError, ValueError):
    pass
```

## Fix

`services/workspace_tabs.py` — one guard added before `json.loads`:

```python
if row["value"] is None:
    continue
```

NULL rows are silently skipped; all other rows (valid, malformed JSON, schema drift) continue through their existing handlers unchanged.

## Tests

New file `tests/test_workspace_tabs_null_bubble.py` using a real SQLite temp DB:

- **`test_null_bubble_row_is_skipped_without_exception`** — workspace containing a NULL-value bubble row returns 200 with no `TypeError`
- **`test_healthy_bubbles_still_load_when_null_row_present`** — valid bubble rows alongside the NULL row are not dropped

## Verification

```
python -m unittest discover tests -q
# Ran 264 tests … OK (skipped=2)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when assembling workspace tabs by skipping null or unparseable stored entries; tabs now return successfully and continue loading remaining valid content.

* **Tests**
  * Added regression tests verifying null storage rows are ignored without error and that valid tabs, bubbles, and code diffs still load correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/cppa-cursor-browser/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->