### PR TITLE
docs: add CHANGELOG.md and versioning policy (closes #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional exclusion rules for sensitive projects and chats (#1, #2)
 - Full-text search with workspace and log-type filters (#63)
 - Hypothesis property-based tests for blob and bubble parsing (#71, #81)
-- PDF export endpoint coverage in CI (#72, #82)
+- PDF export endpoint coverage in CI (#72)
 
 ### Changed
 - Extract shared `from_dict` validation helpers for model classes, reducing duplication (#70, #80)
@@ -36,6 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add incomplete-result signaling on parse failure so callers can distinguish partial vs. complete data (#67, #78)
 - Replace `print()` error output with structured logging throughout (#68, #77)
 - Replace silent `except Exception: pass` with structured logging in workspace and bubble load paths (#66, #76)
-- Rename `_`-prefixed internal functions to public names to satisfy strict linters (#82)
+- Decouple API handlers from private `_`-prefixed service internals (#73)
 
 [Unreleased]: https://github.com/cppalliance/cppa-cursor-browser/commits/HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Hypothesis property-based tests for blob and bubble parsing (#71, #82)
+- PDF export endpoint coverage in CI (#72, #82)
+
+### Changed
+- Extract shared `from_dict` validation helpers for model classes, reducing duplication (#70, #80)
+- Enable mypy `strict-optional` and fix nullability gaps across the codebase (#69, #79)
+
+### Fixed
+- Add incomplete-result signaling on parse failure so callers can distinguish partial vs. complete data (#67, #78)
+- Replace `print()` error output with structured logging throughout (#68, #77)
+- Replace silent `except Exception: pass` with structured logging in workspace and bubble load paths (#66, #76)
+- Rename `_`-prefixed internal functions to public names to satisfy strict linters (#82)
+
+## [0.1.0] - 2026-05-21
+
+### Added
+- **Web UI** — browse and search all Cursor AI workspaces; conversation view with syntax-highlighted code blocks, dark/light mode, and bookmarkable chat URLs (#63)
+- **Export formats** — one-click export of chats as Markdown, HTML, PDF, JSON, and CSV from the web UI (#63)
+- **CLI export** (`cursor-chat-export` / `scripts/export.py`) — zip archive or individual Markdown files with YAML frontmatter; incremental mode (`--since last`) preserves state across runs (#63, #42, #61)
+- **Cursor CLI agent session support** — browse and export sessions stored in `~/.cursor/chats/` by the `cursor agent` CLI; gracefully degrades when the IDE database is absent (#7, #8, #63)
+- **Desktop app packaging** — Windows `.exe` via PyInstaller + pywebview; no Python installation required on the target machine (#63)
+- **Type-safe models** with schema validation at SQLite read boundaries (#24, #30)
+- **CI matrix** (Linux / macOS / Windows) running pytest, mypy, and gitleaks (#13, #19, #44, #62)
+- **Python packaging infrastructure** (`pyproject.toml` with hatchling, bounded dependency pins, `requirements-lock.txt`, Dependabot) (#45, #47, #49, #53)
+- Optional exclusion rules for sensitive projects and chats (#1, #2)
+- Full-text search with workspace and log-type filters (#63)
+
+### Fixed
+- Path traversal and symlink-escape protection on `/api/set-workspace` (#15, #22)
+- Disabled Werkzeug debug mode by default; opt-in via `--debug` / `FLASK_DEBUG=1` (#9, #20)
+- Sanitise Marked.js HTML output with DOMPurify (#11, #21)
+- Wrapped all production `sqlite3.connect()` calls in context managers (#17, #23)
+- Skip NULL bubble rows in workspace tabs loader (#50, #52)
+- Thread-unsafe `_workspace_path_override` race condition (#43, #54)
+- Normalise Windows-style paths on non-Windows hosts (#8)
+
+[Unreleased]: https://github.com/cppalliance/cppa-cursor-browser/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/cppalliance/cppa-cursor-browser/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Hypothesis property-based tests for blob and bubble parsing (#71, #82)
-- PDF export endpoint coverage in CI (#72, #82)
-
-### Changed
-- Extract shared `from_dict` validation helpers for model classes, reducing duplication (#70, #80)
-- Enable mypy `strict-optional` and fix nullability gaps across the codebase (#69, #79)
-
-### Fixed
-- Add incomplete-result signaling on parse failure so callers can distinguish partial vs. complete data (#67, #78)
-- Replace `print()` error output with structured logging throughout (#68, #77)
-- Replace silent `except Exception: pass` with structured logging in workspace and bubble load paths (#66, #76)
-- Rename `_`-prefixed internal functions to public names to satisfy strict linters (#82)
-
-## [0.1.0] - 2026-05-21
-
-### Added
 - **Web UI** — browse and search all Cursor AI workspaces; conversation view with syntax-highlighted code blocks, dark/light mode, and bookmarkable chat URLs (#63)
 - **Export formats** — one-click export of chats as Markdown, HTML, PDF, JSON, and CSV from the web UI (#63)
 - **CLI export** (`cursor-chat-export` / `scripts/export.py`) — zip archive or individual Markdown files with YAML frontmatter; incremental mode (`--since last`) preserves state across runs (#63, #42, #61)
@@ -34,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Python packaging infrastructure** (`pyproject.toml` with hatchling, bounded dependency pins, `requirements-lock.txt`, Dependabot) (#45, #47, #49, #53)
 - Optional exclusion rules for sensitive projects and chats (#1, #2)
 - Full-text search with workspace and log-type filters (#63)
+- Hypothesis property-based tests for blob and bubble parsing (#71, #81)
+- PDF export endpoint coverage in CI (#72, #82)
+
+### Changed
+- Extract shared `from_dict` validation helpers for model classes, reducing duplication (#70, #80)
+- Enable mypy `strict-optional` and fix nullability gaps across the codebase (#69, #79)
 
 ### Fixed
 - Path traversal and symlink-escape protection on `/api/set-workspace` (#15, #22)
@@ -43,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip NULL bubble rows in workspace tabs loader (#50, #52)
 - Thread-unsafe `_workspace_path_override` race condition (#43, #54)
 - Normalise Windows-style paths on non-Windows hosts (#8)
+- Add incomplete-result signaling on parse failure so callers can distinguish partial vs. complete data (#67, #78)
+- Replace `print()` error output with structured logging throughout (#68, #77)
+- Replace silent `except Exception: pass` with structured logging in workspace and bubble load paths (#66, #76)
+- Rename `_`-prefixed internal functions to public names to satisfy strict linters (#82)
 
-[Unreleased]: https://github.com/cppalliance/cppa-cursor-browser/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/cppalliance/cppa-cursor-browser/releases/tag/v0.1.0
+[Unreleased]: https://github.com/cppalliance/cppa-cursor-browser/commits/HEAD

--- a/README.md
+++ b/README.md
@@ -242,14 +242,12 @@ The desktop app uses [pywebview](https://pywebview.flowrl.com/) to render the Fl
 
 ## Versioning
 
-> **Merge note:** The full policy and `CHANGELOG.md` ship in [PR #85](https://github.com/cppalliance/cppa-cursor-browser/pull/85) (#74). Land that PR with or before this one to avoid duplicate or dead links.
-
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (`MAJOR.MINOR.PATCH`).
 
 **Pre-1.0 stability (current):** The project is at `0.x.y`. During this phase:
 
 - **Minor version bumps (`0.x` → `0.x+1`)** may include breaking changes to the HTTP API, CLI flags, or exported file formats. Consumers of the `/api/*` endpoints or the `cursor-chat-export` CLI should review the changelog before upgrading.
-- **Patch version bumps (`0.x.y` → `0.x.y+1`)** are backward-compatible bug fixes only. Critical security fixes may break compatibility at any version with appropriate changelog notation.
+- **Patch version bumps (`0.x.y` → `0.x.y+1`)** are backward-compatible bug fixes only.
 
 **What constitutes a breaking change:**
 
@@ -263,7 +261,7 @@ Internal Python modules are not a semver-governed library API for external impor
 
 Adding new optional fields to JSON responses, adding new CLI flags with sensible defaults, or adding new export-format sections are *not* considered breaking.
 
-Notable changes will be documented in **[CHANGELOG.md](CHANGELOG.md)** following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format (see #74 / PR #85).
+Notable changes will be documented in **[CHANGELOG.md](CHANGELOG.md)** following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
 When an API surface is scheduled for removal, follow the process in **[docs/API_DEPRECATION.md](docs/API_DEPRECATION.md)** (response headers, changelog entries, minimum notice period).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ include = [
     "requirements.txt",
     "README.md",
     "docs/",
+    "CHANGELOG.md",
     "DEPLOYMENT.md",
     "LICENSE",
     "cursor-browser.spec",


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with a single `[Unreleased]` section documenting all notable work to date (no versioned release entry yet — nothing has been tagged or shipped)
- Add a **Versioning** section to `README.md` documenting the semver scheme, pre-1.0 stability guarantees, and a table of what constitutes a breaking change per API surface (HTTP API, CLI flags, export format layout, public Python symbols)
- Add `CHANGELOG.md` to `pyproject.toml` sdist includes so it ships with source distributions

Closes #74

## Motivation

The project had no documented versioning posture. The README and `DEPLOYMENT.md` are written at production-deployment level detail, creating an implicit stability signal that did not match the actual pre-1.0 contract. Consumers of the `/api/*` endpoints and the `cursor-chat-export` CLI had no way to know when or how the contract might change. This is the "Invisible Contract" finding from the baseline eval (T16+T34).

## Test plan

- [ ] `CHANGELOG.md` renders correctly on GitHub (headings, `[Unreleased]` footer link to `commits/HEAD`)
- [ ] Versioning section in `README.md` is visible in the rendered docs
- [ ] `pyproject.toml` sdist include list contains `CHANGELOG.md`
- [ ] `pyproject.toml` `version` field (`0.1.0`) reflects the planned package version; changelog correctly uses `[Unreleased]` until the first tagged release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web UI: workspace browsing/search, improved code-block rendering, dark/light mode, bookmarkable URLs
  * Export: chat export (Markdown/HTML/PDF/JSON/CSV + one-click web), CLI incremental export, session browsing/export, Windows desktop packaging

* **Bug Fixes**
  * Hardened workspace handling, safer path normalization and sanitization, debug mode disabled by default

* **Documentation**
  * Added comprehensive CHANGELOG and README versioning guidance (Semantic Versioning)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/cppa-cursor-browser/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->