### PR TITLE
Fix thread-unsafe _workspace_path_override race (#43)

### DIFF
--- a/tests/test_workspace_path_thread_safety.py
+++ b/tests/test_workspace_path_thread_safety.py
@@ -1,0 +1,124 @@
+"""
+Regression tests for issue #43 — thread-safe _workspace_path_override.
+
+Run:
+    python -m unittest tests.test_workspace_path_thread_safety -v
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import threading
+import unittest
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+from utils.workspace_path import (
+    get_workspace_path_override,
+    resolve_workspace_path,
+    set_workspace_path_override,
+)
+
+
+class TestWorkspacePathThreadSafety(unittest.TestCase):
+    """Concurrent set-workspace + resolve must not observe torn global state."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="cursor-ws-thread-test-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.path_a = os.path.join(self.tmp, "storage-a")
+        self.path_b = os.path.join(self.tmp, "storage-b")
+        os.makedirs(self.path_a)
+        os.makedirs(self.path_b)
+        self._prior_workspace_env = os.environ.pop("WORKSPACE_PATH", None)
+        self.addCleanup(self._restore_workspace_env)
+        self.addCleanup(set_workspace_path_override, None)
+
+    def _restore_workspace_env(self):
+        if self._prior_workspace_env is None:
+            os.environ.pop("WORKSPACE_PATH", None)
+        else:
+            os.environ["WORKSPACE_PATH"] = self._prior_workspace_env
+
+    def test_concurrent_set_and_resolve_never_returns_mixed_paths(self):
+        iterations = 500
+        errors: list[str] = []
+        start = threading.Barrier(9)  # 1 writer + 8 readers
+        # Seed before workers start so readers never observe the unset default path.
+        set_workspace_path_override(self.path_a)
+
+        def writer() -> None:
+            start.wait()
+            for i in range(iterations):
+                set_workspace_path_override(self.path_a if i % 2 == 0 else self.path_b)
+
+        def reader() -> None:
+            start.wait()
+            for _ in range(iterations):
+                override = get_workspace_path_override()
+                if override is None:
+                    errors.append("override was unexpectedly cleared during run")
+                    continue
+                if override not in (self.path_a, self.path_b):
+                    errors.append(f"override returned unexpected value: {override!r}")
+                    continue
+                resolved = resolve_workspace_path()
+                expected = os.path.realpath(override)
+                if resolved != expected:
+                    errors.append(
+                        f"resolve {resolved!r} != realpath(override) {expected!r}"
+                    )
+
+        with ThreadPoolExecutor(max_workers=9) as pool:
+            futures = [pool.submit(writer)]
+            futures.extend(pool.submit(reader) for _ in range(8))
+            for fut in as_completed(futures):
+                fut.result()
+
+        self.assertEqual(errors, [], "\n".join(errors[:20]))
+
+    def test_concurrent_clear_and_set_stays_consistent(self):
+        iterations = 200
+        errors: list[str] = []
+        start = threading.Barrier(5)
+
+        def toggler() -> None:
+            start.wait()
+            for i in range(iterations):
+                if i % 3 == 0:
+                    set_workspace_path_override(None)
+                else:
+                    set_workspace_path_override(
+                        self.path_a if i % 2 == 0 else self.path_b
+                    )
+
+        def reader() -> None:
+            start.wait()
+            for _ in range(iterations):
+                override = get_workspace_path_override()
+                resolved = resolve_workspace_path()
+                if override is None:
+                    continue
+                if override not in (self.path_a, self.path_b):
+                    errors.append(f"unexpected override: {override!r}")
+                elif resolved != os.path.realpath(override):
+                    errors.append(
+                        f"resolve {resolved!r} != realpath({override!r})"
+                    )
+
+        with ThreadPoolExecutor(max_workers=5) as pool:
+            futures = [pool.submit(toggler)]
+            futures.extend(pool.submit(reader) for _ in range(4))
+            for fut in as_completed(futures):
+                fut.result()
+
+        self.assertEqual(errors, [], "\n".join(errors[:20]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workspace_path_thread_safety.py
+++ b/tests/test_workspace_path_thread_safety.py
@@ -19,7 +19,6 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, REPO_ROOT)
 
 from utils.workspace_path import (
-    get_workspace_path_override,
     resolve_workspace_path,
     set_workspace_path_override,
 )
@@ -35,9 +34,15 @@ class TestWorkspacePathThreadSafety(unittest.TestCase):
         self.path_b = os.path.join(self.tmp, "storage-b")
         os.makedirs(self.path_a)
         os.makedirs(self.path_b)
+        self.allowed_resolved = {
+            os.path.realpath(self.path_a),
+            os.path.realpath(self.path_b),
+        }
         self._prior_workspace_env = os.environ.pop("WORKSPACE_PATH", None)
         self.addCleanup(self._restore_workspace_env)
         self.addCleanup(set_workspace_path_override, None)
+        set_workspace_path_override(None)
+        self.fallback_resolved = resolve_workspace_path()
 
     def _restore_workspace_env(self):
         if self._prior_workspace_env is None:
@@ -60,18 +65,10 @@ class TestWorkspacePathThreadSafety(unittest.TestCase):
         def reader() -> None:
             start.wait()
             for _ in range(iterations):
-                override = get_workspace_path_override()
-                if override is None:
-                    errors.append("override was unexpectedly cleared during run")
-                    continue
-                if override not in (self.path_a, self.path_b):
-                    errors.append(f"override returned unexpected value: {override!r}")
-                    continue
                 resolved = resolve_workspace_path()
-                expected = os.path.realpath(override)
-                if resolved != expected:
+                if resolved not in self.allowed_resolved:
                     errors.append(
-                        f"resolve {resolved!r} != realpath(override) {expected!r}"
+                        f"resolve returned unexpected path: {resolved!r}"
                     )
 
         with ThreadPoolExecutor(max_workers=9) as pool:
@@ -100,16 +97,13 @@ class TestWorkspacePathThreadSafety(unittest.TestCase):
         def reader() -> None:
             start.wait()
             for _ in range(iterations):
-                override = get_workspace_path_override()
                 resolved = resolve_workspace_path()
-                if override is None:
+                if (
+                    resolved in self.allowed_resolved
+                    or resolved == self.fallback_resolved
+                ):
                     continue
-                if override not in (self.path_a, self.path_b):
-                    errors.append(f"unexpected override: {override!r}")
-                elif resolved != os.path.realpath(override):
-                    errors.append(
-                        f"resolve {resolved!r} != realpath({override!r})"
-                    )
+                errors.append(f"resolve returned unexpected path: {resolved!r}")
 
         with ThreadPoolExecutor(max_workers=5) as pool:
             futures = [pool.submit(toggler)]

--- a/tests/test_workspace_path_thread_safety.py
+++ b/tests/test_workspace_path_thread_safety.py
@@ -34,14 +34,13 @@ class TestWorkspacePathThreadSafety(unittest.TestCase):
         self.path_b = os.path.join(self.tmp, "storage-b")
         os.makedirs(self.path_a)
         os.makedirs(self.path_b)
-        self.allowed_resolved = {
-            os.path.realpath(self.path_a),
-            os.path.realpath(self.path_b),
-        }
+        # Match resolve_workspace_path() (expand_tilde only — no realpath).
+        self.allowed_resolved = {self.path_a, self.path_b}
         self._prior_workspace_env = os.environ.pop("WORKSPACE_PATH", None)
         self.addCleanup(self._restore_workspace_env)
         self.addCleanup(set_workspace_path_override, None)
-        set_workspace_path_override(None)
+        # With WORKSPACE_PATH popped and override None, this is resolve()'s
+        # "override cleared" path — used by test_concurrent_clear_and_set.
         self.fallback_resolved = resolve_workspace_path()
 
     def _restore_workspace_env(self):

--- a/utils/workspace_path.py
+++ b/utils/workspace_path.py
@@ -10,9 +10,9 @@ import threading
 from .path_helpers import expand_tilde_path
 
 # Module-level override set via POST /api/set-workspace (or --base-dir).
-# All reads and writes are serialized by _workspace_path_lock so threaded
-# WSGI workers (gunicorn --threads, waitress, etc.) cannot observe torn
-# state between set_workspace_path_override and resolve_workspace_path.
+# Reads and writes are serialized by _workspace_path_lock so threaded WSGI
+# workers (gunicorn --threads, waitress, etc.) always see the latest override
+# from another thread and resolve_workspace_path's snapshot+expand stays consistent.
 _workspace_path_lock = threading.Lock()
 _workspace_path_override: str | None = None
 

--- a/utils/workspace_path.py
+++ b/utils/workspace_path.py
@@ -5,20 +5,27 @@ from __future__ import annotations
 import os
 import sys
 import subprocess
+import threading
 
 from .path_helpers import expand_tilde_path
 
-# Module-level override set via the /api/set-workspace endpoint
+# Module-level override set via POST /api/set-workspace (or --base-dir).
+# All reads and writes are serialized by _workspace_path_lock so threaded
+# WSGI workers (gunicorn --threads, waitress, etc.) cannot observe torn
+# state between set_workspace_path_override and resolve_workspace_path.
+_workspace_path_lock = threading.Lock()
 _workspace_path_override: str | None = None
 
 
-def set_workspace_path_override(path: str):
+def set_workspace_path_override(path: str | None) -> None:
     global _workspace_path_override
-    _workspace_path_override = path
+    with _workspace_path_lock:
+        _workspace_path_override = path
 
 
 def get_workspace_path_override() -> str | None:
-    return _workspace_path_override
+    with _workspace_path_lock:
+        return _workspace_path_override
 
 
 def get_default_workspace_path() -> str:
@@ -64,8 +71,10 @@ def resolve_workspace_path() -> str:
     is only tilde-expanded — trusted-operator escape hatch, not the same checks
     as the API (issue #15).
     """
-    if _workspace_path_override:
-        return expand_tilde_path(_workspace_path_override)
+    with _workspace_path_lock:
+        override = _workspace_path_override
+    if override:
+        return expand_tilde_path(override)
     env_path = os.environ.get("WORKSPACE_PATH", "").strip()
     if env_path:
         return expand_tilde_path(env_path)


### PR DESCRIPTION
## Summary

Fixes [#43](https://github.com/cppalliance/cppa-cursor-browser/issues/43) by serializing access to the module-level `_workspace_path_override` with a `threading.Lock`. The override is written by `POST /api/set-workspace` (and `--base-dir`) and read on every call to `resolve_workspace_path()`; without synchronization, threaded WSGI deployments (gunicorn `--threads`, waitress, etc.) can race and serve data from the wrong workspace path.

- Add `_workspace_path_lock` and document the locking contract on `_workspace_path_override`
- Protect reads in `get_workspace_path_override()` and `resolve_workspace_path()` (snapshot under lock, then expand outside)
- Protect writes in `set_workspace_path_override()`; widen type to `str | None` for test/cleanup clears
- Add `tests/test_workspace_path_thread_safety.py` with concurrent set/resolve and clear/set/resolve stress tests

Eval reference: `workspace-path-race-condition` cluster (test 13) in the [April 2026 Python eval](https://github.com/cppalliance/cppa-cursor-browser) baseline.

## Why a lock (not Flask `g`/session)

The override is **server-wide** configuration for this localhost tool, not per-request state. A lock is the minimum change that makes threaded deployment safe without changing API semantics. Per-user isolation would require session-scoped storage and is out of scope for this fix.

## Test plan

- [x] `python -m unittest tests.test_workspace_path_thread_safety -v`
- [x] `python -m unittest tests.test_workspace_path_validation -v` (existing set-workspace regressions still pass)
- [ ] Manual: run app under a threaded server, call `POST /api/set-workspace` while hitting list/search endpoints concurrently; confirm stable workspace selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a concurrency issue so workspace path overrides remain consistent and never produce mixed or partial results during concurrent set/clear/resolve operations.
  * Clear/set races now yield stable, predictable resolved paths.

* **Tests**
  * Added concurrency regression tests that validate stable behavior of workspace path overrides under concurrent set, clear, and resolve scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/cppa-cursor-browser/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->