### PR TITLE
test: add PDF export endpoint coverage and run in CI (closes #72)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,12 +111,10 @@ jobs:
         run: python -m unittest discover tests -v
 
       - name: Run pytest integration suite
-        # Pytest fixtures (tests/conftest.py) build a temp workspaceStorage
-        # and exercise the Flask routes via app.test_client(). Scoped to the
-        # new endpoint file because `pytest tests/` would also re-collect the
-        # 178 unittest.TestCase subclasses already run in the step above —
-        # ~2× the CI minutes for zero extra signal.
-        run: python -m pytest tests/test_api_endpoints.py -v --tb=short
+        # Pytest fixtures (tests/conftest.py) build a temp workspaceStorage and
+        # exercise Flask routes via app.test_client(). Only listed files — not
+        # `pytest tests/` — to avoid re-collecting unittest.TestCase classes above.
+        run: python -m pytest tests/test_api_endpoints.py tests/test_pdf_export.py -v --tb=short
 
       # ── PyInstaller desktop build (Windows only, once per workflow) ────────
       # Closes #44. Builds the onedir bundle and smoke-tests --help so the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,15 @@ def workspace_storage() -> Generator[str, None, None]:
 
 
 @pytest.fixture
+def pdf_client():
+    """Flask test client for routes that do not read workspace storage (e.g. PDF export)."""
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["EXCLUSION_RULES"] = []
+    return app.test_client()
+
+
+@pytest.fixture
 def client(workspace_storage: str):
     """Flask test client bound to the temp workspace_storage fixture."""
     app = create_app()

--- a/tests/test_pdf_export.py
+++ b/tests/test_pdf_export.py
@@ -1,13 +1,20 @@
-"""Unit tests for POST /api/generate-pdf (api/pdf.py)."""
+"""Unit tests for POST /api/generate-pdf (api/pdf.py). Closes #72."""
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 PDF_MAGIC = b"%PDF-"
 
 
-def _post_pdf(client, *, markdown: str = "", title: str = "Chat", json_data=None):
+def _post_pdf(
+    client,
+    *,
+    markdown: str = "",
+    title: str = "Chat",
+    json_data: dict[str, Any] | None = None,
+):
     if json_data is not None:
         return client.post(
             "/api/generate-pdf",
@@ -32,7 +39,7 @@ def _assert_pdf_response(response) -> None:
 
 
 class TestGeneratePdfHappyPath:
-    def test_normal_conversation_markdown(self, client):
+    def test_normal_conversation_markdown(self, pdf_client):
         md = """# Chat export
 
 ## User question
@@ -49,50 +56,70 @@ def fact(n):
 
 ---
 """
-        response = _post_pdf(client, markdown=md, title="Happy conversation")
+        response = _post_pdf(pdf_client, markdown=md, title="Happy conversation")
         _assert_pdf_response(response)
         assert (
             'attachment; filename="Happy conversation.pdf"'
             in response.headers.get("Content-Disposition", "")
         )
 
+    def test_empty_json_body_uses_defaults(self, pdf_client):
+        response = _post_pdf(pdf_client, json_data={})
+        _assert_pdf_response(response)
+        assert (
+            'attachment; filename="Chat.pdf"'
+            in response.headers.get("Content-Disposition", "")
+        )
+
+    def test_unsafe_title_characters_sanitized_in_filename(self, pdf_client):
+        response = _post_pdf(
+            pdf_client,
+            markdown="Hello",
+            title='bad<>:"/\\|?*name',
+        )
+        _assert_pdf_response(response)
+        assert (
+            'attachment; filename="bad_________name.pdf"'
+            in response.headers.get("Content-Disposition", "")
+        )
+
 
 class TestGeneratePdfEdgeCases:
-    def test_empty_markdown(self, client):
-        response = _post_pdf(client, markdown="", title="Empty chat")
+    def test_empty_markdown(self, pdf_client):
+        response = _post_pdf(pdf_client, markdown="", title="Empty chat")
         _assert_pdf_response(response)
 
-    def test_very_long_content(self, client):
+    def test_very_long_content(self, pdf_client):
         line = "This is a repeated paragraph for length testing. " * 20
         md = "\n".join(f"Line {i}: {line}" for i in range(500))
-        response = _post_pdf(client, markdown=md, title="Long chat")
+        response = _post_pdf(pdf_client, markdown=md, title="Long chat")
         _assert_pdf_response(response)
 
-    def test_unicode_and_emoji_content(self, client):
+    def test_unicode_and_emoji_content(self, pdf_client):
         md = (
             "Smart quotes: “hello” and ’world’\n"
             "Emoji: 🚀🔥 should not break PDF\n"
             "Bullet • point\n"
         )
-        response = _post_pdf(client, markdown=md, title="Unicode chat")
+        response = _post_pdf(pdf_client, markdown=md, title="Unicode chat")
         _assert_pdf_response(response)
 
 
 class TestGeneratePdfErrors:
-    def test_pdf_engine_failure_returns_500(self, client):
+    def test_pdf_engine_failure_returns_500(self, pdf_client):
         with patch(
             "fpdf.fpdf.FPDF.output",
             side_effect=RuntimeError("simulated failure"),
         ):
-            response = _post_pdf(client, markdown="Hello", title="Fail")
+            response = _post_pdf(pdf_client, markdown="Hello", title="Fail")
         assert response.status_code == 500
         assert response.get_json() == {"error": "Failed to generate PDF"}
 
-    def test_invalid_export_payload_returns_500(self, client):
+    def test_invalid_export_payload_returns_500(self, pdf_client):
         # Conversation IDs are resolved client-side (tabs API) before markdown is
         # POSTed here. A non-string markdown field mimics a corrupted export request.
         response = _post_pdf(
-            client,
+            pdf_client,
             json_data={"markdown": ["not", "a", "string"], "title": "Bad payload"},
         )
         assert response.status_code == 500

--- a/tests/test_pdf_export.py
+++ b/tests/test_pdf_export.py
@@ -1,0 +1,99 @@
+"""Unit tests for POST /api/generate-pdf (api/pdf.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+PDF_MAGIC = b"%PDF-"
+
+
+def _post_pdf(client, *, markdown: str = "", title: str = "Chat", json_data=None):
+    if json_data is not None:
+        return client.post(
+            "/api/generate-pdf",
+            json=json_data,
+            content_type="application/json",
+        )
+    return client.post(
+        "/api/generate-pdf",
+        json={"markdown": markdown, "title": title},
+        content_type="application/json",
+    )
+
+
+def _assert_pdf_response(response) -> None:
+    assert response.status_code == 200
+    assert response.content_type.startswith("application/pdf")
+    data = response.data
+    assert len(data) > 0
+    assert data.startswith(PDF_MAGIC)
+    # Trailing %%EOF is a minimal structural check (see tests/web-ui-qa-checklist.md).
+    assert b"%%EOF" in data[-1024:]
+
+
+class TestGeneratePdfHappyPath:
+    def test_normal_conversation_markdown(self, client):
+        md = """# Chat export
+
+## User question
+
+Please explain **recursion** in Python.
+
+- Base case
+- Recursive step
+
+```python
+def fact(n):
+    return 1 if n < 2 else n * fact(n - 1)
+```
+
+---
+"""
+        response = _post_pdf(client, markdown=md, title="Happy conversation")
+        _assert_pdf_response(response)
+        assert (
+            'attachment; filename="Happy conversation.pdf"'
+            in response.headers.get("Content-Disposition", "")
+        )
+
+
+class TestGeneratePdfEdgeCases:
+    def test_empty_markdown(self, client):
+        response = _post_pdf(client, markdown="", title="Empty chat")
+        _assert_pdf_response(response)
+
+    def test_very_long_content(self, client):
+        line = "This is a repeated paragraph for length testing. " * 20
+        md = "\n".join(f"Line {i}: {line}" for i in range(500))
+        response = _post_pdf(client, markdown=md, title="Long chat")
+        _assert_pdf_response(response)
+
+    def test_unicode_and_emoji_content(self, client):
+        md = (
+            "Smart quotes: “hello” and ’world’\n"
+            "Emoji: 🚀🔥 should not break PDF\n"
+            "Bullet • point\n"
+        )
+        response = _post_pdf(client, markdown=md, title="Unicode chat")
+        _assert_pdf_response(response)
+
+
+class TestGeneratePdfErrors:
+    def test_pdf_engine_failure_returns_500(self, client):
+        with patch(
+            "fpdf.fpdf.FPDF.output",
+            side_effect=RuntimeError("simulated failure"),
+        ):
+            response = _post_pdf(client, markdown="Hello", title="Fail")
+        assert response.status_code == 500
+        assert response.get_json() == {"error": "Failed to generate PDF"}
+
+    def test_invalid_export_payload_returns_500(self, client):
+        # Conversation IDs are resolved client-side (tabs API) before markdown is
+        # POSTed here. A non-string markdown field mimics a corrupted export request.
+        response = _post_pdf(
+            client,
+            json_data={"markdown": ["not", "a", "string"], "title": "Bad payload"},
+        )
+        assert response.status_code == 500
+        assert response.get_json() == {"error": "Failed to generate PDF"}


### PR DESCRIPTION
## Summary

- Add `tests/test_pdf_export.py` with 8 Flask test-client cases for `POST /api/generate-pdf`: normal markdown export, empty body defaults, unsafe title filename sanitization, empty markdown, long content, Unicode/emoji, simulated PDF engine failure (500), and malformed `markdown` payload (500).
- Add a lightweight `pdf_client` fixture in `conftest.py` so PDF tests do not need the full `workspace_storage` setup.
- Include `tests/test_pdf_export.py` in the CI pytest step so the new tests actually run in the matrix (previously only `test_api_endpoints.py` was executed).

Closes #72.

**API note:** The PDF route accepts `{ markdown, title }` from the browser after client-side markdown conversion (`download.js`). It does not look up conversations by ID on the server; invalid tab IDs are handled by `/api/workspaces/.../tabs` (covered in `test_api_endpoints.py`). Server-side error coverage uses a mocked `FPDF.output` failure and a non-string `markdown` field.

## Test plan

- [x] `python -m pytest tests/test_pdf_export.py tests/test_api_endpoints.py -v`
- [x] `python -m pytest tests/ -q` (full suite)
- [ ] CI green on PR (ubuntu/windows/macos × Python 3.10–3.13)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for PDF export endpoint covering normal operation, edge cases (empty content, long content, unicode/emoji), and error handling scenarios.

* **Chores**
  * Updated test automation workflow to include PDF export tests in CI pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/cppa-cursor-browser/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->