### PR TITLE
Add incomplete-result signaling on parse failure (#67)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,7 @@ jobs:
         # new endpoint file because `pytest tests/` would also re-collect the
         # 178 unittest.TestCase subclasses already run in the step above —
         # ~2× the CI minutes for zero extra signal.
-        run: python -m pytest tests/test_api_endpoints.py tests/test_parse_failure_logging.py -v --tb=short
+        run: python -m pytest tests/test_api_endpoints.py -v --tb=short
 
       # ── PyInstaller desktop build (Windows only, once per workflow) ────────
       # Closes #44. Builds the onedir bundle and smoke-tests --help so the

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,7 @@ jobs:
         # new endpoint file because `pytest tests/` would also re-collect the
         # 178 unittest.TestCase subclasses already run in the step above —
         # ~2× the CI minutes for zero extra signal.
-        run: python -m pytest tests/test_api_endpoints.py -v --tb=short
+        run: python -m pytest tests/test_api_endpoints.py tests/test_parse_failure_logging.py -v --tb=short
 
       # ── PyInstaller desktop build (Windows only, once per workflow) ────────
       # Closes #44. Builds the onedir bundle and smoke-tests --help so the

--- a/api/export_api.py
+++ b/api/export_api.py
@@ -222,4 +222,4 @@ def export_chats():
             type(e).__name__,
             exc_info=True,
         )
-        return jsonify({"error": f"Export failed: {str(e)}"}), 500
+        return jsonify({"error": "Export failed"}), 500

--- a/api/pdf.py
+++ b/api/pdf.py
@@ -176,7 +176,7 @@ def generate_pdf():
             type(e).__name__,
             exc_info=True,
         )
-        return jsonify({"error": f"Failed to generate PDF: {str(e)}"}), 500
+        return jsonify({"error": "Failed to generate PDF"}), 500
 
 
 def _render_code_block(pdf, code_text: str):

--- a/api/search.py
+++ b/api/search.py
@@ -19,7 +19,7 @@ from utils.workspace_path import resolve_workspace_path, get_cli_chats_path
 from utils.path_helpers import to_epoch_ms, warn_workspace_json_read
 from utils.text_extract import extract_text_from_bubble
 from utils.cli_chat_reader import list_cli_projects, traverse_blobs, messages_to_bubbles
-from models import Bubble, Composer, SchemaError
+from models import Bubble, Composer, ParseWarningCollector, SchemaError
 
 bp = Blueprint("search", __name__)
 _logger = logging.getLogger(__name__)
@@ -79,6 +79,7 @@ def search():
 
         workspace_path = resolve_workspace_path()
         results = []
+        parse_warnings = ParseWarningCollector()
         query_lower = query.lower()
 
         global_db_path = os.path.normpath(os.path.join(workspace_path, "..", "globalStorage", "state.vscdb"))
@@ -170,8 +171,9 @@ def search():
                                 e,
                                 type(e).__name__,
                             )
+                            parse_warnings.record_bubble_skipped()
                         except (json.JSONDecodeError, ValueError):
-                            pass
+                            parse_warnings.record_bubble_skipped()
 
                 # Search through composerData
                 composer_rows = conn.execute(
@@ -189,8 +191,10 @@ def search():
                             e,
                             type(e).__name__,
                         )
+                        parse_warnings.record_composer_skipped()
                         continue
                     except (json.JSONDecodeError, TypeError, ValueError):
+                        parse_warnings.record_composer_skipped()
                         continue
                     try:
                         cd = composer.raw
@@ -285,6 +289,7 @@ def search():
                             composer_id,
                             e,
                         )
+                        parse_warnings.record_composer_skipped()
 
             except Exception:
                 _logger.exception("Error searching global storage")
@@ -498,7 +503,8 @@ def search():
             return t
         results.sort(key=_ts, reverse=True)
 
-        return jsonify({"results": results})
+        payload: dict = {"results": results}
+        return jsonify(parse_warnings.attach_to(payload))
 
     except Exception:
         _logger.exception("Search failed")

--- a/api/search.py
+++ b/api/search.py
@@ -172,7 +172,12 @@ def search():
                                 type(e).__name__,
                             )
                             parse_warnings.record_bubble_skipped()
-                        except (json.JSONDecodeError, ValueError):
+                        except (json.JSONDecodeError, TypeError, ValueError) as e:
+                            _logger.warning(
+                                "Failed to decode Bubble from bubbleId:%s: %s",
+                                bid,
+                                e,
+                            )
                             parse_warnings.record_bubble_skipped()
 
                 # Search through composerData
@@ -193,7 +198,12 @@ def search():
                         )
                         parse_warnings.record_composer_skipped()
                         continue
-                    except (json.JSONDecodeError, TypeError, ValueError):
+                    except (json.JSONDecodeError, TypeError, ValueError) as e:
+                        _logger.warning(
+                            "Failed to decode Composer from composerData:%s: %s",
+                            composer_id,
+                            e,
+                        )
                         parse_warnings.record_composer_skipped()
                         continue
                     try:
@@ -289,7 +299,7 @@ def search():
                             composer_id,
                             e,
                         )
-                        parse_warnings.record_composer_skipped()
+                        parse_warnings.record_composer_processing_failure()
 
             except Exception:
                 _logger.exception("Error searching global storage")

--- a/api/workspaces.py
+++ b/api/workspaces.py
@@ -56,9 +56,10 @@ def list_workspaces():
         workspace_path = resolve_workspace_path()
         rules = current_app.config.get("EXCLUSION_RULES") or []
         projects, warnings = list_workspace_projects(workspace_path, rules)
+        payload: dict = {"projects": projects}
         if warnings:
-            return jsonify({"projects": projects, "warnings": warnings})
-        return jsonify(projects)
+            payload["warnings"] = warnings
+        return jsonify(payload)
     except Exception:
         _logger.exception("Failed to get workspaces")
         return jsonify({"error": "Failed to get workspaces"}), 500

--- a/api/workspaces.py
+++ b/api/workspaces.py
@@ -55,7 +55,9 @@ def list_workspaces():
     try:
         workspace_path = resolve_workspace_path()
         rules = current_app.config.get("EXCLUSION_RULES") or []
-        projects = list_workspace_projects(workspace_path, rules)
+        projects, warnings = list_workspace_projects(workspace_path, rules)
+        if warnings:
+            return jsonify({"projects": projects, "warnings": warnings})
         return jsonify(projects)
     except Exception:
         _logger.exception("Failed to get workspaces")

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,6 +1,7 @@
 from models.cli_session import CliSessionMeta
 from models.conversation import Bubble, Composer, WorkspaceLocalComposer
 from models.errors import SchemaError
+from models.parse_warnings import ParseWarningCollector, attach_warnings
 from models.export import ExportEntry
 from models.workspace import Workspace
 
