### PR TITLE
docs: document API deprecation process (closes #75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,30 @@ The desktop app uses [pywebview](https://pywebview.flowrl.com/) to render the Fl
 - **Frontend:** Vanilla HTML/CSS/JS (no npm, no build step)
 - **PDF:** fpdf2
 
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (`MAJOR.MINOR.PATCH`).
+
+**Pre-1.0 stability (current):** The project is at `0.x.y`. During this phase:
+
+- **Minor version bumps (`0.x` → `0.x+1`)** may include breaking changes to the HTTP API, CLI flags, or exported file formats. Consumers of the `/api/*` endpoints or the `cursor-chat-export` CLI should review the changelog before upgrading.
+- **Patch version bumps (`0.x.y` → `0.x.y+1`)** are backward-compatible bug fixes only.
+
+**What constitutes a breaking change:**
+
+| Surface | Breaking examples |
+|---|---|
+| HTTP API | Removing or renaming an endpoint; changing the JSON schema of a response in a non-additive way |
+| CLI (`cursor-chat-export`) | Removing or renaming a flag; changing default output structure |
+| Export formats | Removing YAML frontmatter fields; changing the zip directory layout |
+| Python package | Removing a public symbol from an importable module |
+
+Adding new optional fields to JSON responses, adding new CLI flags with sensible defaults, or adding new export-format sections are *not* considered breaking.
+
+A complete history of changes is maintained in **[CHANGELOG.md](CHANGELOG.md)** following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+When an API surface is scheduled for removal, follow the process in **[docs/API_DEPRECATION.md](docs/API_DEPRECATION.md)** (response headers, changelog entries, minimum notice period).
+
 ## License
 
 This project is licensed under the [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 **Pre-1.0 stability (current):** The project is at `0.x.y`. During this phase:
 
 - **Minor version bumps (`0.x` → `0.x+1`)** may include breaking changes to the HTTP API, CLI flags, or exported file formats. Consumers of the `/api/*` endpoints or the `cursor-chat-export` CLI should review the changelog before upgrading.
-- **Patch version bumps (`0.x.y` → `0.x.y+1`)** are backward-compatible bug fixes only.
+- **Patch version bumps (`0.x.y` → `0.x.y+1`)** are backward-compatible bug fixes only. Critical security fixes may break compatibility at any version with appropriate changelog notation.
 
 **What constitutes a breaking change:**
 
@@ -258,7 +258,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 | HTTP API | Removing or renaming an endpoint; changing the JSON schema of a response in a non-additive way |
 | CLI (`cursor-chat-export`) | Removing or renaming a flag; changing default output structure |
 | Export formats | Removing YAML frontmatter fields; changing the zip directory layout |
-| Python package | Removing a public symbol from an importable module |
+
+Internal Python modules are not a semver-governed library API for external importers.
 
 Adding new optional fields to JSON responses, adding new CLI flags with sensible defaults, or adding new export-format sections are *not* considered breaking.
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ The desktop app uses [pywebview](https://pywebview.flowrl.com/) to render the Fl
 
 ## Versioning
 
+> **Merge note:** The full policy and `CHANGELOG.md` ship in [PR #85](https://github.com/cppalliance/cppa-cursor-browser/pull/85) (#74). Land that PR with or before this one to avoid duplicate or dead links.
+
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (`MAJOR.MINOR.PATCH`).
 
 **Pre-1.0 stability (current):** The project is at `0.x.y`. During this phase:
@@ -260,7 +262,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 
 Adding new optional fields to JSON responses, adding new CLI flags with sensible defaults, or adding new export-format sections are *not* considered breaking.
 
-A complete history of changes is maintained in **[CHANGELOG.md](CHANGELOG.md)** following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+Notable changes will be documented in **[CHANGELOG.md](CHANGELOG.md)** following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format (see #74 / PR #85).
 
 When an API surface is scheduled for removal, follow the process in **[docs/API_DEPRECATION.md](docs/API_DEPRECATION.md)** (response headers, changelog entries, minimum notice period).
 

--- a/docs/API_DEPRECATION.md
+++ b/docs/API_DEPRECATION.md
@@ -13,7 +13,7 @@ When an endpoint, parameter, response field, or CLI flag is scheduled for remova
 1. **CHANGELOG** — Add an entry under `### Deprecated` naming the surface, its replacement (if any), and the planned removal version.
 2. **Response headers** — Deprecated HTTP endpoints and parameters emit a `Deprecation` header on every affected response (see [Header format](#header-format)).
 3. **Server log** — Route handlers log `logging.warning()` with the deprecated symbol and recommended replacement.
-4. **Removal** — Remove no earlier than **one minor version** after the deprecation was announced (e.g. deprecated in `1.2.0`, removable from `1.4.0`). Document under `### Removed` in the changelog.
+4. **Removal** — Remove no earlier than **one minor version** after the deprecation was announced (e.g. deprecated in `1.2.0`, removable from `1.3.0`). Document under `### Removed` in the changelog.
 
 ## Header format
 

--- a/docs/API_DEPRECATION.md
+++ b/docs/API_DEPRECATION.md
@@ -11,7 +11,7 @@ While the project is at `0.x.y`, **breaking changes may land in any minor releas
 When an endpoint, parameter, response field, or CLI flag is scheduled for removal:
 
 1. **CHANGELOG** — Add an entry under `### Deprecated` naming the surface, its replacement (if any), and the planned removal version.
-2. **Response headers** — Deprecated HTTP endpoints and parameters emit a `Deprecation` header on every affected response (see [Header format](#header-format)).
+2. **Response headers** — Deprecated HTTP endpoints and parameters emit a `Deprecation` header on every affected response (see [Header format](#header-format)). When the first endpoint is deprecated, implement this via a small shared Flask helper so handlers stay consistent with the policy.
 3. **Server log** — Route handlers log `logging.warning()` with the deprecated symbol and recommended replacement.
 4. **Removal** — Remove no earlier than **one minor version** after the deprecation was announced (e.g. deprecated in `1.2.0`, removable from `1.3.0`). Document under `### Removed` in the changelog.
 

--- a/docs/API_DEPRECATION.md
+++ b/docs/API_DEPRECATION.md
@@ -1,0 +1,41 @@
+# API Deprecation Policy
+
+How the HTTP API (`/api/*`), CLI flags (`cursor-chat-export`), and shared JSON response fields are deprecated and removed. Complements the [Versioning](../README.md#versioning) section and [CHANGELOG.md](../CHANGELOG.md).
+
+## Pre-1.0 posture
+
+While the project is at `0.x.y`, **breaking changes may land in any minor release** without a prior deprecation cycle. Deprecations are still recorded in the changelog when practicable, but there is no guarantee of advance notice before removal. After `1.0.0`, the workflow below applies in full.
+
+## Deprecation workflow
+
+When an endpoint, parameter, response field, or CLI flag is scheduled for removal:
+
+1. **CHANGELOG** — Add an entry under `### Deprecated` naming the surface, its replacement (if any), and the planned removal version.
+2. **Response headers** — Deprecated HTTP endpoints and parameters emit a `Deprecation` header on every affected response (see [Header format](#header-format)).
+3. **Server log** — Route handlers log `logging.warning()` with the deprecated symbol and recommended replacement.
+4. **Removal** — Remove no earlier than **one minor version** after the deprecation was announced (e.g. deprecated in `1.2.0`, removable from `1.4.0`). Document under `### Removed` in the changelog.
+
+## Header format
+
+Deprecated HTTP routes and query parameters set:
+
+```http
+Deprecation: true; sunset=2026-09-01
+```
+
+- `sunset` — ISO 8601 calendar date (UTC) when removal is scheduled.
+- Optionally add `link="<url>"` pointing to the changelog entry or migration notes.
+
+Clients should treat any `Deprecation: true` response as a signal to migrate before the sunset date.
+
+## Surfaces covered
+
+| Surface | Signals |
+|---------|---------|
+| HTTP endpoint or parameter | `Deprecation` header, changelog entry, server log |
+| JSON response field | Changelog entry; field remains until removal |
+| CLI flag | `(deprecated)` in `--help`, changelog entry |
+
+## Removal documentation
+
+Removals go under `### Removed` in [CHANGELOG.md](../CHANGELOG.md): what was removed, which version deprecated it, and the migration path.

--- a/docs/API_DEPRECATION.md
+++ b/docs/API_DEPRECATION.md
@@ -4,36 +4,48 @@ How the HTTP API (`/api/*`), CLI flags (`cursor-chat-export`), and shared JSON r
 
 ## Pre-1.0 posture
 
-While the project is at `0.x.y`, **breaking changes may land in any minor release** without a prior deprecation cycle. Deprecations are still recorded in the changelog when practicable, but there is no guarantee of advance notice before removal. After `1.0.0`, the workflow below applies in full.
+While the project is at `0.x.y`, **breaking changes may land in any minor release** without a prior deprecation cycle. Deprecations are still recorded in the changelog when practicable, but there is no guarantee of advance notice before removal. Pre-1.0, workflow steps 2–4 (CLI help text, response headers, server logs) are **encouraged but optional**; step 1 (changelog) applies when practicable. After `1.0.0`, the workflow below applies in full.
 
 ## Deprecation workflow
 
 When an endpoint, parameter, response field, or CLI flag is scheduled for removal:
 
 1. **CHANGELOG** — Add an entry under `### Deprecated` naming the surface, its replacement (if any), and the planned removal version.
-2. **Response headers** — Deprecated HTTP endpoints and parameters emit a `Deprecation` header on every affected response (see [Header format](#header-format)). When the first endpoint is deprecated, implement this via a small shared Flask helper so handlers stay consistent with the policy.
-3. **Server log** — Route handlers log `logging.warning()` with the deprecated symbol and recommended replacement.
-4. **Removal** — Remove no earlier than **one minor version** after the deprecation was announced (e.g. deprecated in `1.2.0`, removable from `1.3.0`). Document under `### Removed` in the changelog.
+2. **CLI help** (flags only) — Add `(deprecated, use <replacement>)` to the flag's argparse help string.
+3. **Response headers** — Deprecated HTTP endpoints and parameters emit deprecation headers on every affected response (see [Header format](#header-format)). When the first endpoint is deprecated, implement via a small shared Flask helper so handlers stay consistent with the policy.
+4. **Server log** — Route handlers log `logging.warning()` with the deprecated symbol and recommended replacement.
+5. **Removal** — Remove no earlier than **one minor version** after the deprecation was announced (e.g. deprecated in `1.2.0`, removable from `1.3.0`). Document under `### Removed` in the changelog.
 
 ## Header format
 
-Deprecated HTTP routes and query parameters set:
+This project currently documents a **simplified custom format** for pre-1.0. It does not match [IETF `Deprecation`](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header) (HTTP-date value, not `true`) or [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594) (separate `Sunset` and `Link` headers). Adopt the standards-aligned form below when the shared Flask helper lands or at `1.0.0`.
+
+**Current (custom, pre-1.0):**
 
 ```http
 Deprecation: true; sunset=2026-09-01
 ```
 
-- `sunset` — ISO 8601 calendar date (UTC) when removal is scheduled.
-- Optionally add `link="<url>"` pointing to the changelog entry or migration notes.
+- `sunset=` — ISO 8601 calendar date (UTC) when removal is scheduled, embedded in the `Deprecation` value.
 
-Clients should treat any `Deprecation: true` response as a signal to migrate before the sunset date.
+**Target (standards-aligned)** — emit as **separate headers** from Flask:
+
+```http
+Deprecation: Tue, 01 Sep 2026 00:00:00 GMT
+Sunset: Tue, 01 Sep 2026 00:00:00 GMT
+Link: <https://github.com/cppalliance/cppa-cursor-browser/blob/HEAD/CHANGELOG.md>; rel="deprecation"
+```
+
+Migration notes use a separate **`Link`** header (RFC 8288), not a `link=` parameter on `Deprecation`.
+
+Clients should treat any deprecation signal as a prompt to migrate before the sunset date.
 
 ## Surfaces covered
 
 | Surface | Signals |
 |---------|---------|
-| HTTP endpoint or parameter | `Deprecation` header, changelog entry, server log |
-| JSON response field | Changelog entry; field remains until removal |
+| HTTP endpoint or parameter | Deprecation headers, changelog entry, server log |
+| JSON response field | Changelog entry; field remains until removal (no in-band signal today; future: `X-Deprecated-Fields` header or `_deprecated` envelope key) |
 | CLI flag | `(deprecated)` in `--help`, changelog entry |
 
 ## Removal documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ include = [
     "launcher.py",
     "requirements.txt",
     "README.md",
+    "docs/",
     "DEPLOYMENT.md",
     "LICENSE",
     "cursor-browser.spec",


### PR DESCRIPTION
## Summary

- Add `docs/API_DEPRECATION.md` defining how HTTP API endpoints, CLI flags, and JSON response fields are deprecated and removed
- Cross-link from the README **Versioning** section to the deprecation policy
- Include `docs/` in `pyproject.toml` sdist so the policy ships with source distributions

Closes #75

## Motivation

The project had no documented API deprecation process. Combined with the versioning policy (#74), HTTP API and CLI consumers had no defined warning mechanism when endpoints, parameters, or response shapes change. This addresses the "Invisible Contract" finding from the baseline eval (Test 34 — API Stability Discipline).

## What the policy covers

| Requirement | Where |
|---|---|
| Communication (headers, changelog, server logs) | 4-step workflow in `docs/API_DEPRECATION.md` |
| `Deprecation` header pattern | `Deprecation: true; sunset=<ISO-8601-date>` with optional `link=` |
| Minimum notice period | One minor version before removal (post-1.0) |
| Removal documentation | `### Removed` section in `CHANGELOG.md` |
| Pre-1.0 posture | Breaking changes may land without prior deprecation cycle |

Documentation only — no runtime `Deprecation` headers are emitted yet; the policy establishes the process before it is needed.

## Test plan

- [ ] `docs/API_DEPRECATION.md` renders correctly on GitHub
- [ ] README **Versioning** section links to `docs/API_DEPRECATION.md`
- [ ] `pyproject.toml` sdist include list contains `docs/`
- [ ] Policy cross-references `CHANGELOG.md` and README Versioning consistently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Versioning section describing Semantic Versioning expectations, stability guidance for pre-1.0, and how notable changes are recorded.
  * Added an API deprecation policy covering HTTP API, CLI flags, and JSON response fields with deprecation/removal workflow, header formats, and migration guidance.

* **Chores**
  * Updated packaging so source distributions include project documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/cppa-cursor-browser/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->