@@ -9,7 +10,9 @@ __all__ = [
     "CliSessionMeta",
     "Composer",
     "ExportEntry",
+    "ParseWarningCollector",
     "SchemaError",
     "Workspace",
     "WorkspaceLocalComposer",
+    "attach_warnings",
 ]

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,7 +1,7 @@
 from models.cli_session import CliSessionMeta
 from models.conversation import Bubble, Composer, WorkspaceLocalComposer
 from models.errors import SchemaError
-from models.parse_warnings import ParseWarningCollector, attach_warnings
+from models.parse_warnings import ParseWarningCollector
 from models.export import ExportEntry
 from models.workspace import Workspace
 
@@ -14,5 +14,4 @@ __all__ = [
     "SchemaError",
     "Workspace",
     "WorkspaceLocalComposer",
-    "attach_warnings",
 ]

--- a/models/parse_warnings.py
+++ b/models/parse_warnings.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ParseWarningCollector:
+    """Accumulates parse failures skipped during bubble/composer processing."""
+
+    composers_skipped: int = 0
+    bubbles_skipped: int = 0
+
+    def record_composer_skipped(self, count: int = 1) -> None:
+        if count > 0:
+            self.composers_skipped += count
+
+    def record_bubble_skipped(self, count: int = 1) -> None:
+        if count > 0:
+            self.bubbles_skipped += count
+
+    @property
+    def has_warnings(self) -> bool:
+        return self.composers_skipped > 0 or self.bubbles_skipped > 0
+
+    def to_api_list(self) -> list[dict]:
+        """Structured warnings for JSON API responses (issue #67)."""
+        warnings: list[dict] = []
+        if self.composers_skipped:
+            n = self.composers_skipped
+            noun = "conversation" if n == 1 else "conversations"
+            warnings.append({
+                "type": "parse_error",
+                "count": n,
+                "detail": (
+                    f"{n} {noun} could not be loaded due to schema or JSON parse errors"
+                ),
+            })
+        if self.bubbles_skipped:
+            n = self.bubbles_skipped
+            noun = "message" if n == 1 else "messages"
+            warnings.append({
+                "type": "parse_error",
+                "count": n,
+                "detail": (
+                    f"{n} {noun} could not be loaded due to schema or JSON parse errors"
+                ),
+            })
+        return warnings
+
+    def attach_to(self, payload: dict) -> dict:
+        """Add ``warnings`` to a dict response when any failures were recorded."""
+        if self.has_warnings:
+            payload = {**payload, "warnings": self.to_api_list()}
+        return payload
+
+
+def attach_warnings(payload: dict, warnings: list[dict]) -> dict:
+    """Merge pre-built warnings into a response dict."""
+    if warnings:
+        return {**payload, "warnings": warnings}
+    return payload

--- a/models/parse_warnings.py
+++ b/models/parse_warnings.py
@@ -9,6 +9,7 @@ class ParseWarningCollector:
 
     composers_skipped: int = 0
     bubbles_skipped: int = 0
+    composers_processing_failed: int = 0
 
     def record_composer_skipped(self, count: int = 1) -> None:
         if count > 0:
@@ -18,9 +19,18 @@ class ParseWarningCollector:
         if count > 0:
             self.bubbles_skipped += count
 
+    def record_composer_processing_failure(self, count: int = 1) -> None:
+        """Post-parse assembly failed; not a JSON/schema parse skip."""
+        if count > 0:
+            self.composers_processing_failed += count
+
     @property
     def has_warnings(self) -> bool:
-        return self.composers_skipped > 0 or self.bubbles_skipped > 0
+        return (
+            self.composers_skipped > 0
+            or self.bubbles_skipped > 0
+            or self.composers_processing_failed > 0
+        )
 
     def to_api_list(self) -> list[dict]:
         """Structured warnings for JSON API responses (issue #67)."""
@@ -43,6 +53,16 @@ class ParseWarningCollector:
                 "count": n,
                 "detail": (
                     f"{n} {noun} could not be loaded due to schema or JSON parse errors"
+                ),
+            })
+        if self.composers_processing_failed:
+            n = self.composers_processing_failed
+            noun = "conversation" if n == 1 else "conversations"
+            warnings.append({
+                "type": "processing_error",
+                "count": n,
+                "detail": (
+                    f"{n} {noun} could not be fully assembled after parsing"
                 ),
             })
         return warnings

--- a/models/parse_warnings.py
+++ b/models/parse_warnings.py
@@ -72,10 +72,3 @@ class ParseWarningCollector:
         if self.has_warnings:
             payload = {**payload, "warnings": self.to_api_list()}
         return payload
-
-
-def attach_warnings(payload: dict, warnings: list[dict]) -> dict:
-    """Merge pre-built warnings into a response dict."""
-    if warnings:
-        return {**payload, "warnings": warnings}
-    return payload

--- a/services/workspace_listing.py
+++ b/services/workspace_listing.py
@@ -138,7 +138,7 @@ def list_workspace_projects(workspace_path: str, rules: list) -> tuple[list[dict
                             cid,
                             e,
                         )
-                        parse_warnings.record_composer_skipped()
+                        parse_warnings.record_composer_processing_failure()
             except Exception as e:
                 _logger.error(
                     "Failed to load composer rows from global storage: %s",

--- a/services/workspace_listing.py
+++ b/services/workspace_listing.py
@@ -18,7 +18,7 @@ from utils.path_helpers import (
 )
 from utils.workspace_descriptor import read_json_file
 from utils.workspace_path import get_cli_chats_path
-from models import Composer, SchemaError
+from models import Composer, ParseWarningCollector, SchemaError
 from services.workspace_db import (
     _build_composer_id_to_workspace_id,
     _collect_invalid_workspace_ids,
@@ -37,8 +37,9 @@ from services.workspace_resolver import (
 )
 
 
-def list_workspace_projects(workspace_path: str, rules: list) -> list[dict]:
-    """Return the sorted project list that GET /api/workspaces renders."""
+def list_workspace_projects(workspace_path: str, rules: list) -> tuple[list[dict], list[dict]]:
+    """Return (projects, warnings) for GET /api/workspaces."""
+    parse_warnings = ParseWarningCollector()
     workspace_entries = _collect_workspace_entries(workspace_path)
     invalid_workspace_ids = _collect_invalid_workspace_ids(workspace_entries)
 
@@ -84,6 +85,7 @@ def list_workspace_projects(workspace_path: str, rules: list) -> list[dict]:
                             cid,
                             e,
                         )
+                        parse_warnings.record_composer_skipped()
                         continue
                     if not isinstance(parsed, dict):
                         _logger.warning(
@@ -91,6 +93,7 @@ def list_workspace_projects(workspace_path: str, rules: list) -> list[dict]:
                             cid,
                             type(parsed).__name__,
                         )
+                        parse_warnings.record_composer_skipped()
                         continue
                     try:
                         composer = Composer.from_dict(parsed, composer_id=cid)
@@ -100,6 +103,7 @@ def list_workspace_projects(workspace_path: str, rules: list) -> list[dict]:
                             cid,
                             e,
                         )
+                        parse_warnings.record_composer_skipped()
                         continue
                     cd = composer.raw
                     try:
@@ -134,6 +138,7 @@ def list_workspace_projects(workspace_path: str, rules: list) -> list[dict]:
                             cid,
                             e,
                         )
+                        parse_warnings.record_composer_skipped()
             except Exception as e:
                 _logger.error(
                     "Failed to load composer rows from global storage: %s",
@@ -284,4 +289,4 @@ def list_workspace_projects(workspace_path: str, rules: list) -> list[dict]:
         _logger.warning("Failed to load CLI projects: %s", e)
 
     projects.sort(key=lambda p: p["lastModified"], reverse=True)
-    return projects
+    return projects, parse_warnings.to_api_list()

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -145,7 +145,7 @@ def assemble_workspace_tabs(
                     continue
                 try:
                     parsed = json.loads(row["value"])
-
+                    
                 except (json.JSONDecodeError, TypeError, ValueError) as e:
                     payload_len, payload_fp = _kv_payload_log_meta(row["value"])
                     _logger.warning(

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -134,17 +134,13 @@ def assemble_workspace_tabs(
                 return []
 
         # Load bubbles
-        for row in _safe_fetchall("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'"):
+        for row in _safe_fetchall(
+            "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'"
+            " AND value IS NOT NULL"
+        ):
             parts = row["key"].split(":")
             if len(parts) >= 3:
                 bid = parts[2]
-                if row["value"] is None:
-                    _logger.warning(
-                        "Skipping Bubble cursorDiskKV row with NULL value: key=%r",
-                        row["key"],
-                    )
-                    parse_warnings.record_bubble_skipped()
-                    continue
                 try:
                     parsed = json.loads(row["value"])
 
@@ -214,6 +210,7 @@ def assemble_workspace_tabs(
         # Get composer data entries with conversations
         composer_rows = _safe_fetchall(
             "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
+            " AND value IS NOT NULL"
             " AND value LIKE '%fullConversationHeadersOnly%'"
             " AND value NOT LIKE '%fullConversationHeadersOnly\":[]%'"
         )
@@ -231,13 +228,6 @@ def assemble_workspace_tabs(
 
         for row in composer_rows:
             composer_id = row["key"].split(":")[1]
-            if row["value"] is None:
-                _logger.warning(
-                    "Skipping Composer cursorDiskKV row with NULL value: key=%r",
-                    row["key"],
-                )
-                parse_warnings.record_composer_skipped()
-                continue
             try:
                 parsed = json.loads(row["value"])
             except (json.JSONDecodeError, TypeError, ValueError) as e:

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -20,7 +20,7 @@ from utils.exclusion_rules import build_searchable_text, is_excluded_by_rules
 from utils.text_extract import extract_text_from_bubble
 from utils.tool_parser import parse_tool_call as _parse_tool_call
 from utils.workspace_descriptor import read_json_file
-from models import Bubble, Composer, SchemaError
+from models import Bubble, Composer, ParseWarningCollector, SchemaError
 from services.workspace_db import (
     _build_composer_id_to_workspace_id,
     _collect_invalid_workspace_ids,
@@ -83,6 +83,7 @@ def assemble_workspace_tabs(
     rules: list,
 ) -> tuple[dict, int]:
     """Build (payload, status) for GET /api/workspaces/<id>/tabs; status=404 if global storage is missing."""
+    parse_warnings = ParseWarningCollector()
     response: dict = {"tabs": []}
 
     workspace_entries = _collect_workspace_entries(workspace_path)
@@ -142,6 +143,7 @@ def assemble_workspace_tabs(
                         "Skipping Bubble cursorDiskKV row with NULL value: key=%r",
                         row["key"],
                     )
+                    parse_warnings.record_bubble_skipped()
                     continue
                 try:
                     parsed = json.loads(row["value"])
@@ -155,6 +157,7 @@ def assemble_workspace_tabs(
                         payload_len,
                         payload_fp,
                     )
+                    parse_warnings.record_bubble_skipped()
                     continue
                 try:
                     bubble_obj = Bubble.from_dict(parsed, bubble_id=bid)
@@ -168,6 +171,7 @@ def assemble_workspace_tabs(
                         bid,
                         e,
                     )
+                    parse_warnings.record_bubble_skipped()
 
         # Load codeBlockDiffs
         code_block_diff_map = load_code_block_diff_map(global_db)
@@ -232,6 +236,7 @@ def assemble_workspace_tabs(
                     "Skipping Composer cursorDiskKV row with NULL value: key=%r",
                     row["key"],
                 )
+                parse_warnings.record_composer_skipped()
                 continue
             try:
                 parsed = json.loads(row["value"])
@@ -245,6 +250,7 @@ def assemble_workspace_tabs(
                     payload_len,
                     payload_fp,
                 )
+                parse_warnings.record_composer_skipped()
                 continue
             try:
                 composer = Composer.from_dict(parsed, composer_id=composer_id)
@@ -257,6 +263,7 @@ def assemble_workspace_tabs(
                     composer_id,
                     e,
                 )
+                parse_warnings.record_composer_skipped()
                 continue
             try:
                 cd = composer.raw
@@ -579,8 +586,9 @@ def assemble_workspace_tabs(
                     composer_id,
                     e,
                 )
+                parse_warnings.record_composer_skipped()
 
         # Sort tabs by timestamp descending (newest first)
         response["tabs"].sort(key=lambda t: t.get("timestamp") or 0, reverse=True)
 
-        return response, 200
+        return parse_warnings.attach_to(response), 200

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -586,7 +586,7 @@ def assemble_workspace_tabs(
                     composer_id,
                     e,
                 )
-                parse_warnings.record_composer_skipped()
+                parse_warnings.record_composer_processing_failure()
 
         # Sort tabs by timestamp descending (newest first)
         response["tabs"].sort(key=lambda t: t.get("timestamp") or 0, reverse=True)

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -145,7 +145,7 @@ def assemble_workspace_tabs(
                     continue
                 try:
                     parsed = json.loads(row["value"])
-                    
+
                 except (json.JSONDecodeError, TypeError, ValueError) as e:
                     payload_len, payload_fp = _kv_payload_log_meta(row["value"])
                     _logger.warning(

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -36,6 +36,9 @@
   --success-bg: #052e16;
   --success-border: #166534;
   --danger-bg: #450a0a;
+  --warning-bg: #422006;
+  --warning-border: #854d0e;
+  --warning-text: #fcd34d;
   --danger-border: #991b1b;
   --code-bg: #1e1e1e;
   --spinner: #3b82f6;
@@ -74,6 +77,9 @@
   --success-bg: #f0fdf4;
   --success-border: #bbf7d0;
   --danger-bg: #fef2f2;
+  --warning-bg: #fffbeb;
+  --warning-border: #fcd34d;
+  --warning-text: #92400e;
   --danger-border: #fecaca;
   --code-bg: #f5f5f5;
   --spinner: #2563eb;
@@ -249,6 +255,7 @@ h3 { font-size: 1.15rem; font-weight: 600; }
 .alert-info { background: var(--info-bg); border: 1px solid var(--info-border); color: var(--info-text); }
 .alert-success { background: var(--success-bg); border: 1px solid var(--success-border); color: var(--success); }
 .alert-danger { background: var(--danger-bg); border: 1px solid var(--danger-border); color: var(--danger); }
+.alert-warning { background: var(--warning-bg); border: 1px solid var(--warning-border); color: var(--warning-text); }
 
 /* ---------- Badges ---------- */
 .badge {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -88,8 +88,8 @@ function sanitizeFilename(name) {
 }
 
 /**
- * Normalize GET /api/workspaces body: plain array (no warnings) or
- * { projects, warnings } when parse failures occurred (issue #67).
+ * Normalize GET /api/workspaces body: { projects, warnings? } (issue #67).
+ * Accepts a legacy plain array for backward compatibility.
  */
 function normalizeWorkspacesResponse(body) {
   if (Array.isArray(body)) {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -97,8 +97,8 @@ function normalizeWorkspacesResponse(body) {
   }
   if (body && typeof body === 'object') {
     return {
-      projects: body.projects || [],
-      warnings: body.warnings || [],
+      projects: Array.isArray(body.projects) ? body.projects : [],
+      warnings: Array.isArray(body.warnings) ? body.warnings : [],
     };
   }
   return { projects: [], warnings: [] };
@@ -117,10 +117,11 @@ function formatParseWarnings(warnings) {
  */
 function showIncompleteResultsBanner(containerId, warnings) {
   const container = document.getElementById(containerId);
-  if (!container || !warnings || !warnings.length) return;
+  if (!container) return;
 
   const existing = container.querySelector('.incomplete-results-banner');
   if (existing) existing.remove();
+  if (!Array.isArray(warnings) || !warnings.length) return;
 
   const text = formatParseWarnings(warnings);
   const banner = document.createElement('div');

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -86,3 +86,48 @@ function formatDate(timestamp) {
 function sanitizeFilename(name) {
   return (name || '').replace(/[<>:"/\\|?*]/g, '_').replace(/\s+/g, '_').slice(0, 120);
 }
+
+/**
+ * Normalize GET /api/workspaces body: plain array (no warnings) or
+ * { projects, warnings } when parse failures occurred (issue #67).
+ */
+function normalizeWorkspacesResponse(body) {
+  if (Array.isArray(body)) {
+    return { projects: body, warnings: [] };
+  }
+  if (body && typeof body === 'object') {
+    return {
+      projects: body.projects || [],
+      warnings: body.warnings || [],
+    };
+  }
+  return { projects: [], warnings: [] };
+}
+
+/** Human-readable text from API ``warnings`` entries. */
+function formatParseWarnings(warnings) {
+  if (!warnings || !warnings.length) return '';
+  return warnings.map(w => w.detail || `${w.count || 0} items could not be loaded`).join(' ');
+}
+
+/**
+ * Show or replace an incomplete-results banner (issue #67).
+ * @param {string} containerId - element to prepend into
+ * @param {Array} warnings - API warnings array
+ */
+function showIncompleteResultsBanner(containerId, warnings) {
+  const container = document.getElementById(containerId);
+  if (!container || !warnings || !warnings.length) return;
+
+  const existing = container.querySelector('.incomplete-results-banner');
+  if (existing) existing.remove();
+
+  const text = formatParseWarnings(warnings);
+  const banner = document.createElement('div');
+  banner.className = 'alert alert-warning incomplete-results-banner';
+  banner.setAttribute('role', 'status');
+  banner.textContent = text
+    ? `Some results may be incomplete: ${text}`
+    : 'Some results may be incomplete due to parse errors.';
+  container.insertBefore(banner, container.firstChild);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,6 +37,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       fetch('/api/workspaces'),
       fetch('/api/export/state')
     ]);
+    if (!projRes.ok) {
+      document.getElementById('loading').innerHTML =
+        '<p class="text-danger">Failed to load projects.</p>';
+      return;
+    }
     const body = await projRes.json();
     const { projects, warnings } = normalizeWorkspacesResponse(body);
     showIncompleteResultsBanner('parse-warnings-host', warnings);

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,6 +26,7 @@
   <p>Loading projects...</p>
 </div>
 
+<div id="parse-warnings-host"></div>
 <div id="projects-container" style="display:none"></div>
 
 <script>
@@ -36,7 +37,9 @@ document.addEventListener('DOMContentLoaded', async () => {
       fetch('/api/workspaces'),
       fetch('/api/export/state')
     ]);
-    const projects = await projRes.json();
+    const body = await projRes.json();
+    const { projects, warnings } = normalizeWorkspacesResponse(body);
+    showIncompleteResultsBanner('parse-warnings-host', warnings);
     renderProjects(projects);
 
     // Show last export time

--- a/templates/search.html
+++ b/templates/search.html
@@ -80,6 +80,12 @@ async function performSearch(query, type) {
 
   try {
     const res = await fetch(`/api/search?q=${encodeURIComponent(query)}&type=${type}`);
+    if (!res.ok) {
+      showIncompleteResultsBanner('parse-warnings-host', []);
+      loading.style.display = 'none';
+      container.innerHTML = '<p class="text-danger">Search failed.</p>';
+      return;
+    }
     const data = await res.json();
     const results = data.results || [];
     showIncompleteResultsBanner('parse-warnings-host', data.warnings);
@@ -110,6 +116,7 @@ async function performSearch(query, type) {
     }
     container.innerHTML = html;
   } catch (e) {
+    showIncompleteResultsBanner('parse-warnings-host', []);
     loading.style.display = 'none';
     container.innerHTML = '<p class="text-danger">Search failed.</p>';
   }

--- a/templates/search.html
+++ b/templates/search.html
@@ -23,6 +23,7 @@
     <p>Searching...</p>
   </div>
 
+  <div id="parse-warnings-host"></div>
   <p id="result-count" class="text-muted" style="display:none"></p>
   <div id="results-container"></div>
 </div>
@@ -81,6 +82,7 @@ async function performSearch(query, type) {
     const res = await fetch(`/api/search?q=${encodeURIComponent(query)}&type=${type}`);
     const data = await res.json();
     const results = data.results || [];
+    showIncompleteResultsBanner('parse-warnings-host', data.warnings);
 
     loading.style.display = 'none';
     countEl.style.display = 'block';

--- a/templates/workspace.html
+++ b/templates/workspace.html
@@ -30,6 +30,8 @@
     </div>
   </div>
 
+  <div id="parse-warnings-host"></div>
+
   <!-- Project info -->
   <div class="project-info card" style="margin-bottom:1.5rem">
     <h2 id="project-name">Loading...</h2>
@@ -67,6 +69,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const wsInfo = await wsRes.json();
     const data = await tabsRes.json();
     allTabs = data.tabs || [];
+    showIncompleteResultsBanner('parse-warnings-host', data.warnings);
 
     const projectName = wsInfo.name || WORKSPACE_ID;
     document.getElementById('project-name').textContent = projectName;

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -14,12 +14,14 @@ class TestListWorkspaces:
         response = client.get("/api/workspaces")
         assert response.status_code == 200
         body = response.get_json()
-        assert isinstance(body, list)
+        assert isinstance(body, dict)
+        projects = body["projects"]
+        assert isinstance(projects, list)
 
-        ids = [p["id"] for p in body]
+        ids = [p["id"] for p in projects]
         assert HAPPY_WORKSPACE_ID in ids, f"expected {HAPPY_WORKSPACE_ID} in {ids}"
 
-        ws = next(p for p in body if p["id"] == HAPPY_WORKSPACE_ID)
+        ws = next(p for p in projects if p["id"] == HAPPY_WORKSPACE_ID)
         assert "name" in ws
         assert "conversationCount" in ws and isinstance(ws["conversationCount"], int)
         assert "lastModified" in ws and "T" in ws["lastModified"]
@@ -27,7 +29,7 @@ class TestListWorkspaces:
     def test_empty_storage_returns_empty_list(self, empty_workspace_client):
         response = empty_workspace_client.get("/api/workspaces")
         assert response.status_code == 200
-        assert response.get_json() == []
+        assert response.get_json() == {"projects": []}
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +171,7 @@ class TestExclusionRules:
         response = excluded_client.get("/api/workspaces")
         assert response.status_code == 200
         body = response.get_json()
-        ids = [w["id"] for w in body]
+        ids = [w["id"] for w in body["projects"]]
         assert HAPPY_WORKSPACE_ID not in ids, (
             f"exclusion rule did not filter {HAPPY_WORKSPACE_ID}; got {ids}"
         )
@@ -182,7 +184,7 @@ class TestExclusionRules:
         response = kept_client.get("/api/workspaces")
         assert response.status_code == 200
         body = response.get_json()
-        ids = [w["id"] for w in body]
+        ids = [w["id"] for w in body["projects"]]
         assert HAPPY_WORKSPACE_ID in ids, (
             f"non-matching rule filtered the workspace; got {ids}"
         )

--- a/tests/test_parse_failure_logging.py
+++ b/tests/test_parse_failure_logging.py
@@ -34,6 +34,7 @@ def _seed_listing_with_drifted_composer(parent: str) -> str:
 
     conn = sqlite3.connect(os.path.join(global_root, "state.vscdb"))
     conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+    # Missing createdAt — Composer.from_dict raises SchemaError.
     conn.execute(
         "INSERT INTO cursorDiskKV VALUES (?, ?)",
         (
@@ -61,8 +62,10 @@ def _seed_tabs_with_drifted_bubble(parent: str) -> str:
 
     ws_dir = os.path.join(ws_root, "ws-a")
     os.makedirs(ws_dir, exist_ok=True)
+    proj_dir = os.path.join(ws_dir, "proj")
+    os.makedirs(proj_dir, exist_ok=True)
     with open(os.path.join(ws_dir, "workspace.json"), "w", encoding="utf-8") as f:
-        json.dump({"folder": "/tmp/proj"}, f)
+        json.dump({"folder": f"file://{proj_dir}"}, f)
     sqlite3.connect(os.path.join(ws_dir, "state.vscdb")).close()
 
     conn = sqlite3.connect(os.path.join(global_root, "state.vscdb"))
@@ -82,6 +85,7 @@ def _seed_tabs_with_drifted_bubble(parent: str) -> str:
             }),
         ),
     )
+    # Non-dict bubble value trips Bubble.from_dict schema gate.
     conn.execute(
         "INSERT INTO cursorDiskKV VALUES (?, ?)",
         ("bubbleId:cmp-ok:b-bad", json.dumps("not-a-dict")),
@@ -126,9 +130,9 @@ class TestParseFailureLogging(unittest.TestCase):
                 conn.commit()
             with self.assertLogs("services.workspace_tabs", level="WARNING") as cm:
                 with app.test_request_context("/api/workspaces/global/tabs"):
-                    payload, status = assemble_workspace_tabs("global", ws_root, rules=[])
+                    _payload, _status = assemble_workspace_tabs("global", ws_root, rules=[])
 
-        self.assertEqual(status, 200)
+        self.assertEqual(_status, 200)
         messages = [r.getMessage() for r in cm.records]
         self.assertTrue(
             any("decode Bubble" in m and "b-json" in m for m in messages),
@@ -156,9 +160,9 @@ class TestParseFailureLogging(unittest.TestCase):
                 conn.commit()
             with self.assertLogs("services.workspace_tabs", level="WARNING") as cm:
                 with app.test_request_context("/api/workspaces/global/tabs"):
-                    payload, status = assemble_workspace_tabs("global", ws_root, rules=[])
+                    _payload, _status = assemble_workspace_tabs("global", ws_root, rules=[])
 
-        self.assertEqual(status, 200)
+        self.assertEqual(_status, 200)
         messages = [r.getMessage() for r in cm.records]
         self.assertTrue(
             any("decode Composer" in m and "cmp-json" in m for m in messages),

--- a/tests/test_parse_failure_logging.py
+++ b/tests/test_parse_failure_logging.py
@@ -34,7 +34,6 @@ def _seed_listing_with_drifted_composer(parent: str) -> str:
 
     conn = sqlite3.connect(os.path.join(global_root, "state.vscdb"))
     conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
-    # Missing createdAt — Composer.from_dict raises SchemaError.
     conn.execute(
         "INSERT INTO cursorDiskKV VALUES (?, ?)",
         (
@@ -85,7 +84,6 @@ def _seed_tabs_with_drifted_bubble(parent: str) -> str:
             }),
         ),
     )
-    # Non-dict bubble value trips Bubble.from_dict schema gate.
     conn.execute(
         "INSERT INTO cursorDiskKV VALUES (?, ?)",
         ("bubbleId:cmp-ok:b-bad", json.dumps("not-a-dict")),

--- a/tests/test_parse_warnings.py
+++ b/tests/test_parse_warnings.py
@@ -246,7 +246,7 @@ class TestApiParseWarnings(unittest.TestCase):
         self.app.config["TESTING"] = True
         self.client = self.app.test_client()
 
-    def test_workspaces_api_array_when_clean(self) -> None:
+    def test_workspaces_api_object_when_clean(self) -> None:
         tmp = tempfile.mkdtemp()
         try:
             ws_root = _seed_clean_workspace(tmp)
@@ -258,7 +258,9 @@ class TestApiParseWarnings(unittest.TestCase):
 
         self.assertEqual(res.status_code, 200)
         data = res.get_json()
-        self.assertIsInstance(data, list)
+        self.assertIsInstance(data, dict)
+        self.assertIn("projects", data)
+        self.assertNotIn("warnings", data)
 
     def test_workspaces_api_object_when_warnings(self) -> None:
         tmp = tempfile.mkdtemp()

--- a/tests/test_parse_warnings.py
+++ b/tests/test_parse_warnings.py
@@ -1,0 +1,289 @@
+"""Incomplete-result signaling when parse failures occur (issue #67)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from app import create_app
+from models.parse_warnings import ParseWarningCollector
+from services.workspace_listing import list_workspace_projects
+from services.workspace_tabs import assemble_workspace_tabs
+
+
+def _seed_clean_workspace(parent: str) -> str:
+    ws_root = os.path.join(parent, "workspaceStorage")
+    global_root = os.path.join(parent, "globalStorage")
+    os.makedirs(ws_root, exist_ok=True)
+    os.makedirs(global_root, exist_ok=True)
+
+    ws_dir = os.path.join(ws_root, "ws-clean")
+    os.makedirs(ws_dir, exist_ok=True)
+    target = os.path.join(parent, "proj")
+    os.makedirs(target, exist_ok=True)
+    with open(os.path.join(ws_dir, "workspace.json"), "w", encoding="utf-8") as f:
+        json.dump({"folder": f"file://{target}"}, f)
+    sqlite3.connect(os.path.join(ws_dir, "state.vscdb")).close()
+
+    with sqlite3.connect(os.path.join(global_root, "state.vscdb")) as conn:
+        conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+        conn.execute(
+            "INSERT INTO cursorDiskKV VALUES (?, ?)",
+            (
+                "composerData:cmp-ok",
+                json.dumps({
+                    "name": "Good chat",
+                    "createdAt": 1_715_000_000_000,
+                    "lastUpdatedAt": 1_715_000_500_000,
+                    "fullConversationHeadersOnly": [{"bubbleId": "b-1"}],
+                }),
+            ),
+        )
+        conn.execute(
+            "INSERT INTO cursorDiskKV VALUES (?, ?)",
+            ("bubbleId:cmp-ok:b-1", json.dumps({"text": "hello", "type": 1})),
+        )
+        conn.commit()
+    return ws_root
+
+
+def _seed_listing_with_drift(parent: str) -> str:
+    ws_root = os.path.join(parent, "workspaceStorage")
+    global_root = os.path.join(parent, "globalStorage")
+    os.makedirs(ws_root, exist_ok=True)
+    os.makedirs(global_root, exist_ok=True)
+
+    ws_dir = os.path.join(ws_root, "ws-a")
+    os.makedirs(ws_dir, exist_ok=True)
+    target = os.path.join(parent, "real-project")
+    os.makedirs(target, exist_ok=True)
+    with open(os.path.join(ws_dir, "workspace.json"), "w", encoding="utf-8") as f:
+        json.dump({"folder": f"file://{target}"}, f)
+    sqlite3.connect(os.path.join(ws_dir, "state.vscdb")).close()
+
+    with sqlite3.connect(os.path.join(global_root, "state.vscdb")) as conn:
+        conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+        conn.execute(
+            "INSERT INTO cursorDiskKV VALUES (?, ?)",
+            (
+                "composerData:cmp-drift",
+                json.dumps({
+                    "name": "Drifted composer",
+                    "fullConversationHeadersOnly": [{"bubbleId": "b-1"}],
+                }),
+            ),
+        )
+        conn.execute(
+            "INSERT INTO cursorDiskKV VALUES (?, ?)",
+            ("bubbleId:cmp-drift:b-1", json.dumps({"type": "user", "text": "hello"})),
+        )
+        conn.commit()
+    return ws_root
+
+
+class TestParseWarningCollector(unittest.TestCase):
+    def test_clean_collector_emits_no_warnings(self) -> None:
+        collector = ParseWarningCollector()
+        self.assertFalse(collector.has_warnings)
+        self.assertEqual(collector.to_api_list(), [])
+
+    def test_collector_emits_structured_warnings(self) -> None:
+        collector = ParseWarningCollector()
+        collector.record_composer_skipped(2)
+        collector.record_bubble_skipped(1)
+        warnings = collector.to_api_list()
+        self.assertEqual(len(warnings), 2)
+        self.assertEqual(warnings[0]["type"], "parse_error")
+        self.assertEqual(warnings[0]["count"], 2)
+        self.assertIn("conversation", warnings[0]["detail"])
+        self.assertEqual(warnings[1]["count"], 1)
+        self.assertIn("message", warnings[1]["detail"])
+
+
+class TestServiceParseWarnings(unittest.TestCase):
+    def test_listing_clean_results_have_no_warnings(self) -> None:
+        tmp = tempfile.mkdtemp()
+        try:
+            ws_root = _seed_clean_workspace(tmp)
+            with patch("services.workspace_listing.list_cli_projects", return_value=[]):
+                projects, warnings = list_workspace_projects(ws_root, rules=[])
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+        self.assertTrue(any(p.get("conversationCount", 0) > 0 for p in projects))
+        self.assertEqual(warnings, [])
+
+    def test_listing_schema_drift_emits_warning_without_project(self) -> None:
+        tmp = tempfile.mkdtemp()
+        try:
+            ws_root = _seed_listing_with_drift(tmp)
+            with patch("services.workspace_listing.list_cli_projects", return_value=[]):
+                projects, warnings = list_workspace_projects(ws_root, rules=[])
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0]["type"], "parse_error")
+        self.assertEqual(warnings[0]["count"], 1)
+        self.assertFalse(any(p.get("conversationCount", 0) > 0 for p in projects))
+
+    def test_listing_warnings_when_decode_fails(self) -> None:
+        tmp = tempfile.mkdtemp()
+        try:
+            ws_root = _seed_clean_workspace(tmp)
+            global_db = os.path.join(tmp, "globalStorage", "state.vscdb")
+            with sqlite3.connect(global_db) as conn:
+                conn.execute(
+                    "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+                    ("composerData:cmp-bad-json", '{"broken":1'),
+                )
+                conn.commit()
+            with patch("services.workspace_listing.list_cli_projects", return_value=[]):
+                _projects, warnings = list_workspace_projects(ws_root, rules=[])
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0]["type"], "parse_error")
+        self.assertEqual(warnings[0]["count"], 1)
+
+    def test_tabs_clean_results_have_no_warnings(self) -> None:
+        tmp = tempfile.mkdtemp()
+        try:
+            ws_dir = os.path.join(tmp, "workspaceStorage")
+            global_dir = os.path.join(tmp, "globalStorage")
+            os.makedirs(ws_dir)
+            os.makedirs(global_dir)
+            db_path = os.path.join(global_dir, "state.vscdb")
+            with sqlite3.connect(db_path) as conn:
+                conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+                conn.execute(
+                    "INSERT INTO cursorDiskKV VALUES (?, ?)",
+                    (
+                        "composerData:cmp-ok",
+                        json.dumps({
+                            "name": "Clean tab",
+                            "createdAt": 1_715_000_000_000,
+                            "fullConversationHeadersOnly": [{"bubbleId": "b-ok", "type": 1}],
+                        }),
+                    ),
+                )
+                conn.execute(
+                    "INSERT INTO cursorDiskKV VALUES (?, ?)",
+                    ("bubbleId:cmp-ok:b-ok", json.dumps({"text": "hello", "type": 1})),
+                )
+                conn.commit()
+            payload, status = assemble_workspace_tabs("global", ws_dir, rules=[])
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+        self.assertEqual(status, 200)
+        self.assertNotIn("warnings", payload)
+        self.assertEqual(len(payload.get("tabs", [])), 1)
+
+    def test_tabs_reports_bubble_and_composer_parse_failures(self) -> None:
+        tmp = tempfile.mkdtemp()
+        try:
+            ws_root = os.path.join(tmp, "workspaceStorage")
+            global_root = os.path.join(tmp, "globalStorage")
+            os.makedirs(ws_root)
+            os.makedirs(global_root)
+            with sqlite3.connect(os.path.join(global_root, "state.vscdb")) as conn:
+                conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+                conn.execute(
+                    "INSERT INTO cursorDiskKV VALUES (?, ?)",
+                    (
+                        "composerData:cmp-ok",
+                        json.dumps({
+                            "name": "Tab",
+                            "createdAt": 1_715_000_000_000,
+                            "fullConversationHeadersOnly": [
+                                {"bubbleId": "b-bad", "type": 1},
+                                {"bubbleId": "b-good", "type": 1},
+                            ],
+                        }),
+                    ),
+                )
+                conn.execute(
+                    "INSERT INTO cursorDiskKV VALUES (?, ?)",
+                    ("bubbleId:cmp-ok:b-bad", json.dumps("not-a-dict")),
+                )
+                conn.execute(
+                    "INSERT INTO cursorDiskKV VALUES (?, ?)",
+                    ("bubbleId:cmp-ok:b-good", json.dumps({"text": "hi"})),
+                )
+                conn.execute(
+                    "INSERT INTO cursorDiskKV VALUES (?, ?)",
+                    ("composerData:cmp-bad", "{broken"),
+                )
+                conn.commit()
+            payload, status = assemble_workspace_tabs("global", ws_root, rules=[])
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+        self.assertEqual(status, 200)
+        self.assertIn("warnings", payload)
+        types = {w["type"] for w in payload["warnings"]}
+        self.assertEqual(types, {"parse_error"})
+        counts = {w["count"] for w in payload["warnings"]}
+        self.assertIn(1, counts)
+        self.assertTrue(any(w["count"] >= 1 for w in payload["warnings"]))
+
+
+class TestApiParseWarnings(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app = create_app()
+        self.app.config["TESTING"] = True
+        self.client = self.app.test_client()
+
+    def test_workspaces_api_array_when_clean(self) -> None:
+        tmp = tempfile.mkdtemp()
+        try:
+            ws_root = _seed_clean_workspace(tmp)
+            with patch("api.workspaces.resolve_workspace_path", return_value=ws_root), \
+                 patch("services.workspace_listing.list_cli_projects", return_value=[]):
+                res = self.client.get("/api/workspaces")
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+        self.assertEqual(res.status_code, 200)
+        data = res.get_json()
+        self.assertIsInstance(data, list)
+
+    def test_workspaces_api_object_when_warnings(self) -> None:
+        tmp = tempfile.mkdtemp()
+        try:
+            ws_root = _seed_clean_workspace(tmp)
+            global_db = os.path.join(tmp, "globalStorage", "state.vscdb")
+            with sqlite3.connect(global_db) as conn:
+                conn.execute(
+                    "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+                    ("composerData:cmp-bad-json", '{"broken":1'),
+                )
+                conn.commit()
+            with patch("api.workspaces.resolve_workspace_path", return_value=ws_root), \
+                 patch("services.workspace_listing.list_cli_projects", return_value=[]):
+                res = self.client.get("/api/workspaces")
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+        self.assertEqual(res.status_code, 200)
+        data = res.get_json()
+        self.assertIsInstance(data, dict)
+        self.assertIn("projects", data)
+        self.assertIn("warnings", data)
+        self.assertEqual(data["warnings"][0]["type"], "parse_error")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_layouts_dict_shape.py
+++ b/tests/test_project_layouts_dict_shape.py
@@ -67,7 +67,7 @@ def _make_workspace_storage(parent: str, *, layout_as_dict: bool) -> str:
 
 class TestProjectLayoutsDictShape(unittest.TestCase):
     def _assert_assigned_to_workspace(self, ws_root: str) -> None:
-        projects = list_workspace_projects(ws_root, rules=[])
+        projects, _warnings = list_workspace_projects(ws_root, rules=[])
         ids = [p["id"] for p in projects]
         self.assertIn("ws-a", ids, msg=f"expected composer routed to ws-a, got {ids}")
 

--- a/tests/test_workspace_listing_cli.py
+++ b/tests/test_workspace_listing_cli.py
@@ -28,7 +28,7 @@ class TestMalformedCliSessionSkipped(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp, \
              patch("services.workspace_listing.list_cli_projects", return_value=[cli_project]):
-            projects = list_workspace_projects(tmp, rules=[])
+            projects, _warnings = list_workspace_projects(tmp, rules=[])
 
         cli_entries = [p for p in projects if p.get("source") == "cli"]
         self.assertEqual(len(cli_entries), 1, msg=f"expected one CLI project, got {cli_entries}")
@@ -52,7 +52,7 @@ class TestMalformedCliProjectRecordSkipped(unittest.TestCase):
         ]
         with tempfile.TemporaryDirectory() as tmp, \
              patch("services.workspace_listing.list_cli_projects", return_value=garbage_then_real):
-            projects = list_workspace_projects(tmp, rules=[])
+            projects, _warnings = list_workspace_projects(tmp, rules=[])
 
         cli_entries = [p for p in projects if p.get("source") == "cli"]
         self.assertEqual(len(cli_entries), 1)
@@ -67,7 +67,7 @@ class TestMalformedCliProjectRecordSkipped(unittest.TestCase):
         ]
         with tempfile.TemporaryDirectory() as tmp, \
              patch("services.workspace_listing.list_cli_projects", return_value=bad):
-            projects = list_workspace_projects(tmp, rules=[])
+            projects, _warnings = list_workspace_projects(tmp, rules=[])
 
         cli_entries = [p for p in projects if p.get("source") == "cli"]
         self.assertEqual([p["id"] for p in cli_entries], ["cli:ok"])
@@ -82,7 +82,7 @@ class TestMalformedCliProjectRecordSkipped(unittest.TestCase):
         }]
         with tempfile.TemporaryDirectory() as tmp, \
              patch("services.workspace_listing.list_cli_projects", return_value=minimal):
-            projects = list_workspace_projects(tmp, rules=[])
+            projects, _warnings = list_workspace_projects(tmp, rules=[])
 
         cli_entries = [p for p in projects if p.get("source") == "cli"]
         self.assertEqual(len(cli_entries), 1)

--- a/tests/test_workspace_listing_sql_errors.py
+++ b/tests/test_workspace_listing_sql_errors.py
@@ -39,7 +39,7 @@ class TestListingCursorDiskKvCorruptDoesNotRaise(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             ws_root = _seed_corrupt_global_db(tmp)
             try:
-                projects = list_workspace_projects(ws_root, rules=[])
+                projects, _warnings = list_workspace_projects(ws_root, rules=[])
             except sqlite3.Error:
                 self.fail("sqlite3.Error should be caught inside _safe_fetchall")
 

--- a/tests/test_workspace_tabs_null_bubble.py
+++ b/tests/test_workspace_tabs_null_bubble.py
@@ -70,23 +70,17 @@ class TestNullBubbleValueDoesNotCrashTabs(unittest.TestCase):
         self.tmp.cleanup()
 
     def test_null_bubble_row_is_skipped_without_exception(self):
-        """assemble_workspace_tabs must not raise when a bubble row has NULL value."""
+        """assemble_workspace_tabs must not raise when a NULL bubble row exists in KV."""
         try:
-            with self.assertLogs("services.workspace_tabs", level="WARNING") as cm:
-                _payload, status = assemble_workspace_tabs(
-                    workspace_id="global",
-                    workspace_path=self.workspace_path,
-                    rules=[],
-                )
+            payload, status = assemble_workspace_tabs(
+                workspace_id="global",
+                workspace_path=self.workspace_path,
+                rules=[],
+            )
         except TypeError as exc:
             self.fail(f"NULL bubble row raised TypeError: {exc}")
 
         self.assertEqual(status, 200, "NULL bubble row must not turn tabs load into an error response")
-        messages = [r.getMessage() for r in cm.records]
-        self.assertTrue(
-            any("NULL value" in m and "bubble-null" in m for m in messages),
-            f"expected NULL-value warning for bubble-null row, got: {messages}",
-        )
 
     def test_healthy_bubbles_still_load_when_null_row_present(self):
         """The healthy bubble surfaces in a tab even when a NULL row is present."""

--- a/tests/web-ui-smoke.sh
+++ b/tests/web-ui-smoke.sh
@@ -109,7 +109,8 @@ probe "/api/search (no q -> 400)" "/api/search"             400
 if WS_ID=$(curl "${CURL_FLAGS[@]}" "$BASE/api/workspaces" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
-for w in data:
+projects = data if isinstance(data, list) else data.get("projects", [])
+for w in projects:
     if w.get('id') and w['id'] != 'global':
         print(w['id'])
         break


### PR DESCRIPTION
## Summary

When composer or bubble rows fail JSON/schema parsing, the app previously returned a shorter list with no indication that data was dropped. This change adds structured `warnings` metadata on the primary browse/search APIs and shows a banner in the web UI when results may be incomplete.

- Introduce `ParseWarningCollector` in `models/parse_warnings.py` to aggregate skipped composers and bubbles into API warnings (`type: parse_error`, `count`, `detail`).
- Return `(projects, warnings)` from `list_workspace_projects`; attach `warnings` to tabs payloads in `assemble_workspace_tabs` when any parse failures occurred.
- Expose warnings from `GET /api/workspaces`, `GET /api/workspaces/<id>/tabs`, and `GET /api/search` (global `cursorDiskKV` path).
- Keep backward compatibility: `GET /api/workspaces` still returns a JSON array when there are no warnings; when warnings exist, the response is `{ projects: [...], warnings: [...] }`.
- Web UI: `normalizeWorkspacesResponse()`, `showIncompleteResultsBanner()`, and `.alert-warning` styling on Projects, Workspace, and Search pages.

Closes #67.

## Test plan

- [x] `pytest tests/test_parse_warnings.py` — clean results (no `warnings`), parse failures (`warnings` present), service + API shapes
- [x] Full suite: `pytest tests/` (315 passed locally)
- [ ] Manual: corrupt a `composerData:` row in global storage → Projects page shows warning banner; workspace tabs/search show banner when applicable
- [ ] Manual: healthy data → no banner; `GET /api/workspaces` returns a plain array

## Notes

- Warnings are opt-in for API clients; clients that ignore `warnings` behave as before.
- Parse failures continue to be logged at WARNING (issue #66 pattern); this PR adds user-visible signaling on top of that logging.
- Follow-up (optional): wire `load_bubble_map()` skips in workspace listing into the collector so bubble-only failures on the project list also emit `warnings`.

## Dependencies / lockfile

**Base branch:** `feat/replace-print-with-logging` (stacked after #66 / #68).

This PR does **not** change `requirements-lock.txt`. The `click==8.4.0` → `8.4.1` pin (Flask transitive) lives in [PR #76](https://github.com/cppalliance/cppa-cursor-browser/pull/76) as commit `d55881f`: Linux CI `pip-compile` now resolves `click==8.4.1` within the Flask bound, and the lock freshness check failed while the file still pinned `8.4.0`. That is a routine lock refresh for CI, not required for parse-warning behavior. Dependabot also tracks `click` separately (`dependabot/pip/click-8.4.1`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collect and return structured parse/process warnings with workspace and search results.

* **Bug Fixes**
  * Consistent logging for export and PDF failures; API responses now return generic failure messages on server errors.
  * Workspace/tab listing continues past malformed entries and reports skips/failures.

* **UI/UX**
  * Warning banners show on Projects, Search, and Workspace pages for incomplete results.

* **Tests**
  * End-to-end tests added/updated to cover parse-warning reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/cppa-cursor-browser/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->