### PR TITLE
Lazy-load chat histories, fast list summaries, and mtime disk cache (closes #84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Lazy-load workspace UI** — workspace sidebar renders from a lightweight summary
+  payload; full bubble content is fetched per-conversation when the user selects it,
+  reducing first-paint time from 1–2 min to < 3 s on large local fixtures (#84)
+- **`GET /api/workspaces/<id>/tabs?summary=1`** — new summary-only variant returns
+  `id`, `title`, `timestamp`, `messageCount`, and optional `metadata.modelsUsed`
+  without loading any bubble data (#84)
+- **`GET /api/workspaces/<id>/tabs/<composer_id>`** — new single-conversation
+  endpoint loads only scoped `bubbleId:{id}:%`, `messageRequestContext:{id}:%`,
+  and `codeBlockDiff:{id}:%` KV rows, avoiding a full global bubble scan (#84)
+- **Scoped KV loaders** in `services/workspace_db.py`:
+  `load_bubbles_for_composer`, `load_message_request_context_for_composer`,
+  `load_code_block_diffs_for_composer` — used by the single-tab path (#84)
+
+### Changed
+- **`GET /api/workspaces`** (`list_workspace_projects`) no longer performs a
+  global `bubbleId:%` scan; conversation presence is determined from
+  `fullConversationHeadersOnly` headers alone, and workspace assignment relies
+  on `composer_id_to_ws` (primary) plus `projectLayouts` from MRC (#84)
+- **`assemble_workspace_tabs`** inner per-composer loop refactored into a shared
+  `_assemble_tab_from_composer_data` helper reused by `assemble_single_tab`; full
+  path behaviour is unchanged (#84)
+
+### Deprecated
+- Direct use of `GET /api/workspaces/<id>/tabs` (no `?summary=1`) from the workspace
+  UI on page load; the UI now calls `?summary=1` for first paint and lazy-fetches
+  individual tabs. The full-assembly endpoint remains available for export,
+  search, and backward-compatible consumers (planned removal: post-1.0) (#84)
+
+
 - **Web UI** — browse and search all Cursor AI workspaces; conversation view with syntax-highlighted code blocks, dark/light mode, and bookmarkable chat URLs (#63)
 - **Export formats** — one-click export of chats as Markdown, HTML, PDF, JSON, and CSV from the web UI (#63)
 - **CLI export** (`cursor-chat-export` / `scripts/export.py`) — zip archive or individual Markdown files with YAML frontmatter; incremental mode (`--since last`) preserves state across runs (#63, #42, #61)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Summary disk cache (Phase 3)** — project list and tab summaries cached under
+  `~/.cache/cursor-chat-browser/`, invalidated when global or per-workspace DB
+  mtimes change; bypass with `?nocache=1` or `CURSOR_CHAT_BROWSER_NOCACHE=1` (#84)
 - **Lazy-load workspace UI** — workspace sidebar renders from a lightweight summary
   payload; full bubble content is fetched per-conversation when the user selects it,
   reducing first-paint time from 1–2 min to < 3 s on large local fixtures (#84)
@@ -22,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `load_code_block_diffs_for_composer` — used by the single-tab path (#84)
 
 ### Changed
+- **List-path performance** — skip full `messageRequestContext` scan unless
+  invalid workspace aliases are needed; filter `composerData` in SQL; skip
+  `Composer.from_dict` on list/summary paths; cache `composer_id_to_ws` mapping (#84)
 - **`GET /api/workspaces`** (`list_workspace_projects`) no longer performs a
   global `bubbleId:%` scan; conversation presence is determined from
   `fullConversationHeadersOnly` headers alone, and workspace assignment relies

--- a/api/workspaces.py
+++ b/api/workspaces.py
@@ -50,12 +50,18 @@ _logger = logging.getLogger(__name__)
 # GET /api/workspaces
 # ---------------------------------------------------------------------------
 
+def _request_nocache() -> bool:
+    return request.args.get("nocache") in ("1", "true")
+
+
 @bp.route("/api/workspaces")
 def list_workspaces():
     try:
         workspace_path = resolve_workspace_path()
         rules = exclusion_rules()
-        projects, warnings = list_workspace_projects(workspace_path, rules)
+        projects, warnings = list_workspace_projects(
+            workspace_path, rules, nocache=_request_nocache(),
+        )
         payload: dict = {"projects": projects}
         if warnings:
             payload["warnings"] = warnings
@@ -160,7 +166,9 @@ def get_workspace_tabs(workspace_id):
         rules = exclusion_rules()
         summary = request.args.get("summary") in ("1", "true")
         if summary:
-            payload, status = list_workspace_tab_summaries(workspace_id, workspace_path, rules)
+            payload, status = list_workspace_tab_summaries(
+                workspace_id, workspace_path, rules, nocache=_request_nocache(),
+            )
         else:
             payload, status = assemble_workspace_tabs(workspace_id, workspace_path, rules)
         return jsonify(payload), status

--- a/api/workspaces.py
+++ b/api/workspaces.py
@@ -11,7 +11,7 @@ import logging
 import os
 from datetime import datetime, timezone
 
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
 from api.flask_config import exclusion_rules
 
@@ -29,7 +29,11 @@ from services.workspace_resolver import (
 )
 from services.cli_tabs import get_cli_workspace_tabs
 from services.workspace_listing import list_workspace_projects
-from services.workspace_tabs import assemble_workspace_tabs
+from services.workspace_tabs import (
+    assemble_single_tab,
+    assemble_workspace_tabs,
+    list_workspace_tab_summaries,
+)
 
 # Re-exported for tests/test_models_wired_at_read_sites.py — the typed-model
 # spy harness patches `workspaces_mod.Bubble` / `.Composer` / `.Workspace` to
@@ -154,9 +158,31 @@ def get_workspace_tabs(workspace_id):
     try:
         workspace_path = resolve_workspace_path()
         rules = exclusion_rules()
-        payload, status = assemble_workspace_tabs(workspace_id, workspace_path, rules)
+        summary = request.args.get("summary") in ("1", "true")
+        if summary:
+            payload, status = list_workspace_tab_summaries(workspace_id, workspace_path, rules)
+        else:
+            payload, status = assemble_workspace_tabs(workspace_id, workspace_path, rules)
         return jsonify(payload), status
     except Exception:
         _logger.exception("Failed to get workspace tabs")
         return jsonify({"error": "Failed to get workspace tabs"}), 500
+
+
+# ---------------------------------------------------------------------------
+# GET /api/workspaces/<id>/tabs/<composer_id>
+# ---------------------------------------------------------------------------
+
+@bp.route("/api/workspaces/<workspace_id>/tabs/<composer_id>")
+def get_workspace_tab(workspace_id, composer_id):
+    if workspace_id.startswith("cli:"):
+        return jsonify({"error": "Per-tab lazy load is not supported for CLI workspaces"}), 400
+    try:
+        workspace_path = resolve_workspace_path()
+        rules = exclusion_rules()
+        payload, status = assemble_single_tab(workspace_id, composer_id, workspace_path, rules)
+        return jsonify(payload), status
+    except Exception:
+        _logger.exception("Failed to get workspace tab")
+        return jsonify({"error": "Failed to get workspace tab"}), 500
 

--- a/services/summary_cache.py
+++ b/services/summary_cache.py
@@ -84,7 +84,9 @@ def fingerprint_workspace_storage(
     }
 
 
-def _fingerprint_equal(a: dict[str, Any], b: dict[str, Any]) -> bool:
+def _fingerprint_equal(a: object, b: dict[str, Any]) -> bool:
+    if not isinstance(a, dict):
+        return False
     return a == b
 
 

--- a/services/summary_cache.py
+++ b/services/summary_cache.py
@@ -1,0 +1,212 @@
+"""Disk cache for derived workspace summaries (issue #84 Phase 3).
+
+Caches project lists and per-workspace tab summaries keyed by storage mtimes
+so repeat page loads avoid re-scanning Cursor's global KV index.
+
+Bypass: set env ``CURSOR_CHAT_BROWSER_NOCACHE=1`` or pass ``?nocache=1`` on API
+requests. Cache files live under ``~/.cache/cursor-chat-browser/``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+CACHE_VERSION = 1
+CACHE_DIR = Path.home() / ".cache" / "cursor-chat-browser"
+PROJECTS_CACHE_FILE = CACHE_DIR / "projects.json"
+COMPOSER_MAP_CACHE_FILE = CACHE_DIR / "composer-id-to-ws.json"
+TAB_SUMMARIES_PREFIX = "tab-summaries-"
+
+
+def nocache_enabled(*, request_nocache: bool = False) -> bool:
+    if request_nocache:
+        return True
+    return os.environ.get("CURSOR_CHAT_BROWSER_NOCACHE", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _rules_digest(rules: list) -> str:
+    try:
+        payload = json.dumps(rules, sort_keys=True, ensure_ascii=False)
+    except (TypeError, ValueError):
+        payload = repr(rules)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _file_mtime_ns(path: str | None) -> int | None:
+    if not path or not os.path.isfile(path):
+        return None
+    try:
+        return os.stat(path).st_mtime_ns
+    except OSError:
+        return None
+
+
+def fingerprint_workspace_storage(
+    workspace_path: str,
+    workspace_entries: list[dict],
+    *,
+    global_db_path: str | None,
+    rules: list,
+    cli_chats_path: str | None = None,
+) -> dict[str, Any]:
+    """Build a fingerprint dict for cache invalidation."""
+    ws_mt: list[tuple[str, int]] = []
+    for entry in workspace_entries:
+        name = entry.get("name")
+        if not isinstance(name, str):
+            continue
+        base = os.path.join(workspace_path, name)
+        for rel in ("state.vscdb", "workspace.json"):
+            p = os.path.join(base, rel)
+            mtime = _file_mtime_ns(p)
+            if mtime is not None:
+                ws_mt.append((f"{name}/{rel}", mtime))
+    ws_mt.sort(key=lambda x: x[0])
+
+    return {
+        "version": CACHE_VERSION,
+        "workspace_path": os.path.normpath(workspace_path),
+        "global_db_mtime_ns": _file_mtime_ns(global_db_path),
+        "workspace_files": ws_mt,
+        "rules_digest": _rules_digest(rules),
+        "cli_chats_mtime_ns": _file_mtime_ns(cli_chats_path),
+    }
+
+
+def _fingerprint_equal(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    return a == b
+
+
+def _read_cache_file(path: Path | str) -> dict[str, Any] | None:
+    p = Path(path)
+    if not p.is_file():
+        return None
+    try:
+        with p.open(encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        return data
+    except (OSError, json.JSONDecodeError) as e:
+        _logger.debug("Summary cache read failed for %s: %s", path, e)
+        return None
+
+
+def _write_cache_file(path: Path | str, payload: dict[str, Any]) -> None:
+    p = Path(path)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_suffix(p.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False)
+        tmp.replace(p)
+    except OSError as e:
+        _logger.warning("Summary cache write failed for %s: %s", path, e)
+
+
+def get_cached_projects(fingerprint: dict[str, Any]) -> tuple[list[dict], list[dict]] | None:
+    data = _read_cache_file(PROJECTS_CACHE_FILE)
+    if not data:
+        return None
+    if not _fingerprint_equal(data.get("fingerprint"), fingerprint):
+        return None
+    projects = data.get("projects")
+    warnings = data.get("warnings")
+    if not isinstance(projects, list):
+        return None
+    if not isinstance(warnings, list):
+        warnings = []
+    return projects, warnings
+
+
+def set_cached_projects(
+    fingerprint: dict[str, Any],
+    projects: list[dict],
+    warnings: list[dict],
+) -> None:
+    _write_cache_file(
+        PROJECTS_CACHE_FILE,
+        {
+            "fingerprint": fingerprint,
+            "projects": projects,
+            "warnings": warnings,
+        },
+    )
+
+
+def get_cached_composer_id_to_ws(
+    fingerprint: dict[str, Any],
+) -> dict[str, str] | None:
+    data = _read_cache_file(COMPOSER_MAP_CACHE_FILE)
+    if not data:
+        return None
+    if not _fingerprint_equal(data.get("fingerprint"), fingerprint):
+        return None
+    mapping = data.get("composer_id_to_ws")
+    if not isinstance(mapping, dict):
+        return None
+    return {str(k): str(v) for k, v in mapping.items()}
+
+
+def set_cached_composer_id_to_ws(
+    fingerprint: dict[str, Any],
+    mapping: dict[str, str],
+) -> None:
+    _write_cache_file(
+        COMPOSER_MAP_CACHE_FILE,
+        {
+            "fingerprint": fingerprint,
+            "composer_id_to_ws": mapping,
+        },
+    )
+
+
+def _tab_summaries_path(workspace_id: str) -> Path:
+    safe = hashlib.sha256(workspace_id.encode("utf-8")).hexdigest()[:16]
+    return CACHE_DIR / f"{TAB_SUMMARIES_PREFIX}{safe}.json"
+
+
+def get_cached_tab_summaries(
+    fingerprint: dict[str, Any],
+    workspace_id: str,
+) -> tuple[dict, int] | None:
+    data = _read_cache_file(_tab_summaries_path(workspace_id))
+    if not data:
+        return None
+    if data.get("workspace_id") != workspace_id:
+        return None
+    if not _fingerprint_equal(data.get("fingerprint"), fingerprint):
+        return None
+    payload = data.get("payload")
+    status = data.get("status", 200)
+    if not isinstance(payload, dict) or not isinstance(status, int):
+        return None
+    return payload, status
+
+
+def set_cached_tab_summaries(
+    fingerprint: dict[str, Any],
+    workspace_id: str,
+    payload: dict,
+    status: int,
+) -> None:
+    _write_cache_file(
+        _tab_summaries_path(workspace_id),
+        {
+            "workspace_id": workspace_id,
+            "fingerprint": fingerprint,
+            "payload": payload,
+            "status": status,
+        },
+    )

--- a/services/summary_cache.py
+++ b/services/summary_cache.py
@@ -61,7 +61,7 @@ def fingerprint_workspace_storage(
     cli_chats_path: str | None = None,
 ) -> dict[str, Any]:
     """Build a fingerprint dict for cache invalidation."""
-    ws_mt: list[tuple[str, int]] = []
+    ws_mt: list[list[str | int]] = []
     for entry in workspace_entries:
         name = entry.get("name")
         if not isinstance(name, str):
@@ -71,8 +71,8 @@ def fingerprint_workspace_storage(
             p = os.path.join(base, rel)
             mtime = _file_mtime_ns(p)
             if mtime is not None:
-                ws_mt.append((f"{name}/{rel}", mtime))
-    ws_mt.sort(key=lambda x: x[0])
+                ws_mt.append([f"{name}/{rel}", mtime])
+    ws_mt.sort(key=lambda row: row[0])
 
     return {
         "version": CACHE_VERSION,
@@ -84,10 +84,22 @@ def fingerprint_workspace_storage(
     }
 
 
+def _normalize_fingerprint(fp: dict[str, Any]) -> dict[str, Any]:
+    """Normalize fingerprint for comparison (JSON round-trip uses lists, not tuples)."""
+    normalized = dict(fp)
+    wf = fp.get("workspace_files")
+    if isinstance(wf, list):
+        normalized["workspace_files"] = [
+            [row[0], row[1]] if isinstance(row, (list, tuple)) and len(row) == 2 else row
+            for row in wf
+        ]
+    return normalized
+
+
 def _fingerprint_equal(a: object, b: dict[str, Any]) -> bool:
     if not isinstance(a, dict):
         return False
-    return a == b
+    return _normalize_fingerprint(a) == _normalize_fingerprint(b)
 
 
 def _read_cache_file(path: Path | str) -> dict[str, Any] | None:

--- a/services/workspace_db.py
+++ b/services/workspace_db.py
@@ -296,6 +296,7 @@ COMPOSER_ROWS_WITH_HEADERS_SQL = (
     " AND LENGTH(value) > 10"
     " AND value LIKE '%fullConversationHeadersOnly%'"
     " AND value NOT LIKE '%fullConversationHeadersOnly\":[]%'"
+    " AND value NOT LIKE '%fullConversationHeadersOnly\": []%'"
 )
 
 

--- a/services/workspace_db.py
+++ b/services/workspace_db.py
@@ -47,11 +47,52 @@ def load_bubble_map(global_db) -> dict[str, dict]:
     return bubble_map
 
 
-def load_project_layouts_map(global_db) -> dict[str, list]:
-    """Load ``projectLayouts`` from ``messageRequestContext:*`` KV entries.
+def _extract_root_paths_from_context(ctx: dict) -> list[str]:
+    """Pull ``rootPath`` strings from a messageRequestContext JSON object."""
+    paths: list[str] = []
+    layouts = ctx.get("projectLayouts")
+    if not isinstance(layouts, list):
+        return paths
+    for layout in layouts:
+        try:
+            o = json.loads(layout) if isinstance(layout, str) else layout
+            if isinstance(o, dict) and o.get("rootPath"):
+                paths.append(o["rootPath"])
+        except (json.JSONDecodeError, ValueError, KeyError, TypeError):
+            continue
+    return paths
 
-    Returns ``{composer_id: [root_path_str, ...]}``.  String-encoded layout
-    objects are JSON-decoded before the ``rootPath`` field is extracted.
+
+def load_project_layouts_for_composer(global_db, composer_id: str) -> list[str]:
+    """Scoped MRC load: ``messageRequestContext:{composer_id}:%`` only."""
+    paths: list[str] = []
+    try:
+        rows = global_db.execute(
+            "SELECT key, value FROM cursorDiskKV WHERE key LIKE ?",
+            (f"messageRequestContext:{composer_id}:%",),
+        ).fetchall()
+    except sqlite3.Error:
+        return paths
+    for row in rows:
+        try:
+            ctx = json.loads(row["value"])
+            if isinstance(ctx, dict):
+                paths.extend(_extract_root_paths_from_context(ctx))
+        except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
+            _logger.debug(
+                "Skipping malformed messageRequestContext row %s: %s",
+                row["key"],
+                e,
+            )
+    return paths
+
+
+def load_project_layouts_map(global_db) -> dict[str, list]:
+    """Load ``projectLayouts`` from all ``messageRequestContext:*`` KV entries.
+
+    Returns ``{composer_id: [root_path_str, ...]}``.  Prefer
+    :func:`load_project_layouts_for_composer` on list paths when only a few
+    composers need layout fallbacks.
     """
     layouts_map: dict[str, list] = {}
     try:
@@ -67,17 +108,9 @@ def load_project_layouts_map(global_db) -> dict[str, list]:
         cid = parts[1]
         try:
             ctx = json.loads(row["value"])
-            layouts = ctx.get("projectLayouts")
-            if not isinstance(layouts, list):
-                continue
-            layouts_map.setdefault(cid, [])
-            for layout in layouts:
-                try:
-                    o = json.loads(layout) if isinstance(layout, str) else layout
-                    if isinstance(o, dict) and o.get("rootPath"):
-                        layouts_map[cid].append(o["rootPath"])
-                except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
-                    _logger.debug("Skipping malformed layout entry in %s: %s", row["key"], e)
+            if isinstance(ctx, dict):
+                layouts_map.setdefault(cid, [])
+                layouts_map[cid].extend(_extract_root_paths_from_context(ctx))
         except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
             _logger.debug("Skipping malformed messageRequestContext row %s: %s", row["key"], e)
     return layouts_map
@@ -257,6 +290,20 @@ def collect_invalid_workspace_ids(workspace_entries: list[dict]) -> set[str]:
     return invalid
 
 
+# Composers that have at least one header entry (list/summary paths).
+COMPOSER_ROWS_WITH_HEADERS_SQL = (
+    "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
+    " AND LENGTH(value) > 10"
+    " AND value LIKE '%fullConversationHeadersOnly%'"
+    " AND value NOT LIKE '%fullConversationHeadersOnly\":[]%'"
+)
+
+
+def global_storage_db_path(workspace_path: str) -> str:
+    """Resolved path to Cursor global ``state.vscdb`` for a workspace storage root."""
+    return os.path.normpath(os.path.join(workspace_path, "..", "globalStorage", "state.vscdb"))
+
+
 def build_composer_id_to_workspace_id(workspace_path: str, workspace_entries: list) -> dict:
     """Build mapping from composer ID to workspace folder name.
 
@@ -305,6 +352,41 @@ def build_composer_id_to_workspace_id(workspace_path: str, workspace_entries: li
     return mapping
 
 
+def build_composer_id_to_workspace_id_cached(
+    workspace_path: str,
+    workspace_entries: list,
+    rules: list,
+    *,
+    nocache: bool = False,
+) -> dict:
+    """Like :func:`build_composer_id_to_workspace_id` with optional disk cache."""
+    from services.summary_cache import (
+        fingerprint_workspace_storage,
+        get_cached_composer_id_to_ws,
+        nocache_enabled,
+        set_cached_composer_id_to_ws,
+    )
+    from utils.workspace_path import get_cli_chats_path
+
+    gdb = global_storage_db_path(workspace_path)
+    cli_path = get_cli_chats_path()
+    fingerprint = fingerprint_workspace_storage(
+        workspace_path,
+        workspace_entries,
+        global_db_path=gdb if os.path.isfile(gdb) else None,
+        rules=rules,
+        cli_chats_path=cli_path if os.path.isdir(cli_path) else None,
+    )
+    if not nocache_enabled(request_nocache=nocache):
+        cached = get_cached_composer_id_to_ws(fingerprint)
+        if cached is not None:
+            return cached
+    mapping = build_composer_id_to_workspace_id(workspace_path, workspace_entries)
+    if not nocache_enabled(request_nocache=nocache):
+        set_cached_composer_id_to_ws(fingerprint, mapping)
+    return mapping
+
+
 @contextmanager
 def open_global_db(workspace_path: str):
     """Open Cursor global storage SQLite database read-only.
@@ -317,8 +399,7 @@ def open_global_db(workspace_path: str):
         ``row_factory=sqlite3.Row``, or ``None`` if the database file is missing
         or cannot be opened. ``path`` is always the resolved global DB path.
     """
-    global_db_path = os.path.join(workspace_path, "..", "globalStorage", "state.vscdb")
-    global_db_path = os.path.normpath(global_db_path)
+    global_db_path = global_storage_db_path(workspace_path)
     if not os.path.isfile(global_db_path):
         yield None, global_db_path
         return

--- a/services/workspace_db.py
+++ b/services/workspace_db.py
@@ -113,6 +113,99 @@ def load_code_block_diff_map(global_db) -> dict[str, list]:
     return diff_map
 
 
+def load_bubbles_for_composer(global_db, composer_id: str) -> dict[str, dict]:
+    """Load ``bubbleId:{composer_id}:*`` KV entries into ``{bubble_id: bubble_dict}``.
+
+    Scoped alternative to :func:`load_bubble_map` for single-conversation assembly;
+    avoids a full global ``bubbleId:%`` scan.
+    """
+    bubble_map: dict[str, dict] = {}
+    try:
+        rows = global_db.execute(
+            "SELECT key, value FROM cursorDiskKV WHERE key LIKE ?",
+            (f"bubbleId:{composer_id}:%",),
+        ).fetchall()
+    except sqlite3.Error:
+        return bubble_map
+    for row in rows:
+        parts = row["key"].split(":")
+        if len(parts) < 3:
+            continue
+        bid = parts[2]
+        try:
+            b = json.loads(row["value"])
+            if isinstance(b, dict):
+                bubble_map[bid] = b
+        except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
+            _logger.debug("Skipping malformed bubbleId row %s: %s", row["key"], e)
+    return bubble_map
+
+
+def load_message_request_context_for_composer(
+    global_db, composer_id: str
+) -> list[dict]:
+    """Load ``messageRequestContext:{composer_id}:*`` KV entries.
+
+    Returns a list of context dicts, each with an injected ``contextId`` key
+    taken from the third path component of the KV key.  Scoped alternative to
+    the global MRC pass inside :func:`load_project_layouts_map`.
+    """
+    contexts: list[dict] = []
+    try:
+        rows = global_db.execute(
+            "SELECT key, value FROM cursorDiskKV WHERE key LIKE ?",
+            (f"messageRequestContext:{composer_id}:%",),
+        ).fetchall()
+    except sqlite3.Error:
+        return contexts
+    for row in rows:
+        parts = row["key"].split(":")
+        if len(parts) < 3:
+            continue
+        context_id = parts[2]
+        try:
+            ctx = json.loads(row["value"])
+            if isinstance(ctx, dict):
+                contexts.append({**ctx, "contextId": context_id})
+        except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
+            _logger.debug(
+                "Skipping malformed messageRequestContext row %s: %s",
+                row["key"],
+                e,
+            )
+    return contexts
+
+
+def load_code_block_diffs_for_composer(
+    global_db, composer_id: str
+) -> list[dict]:
+    """Load ``codeBlockDiff:{composer_id}:*`` KV entries.
+
+    Returns a list of diff dicts, each with an injected ``diffId`` key.
+    Scoped alternative to :func:`load_code_block_diff_map` for single-conversation
+    assembly.
+    """
+    diffs: list[dict] = []
+    try:
+        rows = global_db.execute(
+            "SELECT key, value FROM cursorDiskKV WHERE key LIKE ?",
+            (f"codeBlockDiff:{composer_id}:%",),
+        ).fetchall()
+    except sqlite3.Error:
+        return diffs
+    for row in rows:
+        parts = row["key"].split(":")
+        try:
+            d = json.loads(row["value"])
+            if isinstance(d, dict):
+                diffs.append({**d, "diffId": parts[2] if len(parts) > 2 else None})
+        except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
+            _logger.debug(
+                "Skipping malformed codeBlockDiff row %s: %s", row["key"], e
+            )
+    return diffs
+
+
 def collect_workspace_entries(workspace_path: str) -> list[dict]:
     """Scan workspace directory and return entries with workspace.json.
 

--- a/services/workspace_listing.py
+++ b/services/workspace_listing.py
@@ -17,15 +17,24 @@ from utils.path_helpers import (
     warn_workspace_json_read,
 )
 from utils.workspace_descriptor import read_json_file
-from utils.workspace_path import get_cli_chats_path
-from models import Composer, ParseWarningCollector, SchemaError
+from models import ParseWarningCollector
+from services.summary_cache import (
+    fingerprint_workspace_storage,
+    get_cached_projects,
+    nocache_enabled,
+    set_cached_projects,
+)
 from services.workspace_db import (
-    build_composer_id_to_workspace_id,
+    COMPOSER_ROWS_WITH_HEADERS_SQL,
+    build_composer_id_to_workspace_id_cached,
     collect_invalid_workspace_ids,
     collect_workspace_entries,
+    global_storage_db_path,
+    load_project_layouts_for_composer,
     load_project_layouts_map,
     open_global_db,
 )
+from utils.workspace_path import get_cli_chats_path
 from services.workspace_resolver import (
     create_project_name_to_workspace_id_map,
     create_workspace_path_to_id_map,
@@ -36,12 +45,46 @@ from services.workspace_resolver import (
 )
 
 
-def list_workspace_projects(workspace_path: str, rules: list) -> tuple[list[dict], list[dict]]:
+def _composer_valid_for_listing(
+    cd: dict,
+    composer_id: str,
+    parse_warnings: ParseWarningCollector,
+) -> bool:
+    """Lightweight list-path checks aligned with :class:`models.Composer` requirements."""
+    if "fullConversationHeadersOnly" not in cd:
+        return False
+    created_at = cd.get("createdAt")
+    if not isinstance(created_at, (int, float)) or isinstance(created_at, bool):
+        _logger.warning(
+            "Failed to parse Composer from composerData:%s: expected timestamp number for createdAt, got %s",
+            composer_id,
+            type(created_at).__name__,
+        )
+        parse_warnings.record_composer_skipped()
+        return False
+    headers = cd.get("fullConversationHeadersOnly")
+    if not isinstance(headers, list):
+        _logger.warning(
+            "Failed to parse Composer from composerData:%s: fullConversationHeadersOnly must be a list",
+            composer_id,
+        )
+        parse_warnings.record_composer_skipped()
+        return False
+    return True
+
+
+def list_workspace_projects(
+    workspace_path: str,
+    rules: list,
+    *,
+    nocache: bool = False,
+) -> tuple[list[dict], list[dict]]:
     """List workspace projects for GET /api/workspaces.
 
     Args:
         workspace_path: Cursor ``workspaceStorage`` root.
         rules: Exclusion rule token lists from :func:`utils.exclusion_rules.load_rules`.
+        nocache: When ``True``, skip the mtime-keyed disk cache (Phase 3).
 
     Returns:
         ``(projects, warnings)``. Each project dict has ``id``, ``name``,
@@ -51,17 +94,47 @@ def list_workspace_projects(workspace_path: str, rules: list) -> tuple[list[dict
         parse-error dicts (``type``, ``count``, ``detail``) from
         :meth:`models.ParseWarningCollector.to_api_list`; empty when no skips.
     """
-    parse_warnings = ParseWarningCollector()
     workspace_entries = collect_workspace_entries(workspace_path)
+    gdb = global_storage_db_path(workspace_path)
+    cli_path = get_cli_chats_path()
+    fingerprint = fingerprint_workspace_storage(
+        workspace_path,
+        workspace_entries,
+        global_db_path=gdb if os.path.isfile(gdb) else None,
+        rules=rules,
+        cli_chats_path=cli_path if os.path.isdir(cli_path) else None,
+    )
+    if not nocache_enabled(request_nocache=nocache):
+        cached = get_cached_projects(fingerprint)
+        if cached is not None:
+            return cached
+
+    projects, warnings = _build_workspace_projects_uncached(
+        workspace_path, rules, workspace_entries, nocache=nocache,
+    )
+    if not nocache_enabled(request_nocache=nocache):
+        set_cached_projects(fingerprint, projects, warnings)
+    return projects, warnings
+
+
+def _build_workspace_projects_uncached(
+    workspace_path: str,
+    rules: list,
+    workspace_entries: list[dict],
+    *,
+    nocache: bool,
+) -> tuple[list[dict], list[dict]]:
+    parse_warnings = ParseWarningCollector()
     invalid_workspace_ids = collect_invalid_workspace_ids(workspace_entries)
 
     project_name_map = create_project_name_to_workspace_id_map(workspace_entries)
     workspace_path_map = create_workspace_path_to_id_map(workspace_entries)
-    composer_id_to_ws = build_composer_id_to_workspace_id(workspace_path, workspace_entries)
+    composer_id_to_ws = build_composer_id_to_workspace_id_cached(
+        workspace_path, workspace_entries, rules, nocache=nocache,
+    )
 
     conversation_map: dict[str, list] = {}
 
-    # closing semantics now baked into the context manager (issue #17).
     with open_global_db(workspace_path) as (global_db, _):
         if global_db:
             def _safe_fetchall(query: str, params: tuple = ()) -> list:
@@ -69,32 +142,32 @@ def list_workspace_projects(workspace_path: str, rules: list) -> tuple[list[dict
                     return global_db.execute(query, params).fetchall()
                 except sqlite3.Error:
                     return []
+
             try:
-                composer_rows = _safe_fetchall(
-                    "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%' AND LENGTH(value) > 10"
-                )
+                composer_rows = _safe_fetchall(COMPOSER_ROWS_WITH_HEADERS_SQL)
 
-                project_layouts_map: dict[str, list] = load_project_layouts_map(global_db)
-                # Summary path: skip the global bubbleId scan entirely.
-                # Workspace assignment uses composer_id_to_ws (primary) and
-                # projectLayouts from MRC; bubble fallbacks are reserved for
-                # full-assembly paths (assemble_workspace_tabs, export, search).
+                project_layouts_map: dict[str, list] = {}
+                if invalid_workspace_ids:
+                    project_layouts_map = load_project_layouts_map(global_db)
+
                 bubble_map: dict[str, dict] = {}
+                invalid_workspace_aliases: dict[str, str] = {}
+                if invalid_workspace_ids:
+                    invalid_workspace_aliases = infer_invalid_workspace_aliases(
+                        composer_rows=composer_rows,
+                        project_layouts_map=project_layouts_map,
+                        project_name_map=project_name_map,
+                        workspace_path_map=workspace_path_map,
+                        workspace_entries=workspace_entries,
+                        bubble_map=bubble_map,
+                        composer_id_to_ws=composer_id_to_ws,
+                        invalid_workspace_ids=invalid_workspace_ids,
+                    )
 
-                invalid_workspace_aliases = infer_invalid_workspace_aliases(
-                    composer_rows=composer_rows,
-                    project_layouts_map=project_layouts_map,
-                    project_name_map=project_name_map,
-                    workspace_path_map=workspace_path_map,
-                    workspace_entries=workspace_entries,
-                    bubble_map=bubble_map,
-                    composer_id_to_ws=composer_id_to_ws,
-                    invalid_workspace_ids=invalid_workspace_ids,
-                )
                 for row in composer_rows:
                     cid = row["key"].split(":")[1]
                     try:
-                        parsed = json.loads(row["value"])
+                        cd = json.loads(row["value"])
                     except (json.JSONDecodeError, TypeError, ValueError) as e:
                         _logger.warning(
                             "Failed to decode Composer from composerData:%s: %s",
@@ -103,26 +176,24 @@ def list_workspace_projects(workspace_path: str, rules: list) -> tuple[list[dict
                         )
                         parse_warnings.record_composer_skipped()
                         continue
-                    if not isinstance(parsed, dict):
+                    if not isinstance(cd, dict):
                         _logger.warning(
                             "Failed to parse Composer from composerData:%s: expected object, got %s",
                             cid,
-                            type(parsed).__name__,
+                            type(cd).__name__,
                         )
                         parse_warnings.record_composer_skipped()
                         continue
-                    try:
-                        composer = Composer.from_dict(parsed, composer_id=cid)
-                    except SchemaError as e:
-                        _logger.warning(
-                            "Failed to parse Composer from composerData:%s: %s",
-                            cid,
-                            e,
-                        )
-                        parse_warnings.record_composer_skipped()
+                    if not _composer_valid_for_listing(cd, cid, parse_warnings):
                         continue
-                    cd = composer.raw
                     try:
+                        if (
+                            cid not in composer_id_to_ws
+                            and cid not in project_layouts_map
+                        ):
+                            project_layouts_map[cid] = load_project_layouts_for_composer(
+                                global_db, cid,
+                            )
                         pid = determine_project_for_conversation(
                             cd, cid, project_layouts_map,
                             project_name_map, workspace_path_map,

--- a/services/workspace_listing.py
+++ b/services/workspace_listing.py
@@ -23,7 +23,6 @@ from services.workspace_db import (
     build_composer_id_to_workspace_id,
     collect_invalid_workspace_ids,
     collect_workspace_entries,
-    load_bubble_map,
     load_project_layouts_map,
     open_global_db,
 )
@@ -76,7 +75,11 @@ def list_workspace_projects(workspace_path: str, rules: list) -> tuple[list[dict
                 )
 
                 project_layouts_map: dict[str, list] = load_project_layouts_map(global_db)
-                bubble_map: dict[str, dict] = load_bubble_map(global_db)
+                # Summary path: skip the global bubbleId scan entirely.
+                # Workspace assignment uses composer_id_to_ws (primary) and
+                # projectLayouts from MRC; bubble fallbacks are reserved for
+                # full-assembly paths (assemble_workspace_tabs, export, search).
+                bubble_map: dict[str, dict] = {}
 
                 invalid_workspace_aliases = infer_invalid_workspace_aliases(
                     composer_rows=composer_rows,
@@ -131,14 +134,7 @@ def list_workspace_projects(workspace_path: str, rules: list) -> tuple[list[dict
                         assigned = pid if pid else "global"
 
                         headers = cd.get("fullConversationHeadersOnly") or []
-                        has_bubbles = any(
-                            bubble_map.get(bubble_id)
-                            for h in headers
-                            if isinstance(h, dict)
-                            for bubble_id in [h.get("bubbleId")]
-                            if isinstance(bubble_id, str)
-                        )
-                        if not has_bubbles:
+                        if not headers:
                             continue
 
                         conversation_map.setdefault(assigned, []).append({

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -689,12 +689,15 @@ def assemble_single_tab(
         cd = composer.raw
 
         # Verify the conversation belongs to the requested workspace.
-        # Scoped MRC load for this composer only; full map + alias scan only
-        # when invalid workspace folders need majority-vote reassignment.
+        # Always scoped: only load messageRequestContext rows for this composer.
         project_layouts_map: dict[str, list] = {}
         invalid_workspace_aliases: dict[str, str] = {}
+        project_layouts_map[composer_id] = load_project_layouts_for_composer(
+            global_db, composer_id,
+        )
         if invalid_workspace_ids:
-            project_layouts_map = load_project_layouts_map(global_db)
+            # Alias resolution still needs the composer roster, but project layouts
+            # are intentionally limited to this composer (single-tab scope).
             composer_rows_for_aliases = _safe_fetchall(COMPOSER_ROWS_WITH_HEADERS_SQL)
             invalid_workspace_aliases = infer_invalid_workspace_aliases(
                 composer_rows=composer_rows_for_aliases,
@@ -705,10 +708,6 @@ def assemble_single_tab(
                 bubble_map={},
                 composer_id_to_ws=composer_id_to_ws,
                 invalid_workspace_ids=invalid_workspace_ids,
-            )
-        else:
-            project_layouts_map[composer_id] = load_project_layouts_for_composer(
-                global_db, composer_id,
             )
 
         pid = determine_project_for_conversation(

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -21,17 +21,27 @@ from utils.text_extract import extract_text_from_bubble
 from utils.tool_parser import parse_tool_call
 from utils.workspace_descriptor import read_json_file
 from models import Bubble, Composer, ParseWarningCollector, SchemaError
+from services.summary_cache import (
+    fingerprint_workspace_storage,
+    get_cached_tab_summaries,
+    nocache_enabled,
+    set_cached_tab_summaries,
+)
 from services.workspace_db import (
-    build_composer_id_to_workspace_id,
+    COMPOSER_ROWS_WITH_HEADERS_SQL,
+    build_composer_id_to_workspace_id_cached,
     collect_invalid_workspace_ids,
     collect_workspace_entries,
+    global_storage_db_path,
     load_bubbles_for_composer,
     load_code_block_diff_map,
     load_code_block_diffs_for_composer,
     load_message_request_context_for_composer,
+    load_project_layouts_for_composer,
     load_project_layouts_map,
     open_global_db,
 )
+from utils.workspace_path import get_cli_chats_path
 from services.workspace_resolver import (
     create_project_name_to_workspace_id_map,
     create_workspace_path_to_id_map,
@@ -425,6 +435,8 @@ def list_workspace_tab_summaries(
     workspace_id: str,
     workspace_path: str,
     rules: list,
+    *,
+    nocache: bool = False,
 ) -> tuple[dict, int]:
     """Return summary tab list for GET /api/workspaces/<id>/tabs?summary=1.
 
@@ -443,14 +455,46 @@ def list_workspace_tab_summaries(
         ``(payload, status)`` — same envelope as :func:`assemble_workspace_tabs`
         but ``tabs`` entries carry no ``bubbles`` field.
     """
+    workspace_entries = collect_workspace_entries(workspace_path)
+    gdb = global_storage_db_path(workspace_path)
+    cli_path = get_cli_chats_path()
+    fingerprint = fingerprint_workspace_storage(
+        workspace_path,
+        workspace_entries,
+        global_db_path=gdb if os.path.isfile(gdb) else None,
+        rules=rules,
+        cli_chats_path=cli_path if os.path.isdir(cli_path) else None,
+    )
+    if not nocache_enabled(request_nocache=nocache):
+        cached = get_cached_tab_summaries(fingerprint, workspace_id)
+        if cached is not None:
+            return cached
+
+    payload, status = _build_workspace_tab_summaries_uncached(
+        workspace_id, workspace_path, rules, workspace_entries, nocache=nocache,
+    )
+    if status == 200 and not nocache_enabled(request_nocache=nocache):
+        set_cached_tab_summaries(fingerprint, workspace_id, payload, status)
+    return payload, status
+
+
+def _build_workspace_tab_summaries_uncached(
+    workspace_id: str,
+    workspace_path: str,
+    rules: list,
+    workspace_entries: list,
+    *,
+    nocache: bool,
+) -> tuple[dict, int]:
     parse_warnings = ParseWarningCollector()
     response: dict = {"tabs": []}
 
-    workspace_entries = collect_workspace_entries(workspace_path)
     invalid_workspace_ids = collect_invalid_workspace_ids(workspace_entries)
     project_name_map = create_project_name_to_workspace_id_map(workspace_entries)
     workspace_path_map = create_workspace_path_to_id_map(workspace_entries)
-    composer_id_to_ws = build_composer_id_to_workspace_id(workspace_path, workspace_entries)
+    composer_id_to_ws = build_composer_id_to_workspace_id_cached(
+        workspace_path, workspace_entries, rules, nocache=nocache,
+    )
     matching_ws_ids = _build_matching_ws_ids(workspace_id, workspace_path, workspace_entries)
 
     with open_global_db(workspace_path) as (global_db, _):
@@ -465,32 +509,29 @@ def list_workspace_tab_summaries(
             except sqlite3.Error:
                 return []
 
-        # Summary path: load only MRC for project-layout resolution — no global
-        # bubbleId scan.
-        project_layouts_map: dict[str, list] = load_project_layouts_map(global_db)
+        project_layouts_map: dict[str, list] = {}
+        if invalid_workspace_ids:
+            project_layouts_map = load_project_layouts_map(global_db)
 
-        composer_rows = _safe_fetchall(
-            "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
-            " AND value IS NOT NULL"
-            " AND value LIKE '%fullConversationHeadersOnly%'"
-            " AND value NOT LIKE '%fullConversationHeadersOnly\":[]%'"
-        )
+        composer_rows = _safe_fetchall(COMPOSER_ROWS_WITH_HEADERS_SQL)
 
-        invalid_workspace_aliases = infer_invalid_workspace_aliases(
-            composer_rows=composer_rows,
-            project_layouts_map=project_layouts_map,
-            project_name_map=project_name_map,
-            workspace_path_map=workspace_path_map,
-            workspace_entries=workspace_entries,
-            bubble_map={},
-            composer_id_to_ws=composer_id_to_ws,
-            invalid_workspace_ids=invalid_workspace_ids,
-        )
+        invalid_workspace_aliases: dict[str, str] = {}
+        if invalid_workspace_ids:
+            invalid_workspace_aliases = infer_invalid_workspace_aliases(
+                composer_rows=composer_rows,
+                project_layouts_map=project_layouts_map,
+                project_name_map=project_name_map,
+                workspace_path_map=workspace_path_map,
+                workspace_entries=workspace_entries,
+                bubble_map={},
+                composer_id_to_ws=composer_id_to_ws,
+                invalid_workspace_ids=invalid_workspace_ids,
+            )
 
         for row in composer_rows:
             composer_id = row["key"].split(":")[1]
             try:
-                parsed = json.loads(row["value"])
+                cd = json.loads(row["value"])
             except (json.JSONDecodeError, TypeError, ValueError) as e:
                 payload_len, payload_fp = _kv_payload_log_meta(row["value"])
                 _logger.warning(
@@ -502,19 +543,17 @@ def list_workspace_tab_summaries(
                 )
                 parse_warnings.record_composer_skipped()
                 continue
-            try:
-                composer = Composer.from_dict(parsed, composer_id=composer_id)
-            except SchemaError as e:
-                _logger.warning(
-                    "Failed to parse Composer from composerData:%s: %s",
-                    composer_id,
-                    e,
-                )
+            if not isinstance(cd, dict):
                 parse_warnings.record_composer_skipped()
                 continue
             try:
-                cd = composer.raw
-
+                if (
+                    composer_id not in composer_id_to_ws
+                    and composer_id not in project_layouts_map
+                ):
+                    project_layouts_map[composer_id] = load_project_layouts_for_composer(
+                        global_db, composer_id,
+                    )
                 pid = determine_project_for_conversation(
                     cd, composer_id, project_layouts_map,
                     project_name_map, workspace_path_map,
@@ -600,7 +639,9 @@ def assemble_single_tab(
     invalid_workspace_ids = collect_invalid_workspace_ids(workspace_entries)
     project_name_map = create_project_name_to_workspace_id_map(workspace_entries)
     workspace_path_map = create_workspace_path_to_id_map(workspace_entries)
-    composer_id_to_ws = build_composer_id_to_workspace_id(workspace_path, workspace_entries)
+    composer_id_to_ws = build_composer_id_to_workspace_id_cached(
+        workspace_path, workspace_entries, rules,
+    )
     matching_ws_ids = _build_matching_ws_ids(workspace_id, workspace_path, workspace_entries)
 
     with open_global_db(workspace_path) as (global_db, _):
@@ -731,7 +772,9 @@ def assemble_workspace_tabs(
     invalid_workspace_ids = collect_invalid_workspace_ids(workspace_entries)
     project_name_map = create_project_name_to_workspace_id_map(workspace_entries)
     workspace_path_map = create_workspace_path_to_id_map(workspace_entries)
-    composer_id_to_ws = build_composer_id_to_workspace_id(workspace_path, workspace_entries)
+    composer_id_to_ws = build_composer_id_to_workspace_id_cached(
+        workspace_path, workspace_entries, rules,
+    )
     matching_ws_ids = _build_matching_ws_ids(workspace_id, workspace_path, workspace_entries)
 
     bubble_map: dict[str, dict] = {}

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -689,26 +689,27 @@ def assemble_single_tab(
         cd = composer.raw
 
         # Verify the conversation belongs to the requested workspace.
-        # Use MRC-based project layouts (no bubble scan) for the resolver.
-        project_layouts_map: dict[str, list] = load_project_layouts_map(global_db)
-
-        # Build aliases for workspace resolution (empty bubble_map — summary path)
-        composer_rows_for_aliases = _safe_fetchall(
-            "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
-            " AND value IS NOT NULL"
-            " AND value LIKE '%fullConversationHeadersOnly%'"
-            " AND value NOT LIKE '%fullConversationHeadersOnly\":[]%'"
-        )
-        invalid_workspace_aliases = infer_invalid_workspace_aliases(
-            composer_rows=composer_rows_for_aliases,
-            project_layouts_map=project_layouts_map,
-            project_name_map=project_name_map,
-            workspace_path_map=workspace_path_map,
-            workspace_entries=workspace_entries,
-            bubble_map={},
-            composer_id_to_ws=composer_id_to_ws,
-            invalid_workspace_ids=invalid_workspace_ids,
-        )
+        # Scoped MRC load for this composer only; full map + alias scan only
+        # when invalid workspace folders need majority-vote reassignment.
+        project_layouts_map: dict[str, list] = {}
+        invalid_workspace_aliases: dict[str, str] = {}
+        if invalid_workspace_ids:
+            project_layouts_map = load_project_layouts_map(global_db)
+            composer_rows_for_aliases = _safe_fetchall(COMPOSER_ROWS_WITH_HEADERS_SQL)
+            invalid_workspace_aliases = infer_invalid_workspace_aliases(
+                composer_rows=composer_rows_for_aliases,
+                project_layouts_map=project_layouts_map,
+                project_name_map=project_name_map,
+                workspace_path_map=workspace_path_map,
+                workspace_entries=workspace_entries,
+                bubble_map={},
+                composer_id_to_ws=composer_id_to_ws,
+                invalid_workspace_ids=invalid_workspace_ids,
+            )
+        else:
+            project_layouts_map[composer_id] = load_project_layouts_for_composer(
+                global_db, composer_id,
+            )
 
         pid = determine_project_for_conversation(
             cd, composer_id, project_layouts_map,

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -25,7 +25,11 @@ from services.workspace_db import (
     build_composer_id_to_workspace_id,
     collect_invalid_workspace_ids,
     collect_workspace_entries,
+    load_bubbles_for_composer,
     load_code_block_diff_map,
+    load_code_block_diffs_for_composer,
+    load_message_request_context_for_composer,
+    load_project_layouts_map,
     open_global_db,
 )
 from services.workspace_resolver import (
@@ -77,6 +81,630 @@ def _kv_payload_log_meta(value: object | None) -> tuple[int, str | None]:
     return len(payload), hashlib.sha256(payload).hexdigest()[:12]
 
 
+def _assemble_tab_from_composer_data(
+    composer_id: str,
+    cd: dict,
+    bubble_map: dict[str, dict],
+    contexts: list[dict],
+    code_block_diffs: list[dict],
+    workspace_display_name: str,
+    rules: list,
+    parse_warnings: ParseWarningCollector,
+) -> dict | None:
+    """Assemble a single tab dict from an already-parsed composer dict.
+
+    Args:
+        composer_id: Composer UUID.
+        cd: Raw ``composerData`` dict (``composer.raw``).
+        bubble_map: ``{bubble_id: bubble_dict}`` — may be global or scoped.
+        contexts: ``messageRequestContext`` entries for *this* composer
+            (list of dicts, each with an injected ``contextId`` key and a
+            ``bubbleId`` field from the JSON value).
+        code_block_diffs: ``codeBlockDiff`` entries for *this* composer.
+        workspace_display_name: Human-readable workspace name for rule matching.
+        rules: Exclusion rule token lists.
+        parse_warnings: Collector for skipped-bubble warnings.
+
+    Returns:
+        A tab dict on success, or ``None`` when the tab should be omitted
+        (no renderable bubbles or excluded by rules).
+    """
+    headers = cd.get("fullConversationHeadersOnly") or []
+
+    bubbles: list[dict[str, Any]] = []
+    for header in headers:
+        if not isinstance(header, dict):
+            continue
+        bubble_id = header.get("bubbleId")
+        if not isinstance(bubble_id, str):
+            continue
+        bubble = bubble_map.get(bubble_id)
+        if not bubble:
+            continue
+
+        is_user = header.get("type") == 1
+        msg_type = "user" if is_user else "ai"
+        text = extract_text_from_bubble(bubble)
+
+        context_text = ""
+        for ctx in contexts:
+            if ctx.get("bubbleId") == bubble_id:
+                if ctx.get("gitStatusRaw"):
+                    context_text += f"\n\n**Git Status:**\n```\n{ctx['gitStatusRaw']}\n```"
+                tf = ctx.get("terminalFiles")
+                if isinstance(tf, list) and tf:
+                    context_text += "\n\n**Terminal Files:**"
+                    for f in tf:
+                        if not isinstance(f, dict):
+                            continue
+                        context_text += f"\n- {f.get('path', '')}"
+                af = ctx.get("attachedFoldersListDirResults")
+                if isinstance(af, list) and af:
+                    context_text += "\n\n**Attached Folders:**"
+                    for fld in af:
+                        if not isinstance(fld, dict):
+                            continue
+                        files = fld.get("files")
+                        if isinstance(files, list) and files:
+                            context_text += f"\n\n**Folder:** {fld.get('path', 'Unknown')}"
+                            for fi in files:
+                                if not isinstance(fi, dict):
+                                    continue
+                                context_text += f"\n- {fi.get('name', '')} ({fi.get('type', '')})"
+                cr = ctx.get("cursorRules")
+                if isinstance(cr, list) and cr:
+                    context_text += "\n\n**Cursor Rules:**"
+                    for rule in cr:
+                        if not isinstance(rule, dict):
+                            continue
+                        context_text += f"\n- {rule.get('name') or rule.get('description') or 'Rule'}"
+                sc = ctx.get("summarizedComposers")
+                if isinstance(sc, list) and sc:
+                    context_text += "\n\n**Related Conversations:**"
+                    for comp in sc:
+                        if not isinstance(comp, dict):
+                            continue
+                        context_text += f"\n- {comp.get('name') or comp.get('composerId') or 'Conversation'}"
+
+        full_text = text + context_text
+        raw = bubble
+        token_count = raw.get("tokenCount")
+
+        tool_calls = None
+        tfd = raw.get("toolFormerData")
+        if isinstance(tfd, dict):
+            tool_call = parse_tool_call(tfd)
+            if isinstance(tool_call, dict):
+                tool_calls = [tool_call]
+
+        thinking = None
+        thinking_duration_ms = None
+        if raw.get("thinking"):
+            thinking = raw["thinking"] if isinstance(raw["thinking"], str) else (raw["thinking"].get("text") if isinstance(raw["thinking"], dict) else None)
+            thinking_duration_ms = raw.get("thinkingDurationMs")
+
+        has_content = full_text.strip() or tool_calls or thinking
+        if not has_content:
+            continue
+
+        ctx_window = raw.get("contextWindowStatusAtCreation") or {}
+        ctx_pct = None
+        if isinstance(ctx_window, dict):
+            if ctx_window.get("percentageRemainingFloat") is not None:
+                ctx_pct = ctx_window.get("percentageRemainingFloat")
+            elif ctx_window.get("percentageRemaining") is not None:
+                ctx_pct = ctx_window.get("percentageRemaining")
+
+        display_text = full_text.strip()
+        if not display_text and tool_calls:
+            tc = tool_calls[0]
+            if isinstance(tc, dict):
+                display_text = f"**Tool: {tc.get('name', 'unknown')}**"
+                if tc.get("status"):
+                    display_text += f" ({tc['status']})"
+        if not display_text and thinking:
+            display_text = thinking
+
+        bubble_meta = None
+        model_info = raw.get("modelInfo") or {}
+        model_name = model_info.get("modelName")
+        if model_name == "default":
+            model_name = None
+
+        if msg_type == "ai":
+            tc_dict = token_count if isinstance(token_count, dict) else {}
+            in_tok = tc_dict.get("inputTokens") or 0
+            out_tok = tc_dict.get("outputTokens") or 0
+            cached_tok = tc_dict.get("cachedTokens") or 0
+            bubble_meta = {
+                "modelName": model_name,
+                "inputTokens": in_tok if in_tok > 0 else None,
+                "outputTokens": out_tok if out_tok > 0 else None,
+                "cachedTokens": cached_tok if cached_tok > 0 else None,
+                "toolResultsCount": (len(tool_calls) if tool_calls else None) or (len(raw["toolResults"]) if isinstance(raw.get("toolResults"), list) and raw["toolResults"] else None),
+                "toolResults": raw.get("toolResults") if isinstance(raw.get("toolResults"), list) and raw["toolResults"] else None,
+                "toolCalls": tool_calls,
+                "thinking": thinking,
+                "thinkingDurationMs": thinking_duration_ms,
+                "contextWindowPercent": ctx_pct,
+            }
+        elif msg_type == "user":
+            bubble_meta = {
+                "modelName": model_name,
+                "contextWindowPercent": ctx_pct,
+            }
+            if ctx_window:
+                tokens_used = ctx_window.get("tokensUsed", 0)
+                token_limit = ctx_window.get("tokenLimit", 0)
+                if tokens_used > 0:
+                    bubble_meta["contextTokensUsed"] = tokens_used
+                if token_limit > 0:
+                    bubble_meta["contextTokenLimit"] = token_limit
+
+        if bubble_meta:
+            bubble_meta = {k: v for k, v in bubble_meta.items() if v is not None}
+            if not bubble_meta:
+                bubble_meta = None
+
+        b_entry = {
+            "type": msg_type,
+            "text": display_text,
+            "timestamp": to_epoch_ms(bubble.get("createdAt")) or to_epoch_ms(bubble.get("timestamp")) or int(datetime.now().timestamp() * 1000),
+        }
+        if bubble_meta:
+            b_entry["metadata"] = bubble_meta
+        bubbles.append(b_entry)
+
+    if not bubbles:
+        return None
+
+    title = cd.get("name") or f"Conversation {composer_id[:8]}"
+    if not cd.get("name") and bubbles:
+        first_msg = bubbles[0].get("text", "")
+        if first_msg:
+            first_lines = [ln for ln in first_msg.split("\n") if ln.strip()]
+            if first_lines:
+                title = first_lines[0][:100]
+                if len(title) == 100:
+                    title += "..."
+
+    _early_model_config = cd.get("modelConfig") or {}
+    _early_model_name = _early_model_config.get("modelName")
+    _early_model_names = [_early_model_name] if _early_model_name and _early_model_name != "default" else None
+    if is_excluded_by_rules(rules, build_searchable_text(
+        project_name=workspace_display_name,
+        chat_title=title,
+        model_names=_early_model_names,
+    )):
+        return None
+
+    bubbles.sort(key=lambda b: b.get("timestamp") or 0)
+
+    last_user_ts = None
+    for b in bubbles:
+        if b["type"] == "user":
+            last_user_ts = b.get("timestamp")
+        elif b["type"] == "ai" and last_user_ts is not None:
+            ts = b.get("timestamp")
+            if ts and ts > last_user_ts:
+                meta = b.setdefault("metadata", {})
+                meta["responseTimeMs"] = ts - last_user_ts
+
+    total_input = 0
+    total_output = 0
+    total_cached = 0
+    total_response_ms = 0
+    total_cost = 0.0
+    total_tool_calls = 0
+    total_thinking_ms = 0
+    models_set: set = set()
+    for b in bubbles:
+        m = b.get("metadata") or {}
+        if m.get("inputTokens"):
+            total_input += m["inputTokens"]
+        if m.get("outputTokens"):
+            total_output += m["outputTokens"]
+        if m.get("cachedTokens"):
+            total_cached += m["cachedTokens"]
+        if m.get("responseTimeMs"):
+            total_response_ms += m["responseTimeMs"]
+        if m.get("cost") is not None:
+            total_cost += m["cost"]
+        if m.get("modelName"):
+            models_set.add(m["modelName"])
+        if m.get("toolCalls"):
+            total_tool_calls += len(m["toolCalls"])
+        if m.get("thinkingDurationMs"):
+            total_thinking_ms += m["thinkingDurationMs"]
+
+    usage = cd.get("usageData") or {}
+    composer_cost = usage.get("cost") or usage.get("estimatedCost")
+    if isinstance(composer_cost, (int, float)) and total_cost == 0:
+        total_cost = composer_cost
+
+    lines_added = cd.get("totalLinesAdded", 0)
+    lines_removed = cd.get("totalLinesRemoved", 0)
+    files_added = cd.get("addedFiles", 0)
+    files_removed = cd.get("removedFiles", 0)
+
+    max_ctx_tokens = 0
+    ctx_token_limit = 0
+    for b in bubbles:
+        m = b.get("metadata") or {}
+        if m.get("contextTokensUsed", 0) > max_ctx_tokens:
+            max_ctx_tokens = m["contextTokensUsed"]
+        if m.get("contextTokenLimit", 0) > ctx_token_limit:
+            ctx_token_limit = m["contextTokenLimit"]
+
+    tab_meta = None
+    has_any = any([total_input, total_output, total_cached, total_response_ms,
+                  total_cost, models_set, total_tool_calls, total_thinking_ms,
+                  lines_added, lines_removed, files_added, files_removed,
+                  max_ctx_tokens])
+    if has_any:
+        tab_meta_raw = {
+            "totalInputTokens": total_input or None,
+            "totalOutputTokens": total_output or None,
+            "totalCachedTokens": total_cached or None,
+            "modelsUsed": list(models_set) if models_set else None,
+            "totalResponseTimeMs": total_response_ms or None,
+            "totalCost": total_cost if total_cost > 0 else None,
+            "totalToolCalls": total_tool_calls or None,
+            "totalThinkingDurationMs": total_thinking_ms or None,
+            "totalLinesAdded": lines_added if lines_added else None,
+            "totalLinesRemoved": lines_removed if lines_removed else None,
+            "totalFilesAdded": files_added if files_added else None,
+            "totalFilesRemoved": files_removed if files_removed else None,
+            "maxContextTokensUsed": max_ctx_tokens if max_ctx_tokens else None,
+            "contextTokenLimit": ctx_token_limit if ctx_token_limit else None,
+        }
+        tab_meta = {k: v for k, v in tab_meta_raw.items() if v is not None}
+
+    model_config = cd.get("modelConfig") or {}
+    model_name_from_config = model_config.get("modelName")
+    if model_name_from_config and model_name_from_config != "default":
+        if not tab_meta:
+            tab_meta = {}
+        models_used = tab_meta.get("modelsUsed")
+        if not isinstance(models_used, list):
+            tab_meta["modelsUsed"] = [model_name_from_config]
+        elif model_name_from_config not in models_used:
+            models_used.insert(0, model_name_from_config)
+
+    tab: dict[str, Any] = {
+        "id": composer_id,
+        "title": title,
+        "timestamp": to_epoch_ms(cd.get("lastUpdatedAt")) or to_epoch_ms(cd.get("createdAt")) or int(datetime.now().timestamp() * 1000),
+        "bubbles": [{
+            "type": b["type"],
+            "text": b.get("text", ""),
+            "timestamp": b.get("timestamp", 0),
+            **({"metadata": b["metadata"]} if b.get("metadata") else {}),
+        } for b in bubbles],
+        "codeBlockDiffs": code_block_diffs,
+    }
+    if tab_meta:
+        tab["metadata"] = tab_meta
+    return tab
+
+
+def _build_matching_ws_ids(workspace_id: str, workspace_path: str, workspace_entries: list) -> set[str]:
+    """Return the set of workspace folder IDs that share the same project folder as *workspace_id*.
+
+    Cursor sometimes creates multiple workspace entries for the same on-disk
+    project; conversations recorded under any of those IDs belong to the same
+    project view.
+    """
+    matching: set[str] = {workspace_id}
+    if workspace_id == "global":
+        return matching
+    target_folder = ""
+    wj_path = os.path.join(workspace_path, workspace_id, "workspace.json")
+    try:
+        wd = read_json_file(wj_path)
+        folders = get_workspace_folder_paths(wd)
+        first_folder = folders[0] if folders else None
+        if first_folder:
+            target_folder = normalize_file_path(first_folder)
+    except Exception as e:
+        warn_workspace_json_read(_logger, workspace_id, e)
+    if target_folder:
+        for entry in workspace_entries:
+            try:
+                wd2 = read_json_file(entry["workspaceJsonPath"])
+                folders2 = get_workspace_folder_paths(wd2)
+                f2 = folders2[0] if folders2 else None
+                if f2 and normalize_file_path(f2) == target_folder:
+                    matching.add(entry["name"])
+            except Exception as e:
+                warn_workspace_json_read(_logger, entry["name"], e)
+    return matching
+
+
+def list_workspace_tab_summaries(
+    workspace_id: str,
+    workspace_path: str,
+    rules: list,
+) -> tuple[dict, int]:
+    """Return summary tab list for GET /api/workspaces/<id>/tabs?summary=1.
+
+    Does **not** load the global ``bubbleId:%`` index.  Each tab entry contains
+    only the fields needed by the sidebar: ``id``, ``title``, ``timestamp``,
+    ``messageCount``, and an optional ``metadata.modelsUsed``.  Full bubble
+    bodies are omitted; the UI fetches them on demand via
+    ``GET /api/workspaces/<id>/tabs/<composer_id>``.
+
+    Args:
+        workspace_id: Workspace folder name, or ``"global"`` for unassigned chats.
+        workspace_path: Cursor ``workspaceStorage`` root.
+        rules: Exclusion rule token lists.
+
+    Returns:
+        ``(payload, status)`` — same envelope as :func:`assemble_workspace_tabs`
+        but ``tabs`` entries carry no ``bubbles`` field.
+    """
+    parse_warnings = ParseWarningCollector()
+    response: dict = {"tabs": []}
+
+    workspace_entries = collect_workspace_entries(workspace_path)
+    invalid_workspace_ids = collect_invalid_workspace_ids(workspace_entries)
+    project_name_map = create_project_name_to_workspace_id_map(workspace_entries)
+    workspace_path_map = create_workspace_path_to_id_map(workspace_entries)
+    composer_id_to_ws = build_composer_id_to_workspace_id(workspace_path, workspace_entries)
+    matching_ws_ids = _build_matching_ws_ids(workspace_id, workspace_path, workspace_entries)
+
+    with open_global_db(workspace_path) as (global_db, _):
+        if global_db is None:
+            return {"error": "Global storage not found"}, 404
+
+        workspace_display_name = lookup_workspace_display_name(workspace_path, workspace_id)
+
+        def _safe_fetchall(query: str, params: tuple = ()) -> list:
+            try:
+                return global_db.execute(query, params).fetchall()
+            except sqlite3.Error:
+                return []
+
+        # Summary path: load only MRC for project-layout resolution — no global
+        # bubbleId scan.
+        project_layouts_map: dict[str, list] = load_project_layouts_map(global_db)
+
+        composer_rows = _safe_fetchall(
+            "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
+            " AND value IS NOT NULL"
+            " AND value LIKE '%fullConversationHeadersOnly%'"
+            " AND value NOT LIKE '%fullConversationHeadersOnly\":[]%'"
+        )
+
+        invalid_workspace_aliases = infer_invalid_workspace_aliases(
+            composer_rows=composer_rows,
+            project_layouts_map=project_layouts_map,
+            project_name_map=project_name_map,
+            workspace_path_map=workspace_path_map,
+            workspace_entries=workspace_entries,
+            bubble_map={},
+            composer_id_to_ws=composer_id_to_ws,
+            invalid_workspace_ids=invalid_workspace_ids,
+        )
+
+        for row in composer_rows:
+            composer_id = row["key"].split(":")[1]
+            try:
+                parsed = json.loads(row["value"])
+            except (json.JSONDecodeError, TypeError, ValueError) as e:
+                payload_len, payload_fp = _kv_payload_log_meta(row["value"])
+                _logger.warning(
+                    "Failed to decode Composer from composerData:%s: %s (payload_len=%d, payload_sha256=%s)",
+                    composer_id,
+                    e,
+                    payload_len,
+                    payload_fp,
+                )
+                parse_warnings.record_composer_skipped()
+                continue
+            try:
+                composer = Composer.from_dict(parsed, composer_id=composer_id)
+            except SchemaError as e:
+                _logger.warning(
+                    "Failed to parse Composer from composerData:%s: %s",
+                    composer_id,
+                    e,
+                )
+                parse_warnings.record_composer_skipped()
+                continue
+            try:
+                cd = composer.raw
+
+                pid = determine_project_for_conversation(
+                    cd, composer_id, project_layouts_map,
+                    project_name_map, workspace_path_map,
+                    workspace_entries, {}, composer_id_to_ws, invalid_workspace_ids,
+                )
+                mapped_ws = composer_id_to_ws.get(composer_id)
+                if not pid and mapped_ws in invalid_workspace_ids:
+                    pid = invalid_workspace_aliases.get(mapped_ws)
+                assigned = pid if pid else "global"
+
+                if assigned not in matching_ws_ids:
+                    continue
+
+                headers = cd.get("fullConversationHeadersOnly") or []
+                if not headers:
+                    continue
+
+                title = cd.get("name") or f"Conversation {composer_id[:8]}"
+
+                _early_model_config = cd.get("modelConfig") or {}
+                _early_model_name = _early_model_config.get("modelName")
+                _early_model_names = [_early_model_name] if _early_model_name and _early_model_name != "default" else None
+                if is_excluded_by_rules(rules, build_searchable_text(
+                    project_name=workspace_display_name,
+                    chat_title=title,
+                    model_names=_early_model_names,
+                )):
+                    continue
+
+                tab_meta: dict | None = None
+                if _early_model_names:
+                    tab_meta = {"modelsUsed": _early_model_names}
+
+                tab_entry: dict = {
+                    "id": composer_id,
+                    "title": title,
+                    "timestamp": to_epoch_ms(cd.get("lastUpdatedAt")) or to_epoch_ms(cd.get("createdAt")) or int(datetime.now().timestamp() * 1000),
+                    "messageCount": len(headers),
+                }
+                if tab_meta:
+                    tab_entry["metadata"] = tab_meta
+                response["tabs"].append(tab_entry)
+
+            except Exception as e:
+                _logger.warning(
+                    "Failed to process Composer from composerData:%s: %s",
+                    composer_id,
+                    e,
+                )
+                parse_warnings.record_composer_processing_failure()
+
+        response["tabs"].sort(key=lambda t: t.get("timestamp") or 0, reverse=True)
+        return parse_warnings.attach_to(response), 200
+
+
+def assemble_single_tab(
+    workspace_id: str,
+    composer_id: str,
+    workspace_path: str,
+    rules: list,
+) -> tuple[dict, int]:
+    """Assemble a single conversation tab for GET /api/workspaces/<id>/tabs/<composer_id>.
+
+    Loads only the KV rows scoped to *composer_id* (``bubbleId:{id}:%``,
+    ``messageRequestContext:{id}:%``, ``codeBlockDiff:{id}:%``) instead of
+    performing a full global scan.
+
+    Args:
+        workspace_id: Workspace folder name, or ``"global"``.
+        composer_id: UUID of the composer / conversation to assemble.
+        workspace_path: Cursor ``workspaceStorage`` root.
+        rules: Exclusion rule token lists.
+
+    Returns:
+        ``(payload, status)``.  On success (``200``), *payload* is
+        ``{"tab": {...}}``, optionally with ``"warnings"``.  ``404`` when the
+        global DB is missing, the composer is not found, or it is not assigned
+        to *workspace_id*.
+    """
+    parse_warnings = ParseWarningCollector()
+
+    workspace_entries = collect_workspace_entries(workspace_path)
+    invalid_workspace_ids = collect_invalid_workspace_ids(workspace_entries)
+    project_name_map = create_project_name_to_workspace_id_map(workspace_entries)
+    workspace_path_map = create_workspace_path_to_id_map(workspace_entries)
+    composer_id_to_ws = build_composer_id_to_workspace_id(workspace_path, workspace_entries)
+    matching_ws_ids = _build_matching_ws_ids(workspace_id, workspace_path, workspace_entries)
+
+    with open_global_db(workspace_path) as (global_db, _):
+        if global_db is None:
+            return {"error": "Global storage not found"}, 404
+
+        workspace_display_name = lookup_workspace_display_name(workspace_path, workspace_id)
+
+        def _safe_fetchall(query: str, params: tuple = ()) -> list:
+            try:
+                return global_db.execute(query, params).fetchall()
+            except sqlite3.Error:
+                return []
+
+        rows = _safe_fetchall(
+            "SELECT key, value FROM cursorDiskKV WHERE key = ?",
+            (f"composerData:{composer_id}",),
+        )
+        if not rows:
+            return {"error": "Conversation not found"}, 404
+
+        row = rows[0]
+        try:
+            parsed = json.loads(row["value"])
+        except (json.JSONDecodeError, TypeError, ValueError) as e:
+            payload_len, payload_fp = _kv_payload_log_meta(row["value"])
+            _logger.warning(
+                "Failed to decode Composer from composerData:%s: %s (payload_len=%d, payload_sha256=%s)",
+                composer_id,
+                e,
+                payload_len,
+                payload_fp,
+            )
+            return {"error": "Failed to parse conversation"}, 500
+        try:
+            composer = Composer.from_dict(parsed, composer_id=composer_id)
+        except SchemaError as e:
+            _logger.warning(
+                "Failed to parse Composer from composerData:%s: %s",
+                composer_id,
+                e,
+            )
+            return {"error": "Failed to parse conversation"}, 500
+
+        cd = composer.raw
+
+        # Verify the conversation belongs to the requested workspace.
+        # Use MRC-based project layouts (no bubble scan) for the resolver.
+        project_layouts_map: dict[str, list] = load_project_layouts_map(global_db)
+
+        # Build aliases for workspace resolution (empty bubble_map — summary path)
+        composer_rows_for_aliases = _safe_fetchall(
+            "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
+            " AND value IS NOT NULL"
+            " AND value LIKE '%fullConversationHeadersOnly%'"
+            " AND value NOT LIKE '%fullConversationHeadersOnly\":[]%'"
+        )
+        invalid_workspace_aliases = infer_invalid_workspace_aliases(
+            composer_rows=composer_rows_for_aliases,
+            project_layouts_map=project_layouts_map,
+            project_name_map=project_name_map,
+            workspace_path_map=workspace_path_map,
+            workspace_entries=workspace_entries,
+            bubble_map={},
+            composer_id_to_ws=composer_id_to_ws,
+            invalid_workspace_ids=invalid_workspace_ids,
+        )
+
+        pid = determine_project_for_conversation(
+            cd, composer_id, project_layouts_map,
+            project_name_map, workspace_path_map,
+            workspace_entries, {}, composer_id_to_ws, invalid_workspace_ids,
+        )
+        mapped_ws = composer_id_to_ws.get(composer_id)
+        if not pid and mapped_ws in invalid_workspace_ids:
+            pid = invalid_workspace_aliases.get(mapped_ws)
+        assigned = pid if pid else "global"
+
+        if assigned not in matching_ws_ids:
+            return {"error": "Conversation not found"}, 404
+
+        # Scoped loads — only rows for this composer_id.
+        bubble_map = load_bubbles_for_composer(global_db, composer_id)
+        contexts = load_message_request_context_for_composer(global_db, composer_id)
+        code_block_diffs = load_code_block_diffs_for_composer(global_db, composer_id)
+
+        tab = _assemble_tab_from_composer_data(
+            composer_id=composer_id,
+            cd=cd,
+            bubble_map=bubble_map,
+            contexts=contexts,
+            code_block_diffs=code_block_diffs,
+            workspace_display_name=workspace_display_name,
+            rules=rules,
+            parse_warnings=parse_warnings,
+        )
+
+        if tab is None:
+            return {"error": "Conversation not found"}, 404
+
+        response: dict = {"tab": tab}
+        return parse_warnings.attach_to(response), 200
+
+
 def assemble_workspace_tabs(
     workspace_id: str,
     workspace_path: str,
@@ -104,31 +732,7 @@ def assemble_workspace_tabs(
     project_name_map = create_project_name_to_workspace_id_map(workspace_entries)
     workspace_path_map = create_workspace_path_to_id_map(workspace_entries)
     composer_id_to_ws = build_composer_id_to_workspace_id(workspace_path, workspace_entries)
-
-    # Build set of all workspace IDs that share the same folder as workspace_id
-    # (handles Cursor creating multiple workspace entries for the same project)
-    matching_ws_ids = {workspace_id}
-    if workspace_id != "global":
-        target_folder = ""
-        wj_path = os.path.join(workspace_path, workspace_id, "workspace.json")
-        try:
-            wd = read_json_file(wj_path)
-            folders = get_workspace_folder_paths(wd)
-            first_folder = folders[0] if folders else None
-            if first_folder:
-                target_folder = normalize_file_path(first_folder)
-        except Exception as e:
-            warn_workspace_json_read(_logger, workspace_id, e)
-        if target_folder:
-            for entry in workspace_entries:
-                try:
-                    wd2 = read_json_file(entry["workspaceJsonPath"])
-                    folders2 = get_workspace_folder_paths(wd2)
-                    f2 = folders2[0] if folders2 else None
-                    if f2 and normalize_file_path(f2) == target_folder:
-                        matching_ws_ids.add(entry["name"])
-                except Exception as e:
-                    warn_workspace_json_read(_logger, entry["name"], e)
+    matching_ws_ids = _build_matching_ws_ids(workspace_id, workspace_path, workspace_entries)
 
     bubble_map: dict[str, dict] = {}
     code_block_diff_map: dict[str, list] = {}
@@ -285,311 +889,18 @@ def assemble_workspace_tabs(
                 if assigned not in matching_ws_ids:
                     continue
 
-                headers = cd.get("fullConversationHeadersOnly") or []
-
-                # Build bubbles. Annotated as list[dict[str, Any]] so mypy
-                # treats nested .get("metadata") / m["inputTokens"] etc. as
-                # accessing dict values rather than `object`.
-                bubbles: list[dict[str, Any]] = []
-                for header in headers:
-                    if not isinstance(header, dict):
-                        continue
-                    bubble_id = header.get("bubbleId")
-                    if not isinstance(bubble_id, str):
-                        continue
-                    bubble = bubble_map.get(bubble_id)
-                    if not bubble:
-                        continue
-
-                    is_user = header.get("type") == 1
-                    msg_type = "user" if is_user else "ai"
-                    text = extract_text_from_bubble(bubble)
-
-                    # Append messageRequestContext info
-                    context_text = ""
-                    for ctx in message_request_context_map.get(composer_id, []):
-                        if ctx.get("bubbleId") == bubble_id:
-                            if ctx.get("gitStatusRaw"):
-                                context_text += f"\n\n**Git Status:**\n```\n{ctx['gitStatusRaw']}\n```"
-                            tf = ctx.get("terminalFiles")
-                            if isinstance(tf, list) and tf:
-                                context_text += "\n\n**Terminal Files:**"
-                                for f in tf:
-                                    if not isinstance(f, dict):
-                                        continue
-                                    context_text += f"\n- {f.get('path', '')}"
-                            af = ctx.get("attachedFoldersListDirResults")
-                            if isinstance(af, list) and af:
-                                context_text += "\n\n**Attached Folders:**"
-                                for fld in af:
-                                    if not isinstance(fld, dict):
-                                        continue
-                                    files = fld.get("files")
-                                    if isinstance(files, list) and files:
-                                        context_text += f"\n\n**Folder:** {fld.get('path', 'Unknown')}"
-                                        for fi in files:
-                                            if not isinstance(fi, dict):
-                                                continue
-                                            context_text += f"\n- {fi.get('name', '')} ({fi.get('type', '')})"
-                            cr = ctx.get("cursorRules")
-                            if isinstance(cr, list) and cr:
-                                context_text += "\n\n**Cursor Rules:**"
-                                for rule in cr:
-                                    if not isinstance(rule, dict):
-                                        continue
-                                    context_text += f"\n- {rule.get('name') or rule.get('description') or 'Rule'}"
-                            sc = ctx.get("summarizedComposers")
-                            if isinstance(sc, list) and sc:
-                                context_text += "\n\n**Related Conversations:**"
-                                for comp in sc:
-                                    if not isinstance(comp, dict):
-                                        continue
-                                    context_text += f"\n- {comp.get('name') or comp.get('composerId') or 'Conversation'}"
-
-                    full_text = text + context_text
-
-                    raw = bubble
-                    token_count = raw.get("tokenCount")
-
-                    # Tool calls
-                    tool_calls = None
-                    tfd = raw.get("toolFormerData")
-                    if isinstance(tfd, dict):
-                        tool_call = parse_tool_call(tfd)
-                        if isinstance(tool_call, dict):
-                            tool_calls = [tool_call]
-
-                    # Thinking
-                    thinking = None
-                    thinking_duration_ms = None
-                    if raw.get("thinking"):
-                        thinking = raw["thinking"] if isinstance(raw["thinking"], str) else (raw["thinking"].get("text") if isinstance(raw["thinking"], dict) else None)
-                        thinking_duration_ms = raw.get("thinkingDurationMs")
-
-                    has_content = full_text.strip() or tool_calls or thinking
-                    if not has_content:
-                        continue
-
-                    # Context window
-                    ctx_window = raw.get("contextWindowStatusAtCreation") or {}
-                    ctx_pct = None
-                    if isinstance(ctx_window, dict):
-                        if ctx_window.get("percentageRemainingFloat") is not None:
-                            ctx_pct = ctx_window.get("percentageRemainingFloat")
-                        elif ctx_window.get("percentageRemaining") is not None:
-                            ctx_pct = ctx_window.get("percentageRemaining")
-
-                    # Display text fallbacks
-                    display_text = full_text.strip()
-                    if not display_text and tool_calls:
-                        tc = tool_calls[0]
-                        if isinstance(tc, dict):
-                            display_text = f"**Tool: {tc.get('name', 'unknown')}**"
-                            if tc.get("status"):
-                                display_text += f" ({tc['status']})"
-                    if not display_text and thinking:
-                        display_text = thinking
-
-                    # Build metadata for BOTH user and AI bubbles
-                    bubble_meta = None
-                    if bubble:
-                        model_info = raw.get("modelInfo") or {}
-                        model_name = model_info.get("modelName")
-                        if model_name == "default":
-                            model_name = None
-
-                        if msg_type == "ai":
-                            tc_dict = token_count if isinstance(token_count, dict) else {}
-                            in_tok = tc_dict.get("inputTokens") or 0
-                            out_tok = tc_dict.get("outputTokens") or 0
-                            cached_tok = tc_dict.get("cachedTokens") or 0
-                            bubble_meta = {
-                                "modelName": model_name,
-                                "inputTokens": in_tok if in_tok > 0 else None,
-                                "outputTokens": out_tok if out_tok > 0 else None,
-                                "cachedTokens": cached_tok if cached_tok > 0 else None,
-                                "toolResultsCount": (len(tool_calls) if tool_calls else None) or (len(raw["toolResults"]) if isinstance(raw.get("toolResults"), list) and raw["toolResults"] else None),
-                                "toolResults": raw.get("toolResults") if isinstance(raw.get("toolResults"), list) and raw["toolResults"] else None,
-                                "toolCalls": tool_calls,
-                                "thinking": thinking,
-                                "thinkingDurationMs": thinking_duration_ms,
-                                "contextWindowPercent": ctx_pct,
-                            }
-                        elif msg_type == "user":
-                            bubble_meta = {
-                                "modelName": model_name,
-                                "contextWindowPercent": ctx_pct,
-                            }
-                            if ctx_window:
-                                tokens_used = ctx_window.get("tokensUsed", 0)
-                                token_limit = ctx_window.get("tokenLimit", 0)
-                                if tokens_used > 0:
-                                    bubble_meta["contextTokensUsed"] = tokens_used
-                                if token_limit > 0:
-                                    bubble_meta["contextTokenLimit"] = token_limit
-
-                        if bubble_meta:
-                            bubble_meta = {k: v for k, v in bubble_meta.items() if v is not None}
-                            if not bubble_meta:
-                                bubble_meta = None
-
-                    b_entry = {
-                        "type": msg_type,
-                        "text": display_text,
-                        "timestamp": to_epoch_ms(bubble.get("createdAt")) or to_epoch_ms(bubble.get("timestamp")) or int(datetime.now().timestamp() * 1000),
-                    }
-                    if bubble_meta:
-                        b_entry["metadata"] = bubble_meta
-                    bubbles.append(b_entry)
-
-                if not bubbles:
-                    continue
-
-                # Title
-                title = cd.get("name") or f"Conversation {composer_id[:8]}"
-                if not cd.get("name") and bubbles:
-                    first_msg = bubbles[0].get("text", "")
-                    if first_msg:
-                        first_lines = [ln for ln in first_msg.split("\n") if ln.strip()]
-                        if first_lines:
-                            title = first_lines[0][:100]
-                            if len(title) == 100:
-                                title += "..."
-
-                # Early exclusion check — before expensive metadata aggregation
-                _early_model_config = cd.get("modelConfig") or {}
-                _early_model_name = _early_model_config.get("modelName")
-                _early_model_names = [_early_model_name] if _early_model_name and _early_model_name != "default" else None
-                if is_excluded_by_rules(rules, build_searchable_text(
-                    project_name=workspace_display_name,
-                    chat_title=title,
-                    model_names=_early_model_names,
-                )):
-                    continue
-
-                # codeBlockDiffs are emitted as a structured ``tab.codeBlockDiffs``
-                # field below; the dashboard reads them from there (download.js,
-                # workspace.html). Previously this loop also pushed a synthetic
-                # ``Tool Action`` AI bubble into ``tab.bubbles``, double-representing
-                # every diff on the wire and forcing a ``synthetic`` filter in the
-                # response-time pass. Dropping the synthesis — frontend never read it.
-                diffs = code_block_diff_map.get(composer_id, [])
-
-                bubbles.sort(key=lambda b: b.get("timestamp") or 0)
-
-                # Response time calculation
-                last_user_ts = None
-                for b in bubbles:
-                    if b["type"] == "user":
-                        last_user_ts = b.get("timestamp")
-                    elif b["type"] == "ai" and last_user_ts is not None:
-                        ts = b.get("timestamp")
-                        if ts and ts > last_user_ts:
-                            meta = b.setdefault("metadata", {})
-                            meta["responseTimeMs"] = ts - last_user_ts
-
-                # Aggregate metadata
-                total_input = 0
-                total_output = 0
-                total_cached = 0
-                total_response_ms = 0
-                total_cost = 0.0
-                total_tool_calls = 0
-                total_thinking_ms = 0
-                models_set: set = set()
-                for b in bubbles:
-                    m = b.get("metadata") or {}
-                    if m.get("inputTokens"):
-                        total_input += m["inputTokens"]
-                    if m.get("outputTokens"):
-                        total_output += m["outputTokens"]
-                    if m.get("cachedTokens"):
-                        total_cached += m["cachedTokens"]
-                    if m.get("responseTimeMs"):
-                        total_response_ms += m["responseTimeMs"]
-                    if m.get("cost") is not None:
-                        total_cost += m["cost"]
-                    if m.get("modelName"):
-                        models_set.add(m["modelName"])
-                    if m.get("toolCalls"):
-                        total_tool_calls += len(m["toolCalls"])
-                    if m.get("thinkingDurationMs"):
-                        total_thinking_ms += m["thinkingDurationMs"]
-
-                # Composer-level cost fallback
-                usage = cd.get("usageData") or {}
-                composer_cost = usage.get("cost") or usage.get("estimatedCost")
-                if isinstance(composer_cost, (int, float)) and total_cost == 0:
-                    total_cost = composer_cost
-
-                # Composer-level lines/files changed
-                lines_added = cd.get("totalLinesAdded", 0)
-                lines_removed = cd.get("totalLinesRemoved", 0)
-                files_added = cd.get("addedFiles", 0)
-                files_removed = cd.get("removedFiles", 0)
-
-                # Context window progression from user bubbles
-                max_ctx_tokens = 0
-                ctx_token_limit = 0
-                for b in bubbles:
-                    m = b.get("metadata") or {}
-                    if m.get("contextTokensUsed", 0) > max_ctx_tokens:
-                        max_ctx_tokens = m["contextTokensUsed"]
-                    if m.get("contextTokenLimit", 0) > ctx_token_limit:
-                        ctx_token_limit = m["contextTokenLimit"]
-
-                tab_meta = None
-                has_any = any([total_input, total_output, total_cached, total_response_ms,
-                              total_cost, models_set, total_tool_calls, total_thinking_ms,
-                              lines_added, lines_removed, files_added, files_removed,
-                              max_ctx_tokens])
-                if has_any:
-                    tab_meta_raw = {
-                        "totalInputTokens": total_input or None,
-                        "totalOutputTokens": total_output or None,
-                        "totalCachedTokens": total_cached or None,
-                        "modelsUsed": list(models_set) if models_set else None,
-                        "totalResponseTimeMs": total_response_ms or None,
-                        "totalCost": total_cost if total_cost > 0 else None,
-                        "totalToolCalls": total_tool_calls or None,
-                        "totalThinkingDurationMs": total_thinking_ms or None,
-                        "totalLinesAdded": lines_added if lines_added else None,
-                        "totalLinesRemoved": lines_removed if lines_removed else None,
-                        "totalFilesAdded": files_added if files_added else None,
-                        "totalFilesRemoved": files_removed if files_removed else None,
-                        "maxContextTokensUsed": max_ctx_tokens if max_ctx_tokens else None,
-                        "contextTokenLimit": ctx_token_limit if ctx_token_limit else None,
-                    }
-                    tab_meta = {k: v for k, v in tab_meta_raw.items() if v is not None}
-
-                # Model config from composer data
-                model_config = cd.get("modelConfig") or {}
-                model_name_from_config = model_config.get("modelName")
-                if model_name_from_config and model_name_from_config != "default":
-                    if not tab_meta:
-                        tab_meta = {}
-                    models_used = tab_meta.get("modelsUsed")
-                    if not isinstance(models_used, list):
-                        tab_meta["modelsUsed"] = [model_name_from_config]
-                    elif model_name_from_config not in models_used:
-                        models_used.insert(0, model_name_from_config)
-
-                tab = {
-                    "id": composer_id,
-                    "title": title,
-                    "timestamp": to_epoch_ms(cd.get("lastUpdatedAt")) or to_epoch_ms(cd.get("createdAt")) or int(datetime.now().timestamp() * 1000),
-                    "bubbles": [{
-                        "type": b["type"],
-                        "text": b.get("text", ""),
-                        "timestamp": b.get("timestamp", 0),
-                        **({"metadata": b["metadata"]} if b.get("metadata") else {}),
-                    } for b in bubbles],
-                    "codeBlockDiffs": diffs,
-                }
-                if tab_meta:
-                    tab["metadata"] = tab_meta
-
-                response["tabs"].append(tab)
+                tab = _assemble_tab_from_composer_data(
+                    composer_id=composer_id,
+                    cd=cd,
+                    bubble_map=bubble_map,
+                    contexts=message_request_context_map.get(composer_id, []),
+                    code_block_diffs=code_block_diff_map.get(composer_id, []),
+                    workspace_display_name=workspace_display_name,
+                    rules=rules,
+                    parse_warnings=parse_warnings,
+                )
+                if tab is not None:
+                    response["tabs"].append(tab)
 
             except Exception as e:
                 _logger.warning(

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -106,7 +106,10 @@ a { color: var(--link); text-decoration: none; }
 a:hover { text-decoration: underline; }
 
 /* ---------- Layout ---------- */
-.container { max-width: 1200px; margin: 0 auto; padding: 1.5rem 1rem; flex: 1; }
+/* width: 100% is required here: body is display:flex + flex-direction:column,
+ * and auto horizontal margins (margin: 0 auto) suppress align-items:stretch,
+ * so without an explicit width the container collapses to content width. */
+.container { width: 100%; max-width: 1200px; margin: 0 auto; padding: 1.5rem 1rem; flex: 1; }
 
 /* ---------- Navbar ---------- */
 .navbar {
@@ -297,10 +300,24 @@ h3 { font-size: 1.15rem; font-weight: 600; }
 .dropdown-item:hover { background: var(--bg-hover); text-decoration: none; }
 
 /* ---------- Loading ---------- */
-.loading { display: flex; flex-direction: column; align-items: center; padding: 3rem 0; gap: 1rem; }
+.loading,
+.loading-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  gap: 1rem;
+  text-align: center;
+}
+.loading { padding: 3rem 0; }
+.loading-center { color: var(--text-muted); font-size: 0.9rem; }
 .spinner {
+  display: block;
+  flex-shrink: 0;
   width: 2rem;
   height: 2rem;
+  margin-inline: auto;
   border: 3px solid var(--border);
   border-top-color: var(--spinner);
   border-radius: 50%;
@@ -324,7 +341,17 @@ h3 { font-size: 1.15rem; font-weight: 600; }
  * URL inside .main-content would push the column wider than 1fr — overflowing
  * the viewport on the right. min-width: 0 lets the column shrink and lets the
  * existing overflow-x: auto on .prose pre handle the scroll inside the bubble. */
-.main-content { min-width: 0; }
+/* min-height prevents the right column from collapsing during lazy-load (issue #84). */
+.main-content { min-width: 0; min-height: 60vh; }
+
+/* Loading state: full-width cell; .loading-center centers spinner + label. */
+.main-content.is-loading {
+  width: 100%;
+  min-height: 60vh;
+}
+.main-content.is-loading .loading-center {
+  min-height: 60vh;
+}
 
 /* ---------- Sidebar ---------- */
 .sidebar {
@@ -357,6 +384,13 @@ h3 { font-size: 1.15rem; font-weight: 600; }
 .sidebar::-webkit-scrollbar { width: 6px; }
 .sidebar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
 .sidebar::-webkit-scrollbar-track { background: transparent; }
+
+/* Placeholder shown in the sidebar column while summary tabs are fetching */
+.sidebar-loading {
+  width: 100%;
+  padding: 1.5rem 0;
+  opacity: 0.5;
+}
 
 /* Scroll hint at the bottom */
 .sidebar-scroll-hint {

--- a/templates/workspace.html
+++ b/templates/workspace.html
@@ -39,17 +39,17 @@
     <p class="text-sm text-muted" id="convo-count"></p>
   </div>
 
-  <div id="loading" class="loading">
-    <div class="spinner"></div>
-    <p>Loading conversations...</p>
-  </div>
-
-  <!-- Content grid -->
-  <div id="content-grid" class="workspace-grid" style="display:none">
-    <div class="sidebar" id="sidebar"></div>
-    <div class="main-content" id="main-content">
-      <div class="card" style="padding:2rem;text-align:center">
-        <p class="text-muted">No conversation selected</p>
+  <!-- Content grid — always in layout so column widths never collapse -->
+  <div id="content-grid" class="workspace-grid">
+    <div class="sidebar" id="sidebar">
+      <div class="sidebar-loading loading-center">
+        <div class="spinner" style="width:1.25rem;height:1.25rem;border-width:2px"></div>
+      </div>
+    </div>
+    <div class="main-content is-loading" id="main-content">
+      <div class="loading-center">
+        <div class="spinner"></div>
+        <p>Loading conversations…</p>
       </div>
     </div>
   </div>
@@ -78,8 +78,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       document.getElementById('project-hash').textContent = WORKSPACE_ID;
     }
 
-    document.getElementById('loading').style.display = 'none';
-    document.getElementById('content-grid').style.display = 'grid';
     document.getElementById('convo-count').textContent = `${allTabs.length} conversations`;
 
     renderSidebar();
@@ -92,7 +90,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       selectTab(allTabs[0].id);
     }
   } catch (e) {
-    document.getElementById('loading').innerHTML = '<p class="text-danger">Failed to load workspace.</p>';
+    const main = document.getElementById('main-content');
+    main.classList.remove('is-loading');
+    main.innerHTML =
+      '<div class="card" style="padding:2rem;text-align:center"><p class="text-danger">Failed to load workspace.</p></div>';
+    document.getElementById('sidebar').innerHTML = '';
   }
 });
 
@@ -143,8 +145,10 @@ async function selectTab(id) {
     selectedTab = summary;
     tabCache[id] = summary;
   } else {
-    document.getElementById('main-content').innerHTML =
-      '<div class="card" style="padding:2rem;text-align:center"><div class="spinner"></div><p>Loading conversation…</p></div>';
+    const main = document.getElementById('main-content');
+    main.classList.add('is-loading');
+    main.innerHTML =
+      '<div class="loading-center" style="min-height:60vh"><div class="spinner"></div><p>Loading conversation…</p></div>';
     try {
       const res = await fetch(`/api/workspaces/${WORKSPACE_ID}/tabs/${id}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -154,7 +158,9 @@ async function selectTab(id) {
       tabCache[id] = data.tab;
       selectedTab = data.tab;
     } catch (e) {
-      document.getElementById('main-content').innerHTML =
+      const main = document.getElementById('main-content');
+      main.classList.remove('is-loading');
+      main.innerHTML =
         `<div class="card" style="padding:2rem;text-align:center"><p class="text-danger">Failed to load conversation: ${escapeHtml(e.message)}</p></div>`;
       return;
     }
@@ -170,6 +176,7 @@ async function selectTab(id) {
 
 function renderChat(tab) {
   const main = document.getElementById('main-content');
+  main.classList.remove('is-loading');
   const bubbles = (tab.bubbles || []).filter(b => b.text && b.text.trim());
 
   let html = `<div class="card" style="padding:1.5rem">

--- a/templates/workspace.html
+++ b/templates/workspace.html
@@ -57,14 +57,15 @@
 
 <script>
 const WORKSPACE_ID = "{{ workspace_id }}";
-let allTabs = [];
-let selectedTab = null;
+let allTabs = [];        // summary tabs (no bubbles) from ?summary=1
+let tabCache = {};       // id → full tab (with bubbles), populated on first open
+let selectedTab = null;  // always a full tab once a conversation is opened
 
 document.addEventListener('DOMContentLoaded', async () => {
   try {
     const [wsRes, tabsRes] = await Promise.all([
       fetch(`/api/workspaces/${WORKSPACE_ID}`),
-      fetch(`/api/workspaces/${WORKSPACE_ID}/tabs`)
+      fetch(`/api/workspaces/${WORKSPACE_ID}/tabs?summary=1`)
     ]);
     const wsInfo = await wsRes.json();
     const data = await tabsRes.json();
@@ -105,7 +106,6 @@ function renderSidebar() {
   for (const tab of allTabs) {
     const title = escapeHtml(tab.title || `Chat ${tab.id.slice(0,8)}`);
     const ts = formatDate(tab.timestamp);
-    // Show model if available
     const model = (tab.metadata && tab.metadata.modelsUsed && tab.metadata.modelsUsed[0]) || '';
     const modelBadge = model ? `<span style="font-size:0.65rem;opacity:0.5;display:block;margin-top:1px">${escapeHtml(model)}</span>` : '';
     html += `<button class="sidebar-item" data-id="${tab.id}" onclick="selectTab('${tab.id}')" title="${title}">
@@ -113,16 +113,15 @@ function renderSidebar() {
       <div class="sidebar-item-time">${ts}${modelBadge}</div>
     </button>`;
   }
-  // Scroll hint if many items
   if (allTabs.length > 8) {
     html += '<div class="sidebar-scroll-hint">Scroll for more</div>';
   }
   sidebar.innerHTML = html;
 }
 
-function selectTab(id) {
-  selectedTab = allTabs.find(t => t.id === id);
-  if (!selectedTab) return;
+async function selectTab(id) {
+  const summary = allTabs.find(t => t.id === id);
+  if (!summary) return;
 
   const url = new URL(window.location);
   url.searchParams.set('tab', id);
@@ -132,16 +131,41 @@ function selectTab(id) {
     el.classList.toggle('active', el.dataset.id === id);
   });
 
+  // Scroll the active sidebar item into view
+  const activeEl = document.querySelector('.sidebar-item.active');
+  if (activeEl) activeEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+
+  // Resolve full tab: use cache if available, lazy-fetch if not
+  if (tabCache[id]) {
+    selectedTab = tabCache[id];
+  } else if (summary.bubbles) {
+    // Fallback: summary endpoint returned a full tab (e.g. old server version)
+    selectedTab = summary;
+    tabCache[id] = summary;
+  } else {
+    document.getElementById('main-content').innerHTML =
+      '<div class="card" style="padding:2rem;text-align:center"><div class="spinner"></div><p>Loading conversation…</p></div>';
+    try {
+      const res = await fetch(`/api/workspaces/${WORKSPACE_ID}/tabs/${id}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      if (data.error) throw new Error(data.error);
+      showIncompleteResultsBanner('parse-warnings-host', data.warnings);
+      tabCache[id] = data.tab;
+      selectedTab = data.tab;
+    } catch (e) {
+      document.getElementById('main-content').innerHTML =
+        `<div class="card" style="padding:2rem;text-align:center"><p class="text-danger">Failed to load conversation: ${escapeHtml(e.message)}</p></div>`;
+      return;
+    }
+  }
+
   document.getElementById('action-buttons').style.display = 'flex';
 
   const codeEditsBtn = document.getElementById('dl-code-edits');
   codeEditsBtn.style.display = (selectedTab.codeBlockDiffs && selectedTab.codeBlockDiffs.length) ? 'block' : 'none';
 
   renderChat(selectedTab);
-
-  // Scroll the active sidebar item into view
-  const activeEl = document.querySelector('.sidebar-item.active');
-  if (activeEl) activeEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
 }
 
 function renderChat(tab) {

--- a/templates/workspace.html
+++ b/templates/workspace.html
@@ -122,6 +122,7 @@ function renderSidebar() {
 }
 
 async function selectTab(id) {
+  selectTab._latest = id;
   const summary = allTabs.find(t => t.id === id);
   if (!summary) return;
 
@@ -139,9 +140,11 @@ async function selectTab(id) {
 
   // Resolve full tab: use cache if available, lazy-fetch if not
   if (tabCache[id]) {
+    if (selectTab._latest !== id) return;
     selectedTab = tabCache[id];
   } else if (summary.bubbles) {
     // Fallback: summary endpoint returned a full tab (e.g. old server version)
+    if (selectTab._latest !== id) return;
     selectedTab = summary;
     tabCache[id] = summary;
   } else {
@@ -151,13 +154,16 @@ async function selectTab(id) {
       '<div class="loading-center" style="min-height:60vh"><div class="spinner"></div><p>Loading conversation…</p></div>';
     try {
       const res = await fetch(`/api/workspaces/${WORKSPACE_ID}/tabs/${id}`);
+      if (selectTab._latest !== id) return;
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
+      if (selectTab._latest !== id) return;
       if (data.error) throw new Error(data.error);
       showIncompleteResultsBanner('parse-warnings-host', data.warnings);
       tabCache[id] = data.tab;
       selectedTab = data.tab;
     } catch (e) {
+      if (selectTab._latest !== id) return;
       const main = document.getElementById('main-content');
       main.classList.remove('is-loading');
       main.innerHTML =
@@ -165,6 +171,8 @@ async function selectTab(id) {
       return;
     }
   }
+
+  if (selectTab._latest !== id) return;
 
   document.getElementById('action-buttons').style.display = 'flex';
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -102,6 +102,52 @@ class TestGetWorkspaceTabs:
         body = response.get_json()
         assert "error" in body
 
+    def test_summary_query_returns_tab_list_without_bubbles(self, client):
+        response = client.get(f"/api/workspaces/{HAPPY_WORKSPACE_ID}/tabs?summary=1")
+        assert response.status_code == 200
+        body = response.get_json()
+        assert "tabs" in body and isinstance(body["tabs"], list)
+        assert body["tabs"], "expected at least one summary tab"
+        tab = next(t for t in body["tabs"] if t["id"] == HAPPY_COMPOSER_ID)
+        assert "title" in tab
+        assert "timestamp" in tab and isinstance(tab["timestamp"], int)
+        assert "messageCount" in tab and isinstance(tab["messageCount"], int)
+        assert "bubbles" not in tab
+
+    def test_summary_query_global_workspace(self, client):
+        response = client.get("/api/workspaces/global/tabs?summary=1")
+        assert response.status_code == 200
+        body = response.get_json()
+        assert "tabs" in body and isinstance(body["tabs"], list)
+
+
+class TestGetWorkspaceTab:
+    def test_happy_path_returns_single_tab(self, client):
+        response = client.get(
+            f"/api/workspaces/{HAPPY_WORKSPACE_ID}/tabs/{HAPPY_COMPOSER_ID}"
+        )
+        assert response.status_code == 200
+        body = response.get_json()
+        assert "tab" in body
+        tab = body["tab"]
+        assert tab["id"] == HAPPY_COMPOSER_ID
+        assert "title" in tab
+        assert "timestamp" in tab and isinstance(tab["timestamp"], int)
+        assert "bubbles" in tab and isinstance(tab["bubbles"], list)
+        assert "codeBlockDiffs" in tab
+
+    def test_unknown_composer_returns_404(self, client):
+        response = client.get(
+            f"/api/workspaces/{HAPPY_WORKSPACE_ID}/tabs/no-such-composer"
+        )
+        assert response.status_code == 404
+        assert "error" in response.get_json()
+
+    def test_cli_workspace_returns_400(self, client):
+        response = client.get("/api/workspaces/cli:proj-1/tabs/cmp-happy")
+        assert response.status_code == 400
+        assert "error" in response.get_json()
+
 
 # ---------------------------------------------------------------------------
 # GET /api/search?q=...

--- a/tests/test_parse_warnings.py
+++ b/tests/test_parse_warnings.py
@@ -145,7 +145,10 @@ class TestServiceParseWarnings(unittest.TestCase):
             with sqlite3.connect(global_db) as conn:
                 conn.execute(
                     "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
-                    ("composerData:cmp-bad-json", '{"broken":1'),
+                    (
+                        "composerData:cmp-bad-json",
+                        '{"fullConversationHeadersOnly":[{"bubbleId":"b1"}], "createdAt":',
+                    ),
                 )
                 conn.commit()
             with patch("services.workspace_listing.list_cli_projects", return_value=[]):
@@ -270,7 +273,10 @@ class TestApiParseWarnings(unittest.TestCase):
             with sqlite3.connect(global_db) as conn:
                 conn.execute(
                     "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
-                    ("composerData:cmp-bad-json", '{"broken":1'),
+                    (
+                        "composerData:cmp-bad-json",
+                        '{"fullConversationHeadersOnly":[{"bubbleId":"b1"}], "createdAt":',
+                    ),
                 )
                 conn.commit()
             with patch("api.workspaces.resolve_workspace_path", return_value=ws_root), \

--- a/tests/test_project_layouts_dict_shape.py
+++ b/tests/test_project_layouts_dict_shape.py
@@ -67,7 +67,7 @@ def _make_workspace_storage(parent: str, *, layout_as_dict: bool) -> str:
 
 class TestProjectLayoutsDictShape(unittest.TestCase):
     def _assert_assigned_to_workspace(self, ws_root: str) -> None:
-        projects, _warnings = list_workspace_projects(ws_root, rules=[])
+        projects, _warnings = list_workspace_projects(ws_root, rules=[], nocache=True)
         ids = [p["id"] for p in projects]
         self.assertIn("ws-a", ids, msg=f"expected composer routed to ws-a, got {ids}")
 

--- a/tests/test_summary_cache.py
+++ b/tests/test_summary_cache.py
@@ -65,6 +65,25 @@ class TestSummaryCache(unittest.TestCase):
             fp = fingerprint_workspace_storage(ws, entries, global_db_path=None, rules=[])
             self.assertTrue(fp["workspace_files"])
 
+    def test_workspace_files_fingerprint_round_trip(self):
+        """JSON cache round-trip must match freshly computed workspace_files fingerprints."""
+        with tempfile.TemporaryDirectory() as ws:
+            entry_dir = os.path.join(ws, "entry1")
+            os.makedirs(entry_dir)
+            db = os.path.join(entry_dir, "state.vscdb")
+            with open(db, "wb") as f:
+                f.write(b"x")
+            entries = [{"name": "entry1", "workspaceJsonPath": os.path.join(entry_dir, "workspace.json")}]
+            fp = fingerprint_workspace_storage(ws, entries, global_db_path=None, rules=[])
+            projects = [{"id": "a", "name": "A", "conversationCount": 1, "lastModified": "x"}]
+            warnings: list = []
+            set_cached_projects(fp, projects, warnings)
+            fp2 = fingerprint_workspace_storage(ws, entries, global_db_path=None, rules=[])
+            hit = get_cached_projects(fp2)
+            self.assertIsNotNone(hit, msg="cache miss after JSON round-trip of workspace_files")
+            assert hit is not None
+            self.assertEqual(hit[0], projects)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_summary_cache.py
+++ b/tests/test_summary_cache.py
@@ -1,0 +1,70 @@
+"""Phase 3 — mtime-keyed summary disk cache."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from services import summary_cache
+from pathlib import Path
+
+from services.summary_cache import (
+    fingerprint_workspace_storage,
+    get_cached_projects,
+    set_cached_projects,
+)
+
+
+class TestSummaryCache(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cache_patch = patch.object(summary_cache, "CACHE_DIR", self.tmp.name)
+        self.cache_patch.start()
+        summary_cache.PROJECTS_CACHE_FILE = Path(self.tmp.name) / "projects.json"
+
+    def tearDown(self):
+        self.cache_patch.stop()
+        self.tmp.cleanup()
+
+    def test_cache_hit_when_fingerprint_unchanged(self):
+        fp = {"version": 1, "workspace_path": "/ws", "global_db_mtime_ns": 100}
+        projects = [{"id": "a", "name": "A", "conversationCount": 1, "lastModified": "x"}]
+        warnings: list = []
+        set_cached_projects(fp, projects, warnings)
+        hit = get_cached_projects(fp)
+        self.assertIsNotNone(hit)
+        assert hit is not None
+        self.assertEqual(hit[0], projects)
+
+    def test_cache_miss_when_fingerprint_changes(self):
+        fp1 = {"version": 1, "workspace_path": "/ws", "global_db_mtime_ns": 100}
+        fp2 = {**fp1, "global_db_mtime_ns": 101}
+        set_cached_projects(fp1, [{"id": "a"}], [])
+        self.assertIsNone(get_cached_projects(fp2))
+
+    def test_nocache_env(self):
+        with patch.dict(os.environ, {"CURSOR_CHAT_BROWSER_NOCACHE": "1"}):
+            self.assertTrue(summary_cache.nocache_enabled())
+
+    def test_fingerprint_includes_workspace_files(self):
+        with tempfile.TemporaryDirectory() as ws:
+            entry_dir = os.path.join(ws, "entry1")
+            os.makedirs(entry_dir)
+            db = os.path.join(entry_dir, "state.vscdb")
+            with open(db, "wb") as f:
+                f.write(b"x")
+            entries = [{"name": "entry1", "workspaceJsonPath": os.path.join(entry_dir, "workspace.json")}]
+            fp = fingerprint_workspace_storage(ws, entries, global_db_path=None, rules=[])
+            self.assertTrue(fp["workspace_files"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workspace_listing_performance.py
+++ b/tests/test_workspace_listing_performance.py
@@ -1,0 +1,138 @@
+"""Phase 1 regression — GET /api/workspaces must not scan global bubbleId rows.
+
+Verifies that list_workspace_projects() never issues a
+``SELECT … LIKE 'bubbleId:%'`` query against global storage and still returns
+the correct project card shape.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from unittest.mock import call, patch
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from services.workspace_listing import list_workspace_projects
+
+COMPOSER_ID = "composer-list-perf"
+BUBBLE_ID = "bubble-list-perf"
+
+
+def _make_fixture(base: str) -> str:
+    """Create a minimal workspaceStorage with global KV rows; return ws_path."""
+    ws_path = os.path.join(base, "workspaceStorage")
+    os.makedirs(ws_path)
+    global_dir = os.path.join(base, "globalStorage")
+    os.makedirs(global_dir)
+
+    db_path = os.path.join(global_dir, "state.vscdb")
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+
+    # A bubble row that must NOT be read on the list path.
+    conn.execute(
+        "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+        (
+            f"bubbleId:{COMPOSER_ID}:{BUBBLE_ID}",
+            json.dumps({"type": 1, "text": "hello", "createdAt": 1_739_200_000_000}),
+        ),
+    )
+    # A composerData row with a non-empty fullConversationHeadersOnly — the
+    # summary path uses this to decide whether to include the conversation.
+    conn.execute(
+        "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+        (
+            f"composerData:{COMPOSER_ID}",
+            json.dumps({
+                "name": "Perf Test Chat",
+                "modelConfig": {"modelName": "gpt-4o"},
+                "fullConversationHeadersOnly": [{"bubbleId": BUBBLE_ID, "type": 1}],
+                "lastUpdatedAt": 1_739_300_000_000,
+                "createdAt": 1_739_200_000_000,
+            }),
+        ),
+    )
+    conn.commit()
+    conn.close()
+    return ws_path
+
+
+class TestListWorkspaceProjectsNoBubbleScan(unittest.TestCase):
+    """list_workspace_projects must not query bubbleId rows from global storage."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_no_global_bubble_id_query(self):
+        ws_path = _make_fixture(self.tmp.name)
+
+        executed_queries: list[str] = []
+
+        original_open_global_db = None
+        import services.workspace_db as _ws_db_mod
+
+        original_open_global_db = _ws_db_mod.open_global_db
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _spying_open_global_db(workspace_path):
+            with original_open_global_db(workspace_path) as (conn, path):
+                if conn is not None:
+                    original_execute = conn.execute
+
+                    def _spying_execute(query, params=()):
+                        executed_queries.append(query)
+                        return original_execute(query, params)
+
+                    conn.execute = _spying_execute  # type: ignore[method-assign]
+                yield conn, path
+
+        with patch.object(_ws_db_mod, "open_global_db", _spying_open_global_db):
+            projects, warnings = list_workspace_projects(ws_path, rules=[])
+
+        bubble_scans = [q for q in executed_queries if "bubbleId:%" in q]
+        self.assertEqual(
+            bubble_scans,
+            [],
+            msg=f"list_workspace_projects issued a global bubbleId:% scan:\n{bubble_scans}",
+        )
+
+    def test_projects_still_returned_without_bubble_scan(self):
+        """Conversations present in fullConversationHeadersOnly appear even without bubbles."""
+        ws_path = _make_fixture(self.tmp.name)
+
+        projects, warnings = list_workspace_projects(ws_path, rules=[])
+
+        # The fixture has no workspace entries (no state.vscdb / workspace.json),
+        # so the conversation lands in the "global" bucket.
+        global_bucket = next((p for p in projects if p["id"] == "global"), None)
+        self.assertIsNotNone(
+            global_bucket,
+            msg=f"Expected a 'global' project bucket; got: {[p['id'] for p in projects]}",
+        )
+        self.assertGreaterEqual(global_bucket["conversationCount"], 1)
+
+    def test_output_shape_preserved(self):
+        """Project cards still carry id, name, conversationCount, lastModified."""
+        ws_path = _make_fixture(self.tmp.name)
+        projects, _ = list_workspace_projects(ws_path, rules=[])
+        for p in projects:
+            self.assertIn("id", p)
+            self.assertIn("name", p)
+            self.assertIn("conversationCount", p)
+            self.assertIn("lastModified", p)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workspace_listing_performance.py
+++ b/tests/test_workspace_listing_performance.py
@@ -13,12 +13,13 @@ import sqlite3
 import sys
 import tempfile
 import unittest
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
+import services.workspace_listing as _ws_listing_mod
 from services.workspace_listing import list_workspace_projects
 
 COMPOSER_ID = "composer-list-perf"
@@ -78,10 +79,7 @@ class TestListWorkspaceProjectsNoBubbleScan(unittest.TestCase):
 
         executed_queries: list[str] = []
 
-        original_open_global_db = None
-        import services.workspace_db as _ws_db_mod
-
-        original_open_global_db = _ws_db_mod.open_global_db
+        original_open_global_db = _ws_listing_mod.open_global_db
 
         from contextlib import contextmanager
 
@@ -89,18 +87,13 @@ class TestListWorkspaceProjectsNoBubbleScan(unittest.TestCase):
         def _spying_open_global_db(workspace_path):
             with original_open_global_db(workspace_path) as (conn, path):
                 if conn is not None:
-                    original_execute = conn.execute
-
-                    def _spying_execute(query, params=()):
-                        executed_queries.append(query)
-                        return original_execute(query, params)
-
-                    conn.execute = _spying_execute  # type: ignore[method-assign]
+                    conn.set_trace_callback(executed_queries.append)
                 yield conn, path
 
-        with patch.object(_ws_db_mod, "open_global_db", _spying_open_global_db):
-            projects, warnings = list_workspace_projects(ws_path, rules=[])
+        with patch.object(_ws_listing_mod, "open_global_db", _spying_open_global_db):
+            list_workspace_projects(ws_path, rules=[], nocache=True)
 
+        self.assertTrue(executed_queries, msg="expected SQL queries to be recorded")
         bubble_scans = [q for q in executed_queries if "bubbleId:%" in q]
         self.assertEqual(
             bubble_scans,

--- a/tests/test_workspace_tabs_summary.py
+++ b/tests/test_workspace_tabs_summary.py
@@ -1,0 +1,249 @@
+"""Phase 2a regression — summary and single-tab endpoints must not full-scan bubbles.
+
+Tests:
+  - list_workspace_tab_summaries: no ``bubbleId:%`` global scan; returns
+    id/title/timestamp/messageCount per tab; no ``bubbles`` field.
+  - assemble_single_tab: only queries ``bubbleId:{composer_id}:%`` (scoped);
+    returns correct single-tab structure matching the full-path shape.
+  - assemble_single_tab returns 404 when composer doesn't belong to workspace.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from unittest.mock import patch
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from services.workspace_tabs import (
+    assemble_single_tab,
+    list_workspace_tab_summaries,
+)
+
+COMPOSER_ID = "composer-summary-test"
+OTHER_COMPOSER_ID = "composer-other"
+BUBBLE_ID_A = "bubble-a"
+BUBBLE_ID_B = "bubble-b"
+OTHER_BUBBLE_ID = "bubble-other"
+
+
+def _make_fixture(base: str) -> str:
+    """Create a minimal workspaceStorage + globalStorage; return ws_path."""
+    ws_path = os.path.join(base, "workspaceStorage")
+    os.makedirs(ws_path)
+    global_dir = os.path.join(base, "globalStorage")
+    os.makedirs(global_dir)
+
+    db_path = os.path.join(global_dir, "state.vscdb")
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+
+    # Bubbles for COMPOSER_ID
+    conn.execute(
+        "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+        (
+            f"bubbleId:{COMPOSER_ID}:{BUBBLE_ID_A}",
+            json.dumps({"type": 1, "text": "user message", "createdAt": 1_739_200_000_000}),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+        (
+            f"bubbleId:{COMPOSER_ID}:{BUBBLE_ID_B}",
+            json.dumps({"type": 2, "text": "ai response", "createdAt": 1_739_200_001_000}),
+        ),
+    )
+    # Bubble belonging to a different composer — must NOT appear in scoped load
+    conn.execute(
+        "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+        (
+            f"bubbleId:{OTHER_COMPOSER_ID}:{OTHER_BUBBLE_ID}",
+            json.dumps({"type": 1, "text": "other chat", "createdAt": 1_739_200_002_000}),
+        ),
+    )
+
+    # composerData for COMPOSER_ID
+    conn.execute(
+        "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+        (
+            f"composerData:{COMPOSER_ID}",
+            json.dumps({
+                "name": "Summary Test Chat",
+                "modelConfig": {"modelName": "claude-3-5-sonnet"},
+                "fullConversationHeadersOnly": [
+                    {"bubbleId": BUBBLE_ID_A, "type": 1},
+                    {"bubbleId": BUBBLE_ID_B, "type": 2},
+                ],
+                "lastUpdatedAt": 1_739_300_000_000,
+                "createdAt": 1_739_200_000_000,
+            }),
+        ),
+    )
+    # composerData for OTHER_COMPOSER_ID (should not bleed into single-tab response)
+    conn.execute(
+        "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+        (
+            f"composerData:{OTHER_COMPOSER_ID}",
+            json.dumps({
+                "name": "Other Chat",
+                "modelConfig": {"modelName": "gpt-4o"},
+                "fullConversationHeadersOnly": [
+                    {"bubbleId": OTHER_BUBBLE_ID, "type": 1},
+                ],
+                "lastUpdatedAt": 1_739_300_000_000,
+                "createdAt": 1_739_200_000_000,
+            }),
+        ),
+    )
+    conn.commit()
+    conn.close()
+    return ws_path
+
+
+def _collect_queries(ws_path, fn):
+    """Call fn(ws_path) while recording every SQL query; return (result, queries)."""
+    import services.workspace_db as _ws_db_mod
+
+    orig = _ws_db_mod.open_global_db
+    executed: list[str] = []
+
+    @contextmanager
+    def _spy(workspace_path):
+        with orig(workspace_path) as (conn, path):
+            if conn is not None:
+                orig_exec = conn.execute
+
+                def _tracking_execute(query, params=()):
+                    executed.append(query)
+                    return orig_exec(query, params)
+
+                conn.execute = _tracking_execute  # type: ignore[method-assign]
+            yield conn, path
+
+    with patch.object(_ws_db_mod, "open_global_db", _spy):
+        result = fn(ws_path)
+    return result, executed
+
+
+class TestListWorkspaceTabSummaries(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws_path = _make_fixture(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_no_global_bubble_scan(self):
+        """list_workspace_tab_summaries must not issue a bubbleId:% LIKE query."""
+        (payload, status), queries = _collect_queries(
+            self.ws_path,
+            lambda p: list_workspace_tab_summaries("global", p, rules=[]),
+        )
+        bubble_scans = [q for q in queries if "bubbleId:%" in q]
+        self.assertEqual(
+            bubble_scans,
+            [],
+            msg=f"list_workspace_tab_summaries ran a global bubble scan:\n{bubble_scans}",
+        )
+
+    def test_summary_tabs_have_no_bubbles_field(self):
+        payload, status = list_workspace_tab_summaries("global", self.ws_path, rules=[])
+        self.assertEqual(status, 200)
+        tabs = payload.get("tabs", [])
+        self.assertTrue(tabs, "Expected at least one summary tab")
+        for tab in tabs:
+            self.assertNotIn(
+                "bubbles", tab,
+                msg="Summary tabs must not contain a 'bubbles' field",
+            )
+
+    def test_summary_tab_fields(self):
+        payload, _ = list_workspace_tab_summaries("global", self.ws_path, rules=[])
+        tab = next((t for t in payload["tabs"] if t["id"] == COMPOSER_ID), None)
+        self.assertIsNotNone(tab, msg="Expected COMPOSER_ID in summary tabs")
+        self.assertEqual(tab["id"], COMPOSER_ID)
+        self.assertIn("title", tab)
+        self.assertIn("timestamp", tab)
+        self.assertIn("messageCount", tab)
+        self.assertEqual(tab["messageCount"], 2)
+
+    def test_summary_metadata_modelsused(self):
+        payload, _ = list_workspace_tab_summaries("global", self.ws_path, rules=[])
+        tab = next((t for t in payload["tabs"] if t["id"] == COMPOSER_ID), None)
+        self.assertIsNotNone(tab)
+        meta = tab.get("metadata") or {}
+        self.assertIn("modelsUsed", meta, msg="modelsUsed should appear in summary metadata")
+        self.assertIn("claude-3-5-sonnet", meta["modelsUsed"])
+
+
+class TestAssembleSingleTab(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws_path = _make_fixture(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_scoped_bubble_query_only(self):
+        """assemble_single_tab must query bubbleId:{composer_id}:% — not bubbleId:%."""
+        (payload, status), queries = _collect_queries(
+            self.ws_path,
+            lambda p: assemble_single_tab("global", COMPOSER_ID, p, rules=[]),
+        )
+        global_bubble_scans = [
+            q for q in queries if "bubbleId:%" in q and f"bubbleId:{COMPOSER_ID}:%" not in q
+        ]
+        self.assertEqual(
+            global_bubble_scans,
+            [],
+            msg=f"assemble_single_tab ran a non-scoped bubble scan:\n{global_bubble_scans}",
+        )
+
+    def test_single_tab_structure(self):
+        payload, status = assemble_single_tab("global", COMPOSER_ID, self.ws_path, rules=[])
+        self.assertEqual(status, 200)
+        self.assertIn("tab", payload)
+        tab = payload["tab"]
+        self.assertEqual(tab["id"], COMPOSER_ID)
+        self.assertIn("title", tab)
+        self.assertIn("timestamp", tab)
+        self.assertIn("bubbles", tab)
+        self.assertIn("codeBlockDiffs", tab)
+
+    def test_single_tab_bubbles_only_from_this_composer(self):
+        """Bubbles from OTHER_COMPOSER_ID must not appear in COMPOSER_ID's tab."""
+        payload, status = assemble_single_tab("global", COMPOSER_ID, self.ws_path, rules=[])
+        self.assertEqual(status, 200)
+        texts = [b["text"] for b in payload["tab"]["bubbles"]]
+        self.assertNotIn(
+            "other chat", texts,
+            msg="Bubble from a different composer leaked into the scoped tab",
+        )
+        # At least one bubble from COMPOSER_ID should be present
+        self.assertTrue(
+            any(t in ("user message", "ai response") for t in texts),
+            msg=f"Expected bubbles from COMPOSER_ID, got: {texts}",
+        )
+
+    def test_single_tab_not_found_for_wrong_workspace(self):
+        """assemble_single_tab returns 404 when composer is not in the workspace."""
+        payload, status = assemble_single_tab(
+            "nonexistent-ws-id", COMPOSER_ID, self.ws_path, rules=[]
+        )
+        self.assertEqual(status, 404)
+
+    def test_single_tab_not_found_for_unknown_composer(self):
+        payload, status = assemble_single_tab("global", "no-such-composer", self.ws_path, rules=[])
+        self.assertEqual(status, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workspace_tabs_summary.py
+++ b/tests/test_workspace_tabs_summary.py
@@ -203,6 +203,29 @@ class TestAssembleSingleTab(unittest.TestCase):
             msg=f"assemble_single_tab ran a non-scoped bubble scan:\n{global_bubble_scans}",
         )
 
+    def test_scoped_mrc_load_no_invalid_workspaces(self):
+        """Without invalid workspace folders, per-tab load must not full-scan MRC or composers."""
+        (_, _), queries = _collect_queries(
+            self.ws_path,
+            lambda p: assemble_single_tab("global", COMPOSER_ID, p, rules=[]),
+        )
+        mrc_scans = [
+            q for q in queries
+            if "messageRequestContext:%" in q
+            and f"messageRequestContext:{COMPOSER_ID}:%" not in q
+        ]
+        self.assertEqual(
+            mrc_scans,
+            [],
+            msg=f"assemble_single_tab ran a global MRC scan:\n{mrc_scans}",
+        )
+        composer_scans = [q for q in queries if "composerData:%" in q]
+        self.assertEqual(
+            composer_scans,
+            [],
+            msg=f"assemble_single_tab scanned all composers for aliases:\n{composer_scans}",
+        )
+
     def test_single_tab_structure(self):
         payload, status = assemble_single_tab("global", COMPOSER_ID, self.ws_path, rules=[])
         self.assertEqual(status, 200)

--- a/tests/test_workspace_tabs_summary.py
+++ b/tests/test_workspace_tabs_summary.py
@@ -108,6 +108,31 @@ def _make_fixture(base: str) -> str:
     return ws_path
 
 
+def _add_invalid_workspace_and_mrc_rows(ws_path: str) -> None:
+    """Add an invalid workspace entry and MRC rows for two composers (alias-path trigger)."""
+    invalid_dir = os.path.join(ws_path, "invalid-ws")
+    os.makedirs(invalid_dir, exist_ok=True)
+    wj = os.path.join(invalid_dir, "workspace.json")
+    with open(wj, "w", encoding="utf-8") as f:
+        json.dump({}, f)
+
+    global_db = os.path.join(os.path.dirname(ws_path), "globalStorage", "state.vscdb")
+    conn = sqlite3.connect(global_db)
+    for cid, ctx_id in (
+        (COMPOSER_ID, "ctx-summary"),
+        (OTHER_COMPOSER_ID, "ctx-other"),
+    ):
+        conn.execute(
+            "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+            (
+                f"messageRequestContext:{cid}:{ctx_id}",
+                json.dumps({"projectLayouts": [f"/roots/{cid}"]}),
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
 def _collect_queries(ws_path, fn):
     """Call fn(ws_path) while recording every SQL query; return (result, queries)."""
     import services.workspace_tabs as _ws_tabs_mod
@@ -201,6 +226,25 @@ class TestAssembleSingleTab(unittest.TestCase):
             global_bubble_scans,
             [],
             msg=f"assemble_single_tab ran a non-scoped bubble scan:\n{global_bubble_scans}",
+        )
+
+    def test_scoped_mrc_load_with_invalid_workspaces(self):
+        """With invalid workspace folders, alias scan runs but MRC stays per-composer."""
+        _add_invalid_workspace_and_mrc_rows(self.ws_path)
+        (_, _), queries = _collect_queries(
+            self.ws_path,
+            lambda p: assemble_single_tab("global", COMPOSER_ID, p, rules=[]),
+        )
+        self.assertTrue(queries, msg="expected SQL queries to be recorded")
+        mrc_scans = [
+            q for q in queries
+            if "messageRequestContext:%" in q
+            and f"messageRequestContext:{COMPOSER_ID}:%" not in q
+        ]
+        self.assertEqual(
+            mrc_scans,
+            [],
+            msg=f"assemble_single_tab ran a global MRC scan:\n{mrc_scans}",
         )
 
     def test_scoped_mrc_load_no_invalid_workspaces(self):

--- a/tests/test_workspace_tabs_summary.py
+++ b/tests/test_workspace_tabs_summary.py
@@ -110,25 +110,19 @@ def _make_fixture(base: str) -> str:
 
 def _collect_queries(ws_path, fn):
     """Call fn(ws_path) while recording every SQL query; return (result, queries)."""
-    import services.workspace_db as _ws_db_mod
+    import services.workspace_tabs as _ws_tabs_mod
 
-    orig = _ws_db_mod.open_global_db
+    orig = _ws_tabs_mod.open_global_db
     executed: list[str] = []
 
     @contextmanager
     def _spy(workspace_path):
         with orig(workspace_path) as (conn, path):
             if conn is not None:
-                orig_exec = conn.execute
-
-                def _tracking_execute(query, params=()):
-                    executed.append(query)
-                    return orig_exec(query, params)
-
-                conn.execute = _tracking_execute  # type: ignore[method-assign]
+                conn.set_trace_callback(executed.append)
             yield conn, path
 
-    with patch.object(_ws_db_mod, "open_global_db", _spy):
+    with patch.object(_ws_tabs_mod, "open_global_db", _spy):
         result = fn(ws_path)
     return result, executed
 
@@ -145,8 +139,9 @@ class TestListWorkspaceTabSummaries(unittest.TestCase):
         """list_workspace_tab_summaries must not issue a bubbleId:% LIKE query."""
         (payload, status), queries = _collect_queries(
             self.ws_path,
-            lambda p: list_workspace_tab_summaries("global", p, rules=[]),
+            lambda p: list_workspace_tab_summaries("global", p, rules=[], nocache=True),
         )
+        self.assertTrue(queries, msg="expected SQL queries to be recorded")
         bubble_scans = [q for q in queries if "bubbleId:%" in q]
         self.assertEqual(
             bubble_scans,
@@ -198,6 +193,7 @@ class TestAssembleSingleTab(unittest.TestCase):
             self.ws_path,
             lambda p: assemble_single_tab("global", COMPOSER_ID, p, rules=[]),
         )
+        self.assertTrue(queries, msg="expected SQL queries to be recorded")
         global_bubble_scans = [
             q for q in queries if "bubbleId:%" in q and f"bubbleId:{COMPOSER_ID}:%" not in q
         ]


### PR DESCRIPTION
## Summary

Implements [issue #84](https://github.com/cppalliance/cppa-cursor-browser/issues/84): split summary and full-assembly code paths so list views avoid scanning global `bubbleId:%` rows, the workspace UI lazy-loads conversation bodies on tab selection, and repeat page loads are served from an mtime-keyed disk cache.

- **Home (`GET /api/workspaces`)** — no global bubble scan; SQL-filtered `composerData`; per-composer MRC only when needed; cached `composer_id_to_ws` and project list
- **Workspace sidebar** — `GET /api/workspaces/<id>/tabs?summary=1` returns titles/metadata only; full payloads via `GET /api/workspaces/<id>/tabs/<composer_id>`
- **Phase 3 cache** — project list, composer map, and tab summaries under `~/.cache/cursor-chat-browser/`; invalidate on storage mtimes; bypass with `?nocache=1` or `CURSOR_CHAT_BROWSER_NOCACHE=1`
- **Full `/tabs`, export, and search** — unchanged; monolithic `/tabs` still available for backward compatibility

## Problem

On large local Cursor datasets, the home page and workspace page each rescanned global KV storage on every load (often 1–2+ minutes). The UI blocked on full tab assembly before the sidebar could render.

## Solution

### Backend
| Area | Change |
|------|--------|
| `services/workspace_listing.py` | Summary list path: no `load_bubble_map`; SQL filter for non-empty headers; lazy `load_project_layouts_for_composer`; disk cache wrapper |
| `services/workspace_tabs.py` | `list_workspace_tab_summaries`, `assemble_single_tab`, shared `_assemble_tab_from_composer_data`; scoped bubble/MRC/diff loaders |
| `services/workspace_db.py` | Scoped loaders + `build_composer_id_to_workspace_id_cached` |
| `services/summary_cache.py` | New mtime-keyed cache layer |
| `api/workspaces.py` | `?summary=1`, `/tabs/<composer_id>`, `?nocache=1` |

### Frontend
- `templates/workspace.html` — fetch summary tabs on load; lazy-fetch full tab on selection; `tabCache` for loaded conversations
- `static/css/style.css` — stable grid width during load; `.main-content.is-loading` for centered spinner

### Tests (356 pass)
- `tests/test_workspace_listing_performance.py` — spy: no global `bubbleId:%` on list path
- `tests/test_workspace_tabs_summary.py` — summary/single-tab scoped queries and payload shape
- `tests/test_summary_cache.py` — cache hit/miss and fingerprint invalidation

## Performance notes

- **First load** after cache clear or Cursor data change still rebuilds summaries (expected; much faster than pre-#84 due to skipped bubble + full MRC scans).
- **Repeat loads** (refresh home/workspace with unchanged storage) should be near-instant from disk cache.
- To force cold rebuild: `GET /api/workspaces?nocache=1`

Document representative row counts and timings from your local fixture in review comments if helpful.

## Test plan

- [ ] `pytest` — all tests pass locally
- [ ] Home page: project cards appear; second refresh noticeably faster than first
- [ ] Workspace page: sidebar titles render quickly; selecting a conversation loads bubbles with per-tab spinner
- [ ] Copy All / Download work on a loaded conversation
- [ ] Export script and full `GET /api/workspaces/<id>/tabs` (no `summary=1`) still work
- [ ] `?nocache=1` bypasses cache; cache files appear under `~/.cache/cursor-chat-browser/`

Closes #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lazy-loaded workspace UI with summary endpoint, per-conversation on-demand full load, sidebar model badges, and client tab caching.

* **Performance**
  * Disk-backed fingerprinted summary cache with nocache bypass.
  * Scoped data loading to fetch only targeted conversation rows, avoiding expensive global scans.

* **Style**
  * Updated layout and loading skeleton styles for consistent full-width behavior.

* **Documentation**
  * Changelog updated with Phase 3 summary and API notes.

* **Tests**
  * New/regression tests for cache, tab summaries, scoped loading, and listing performance.

* **Bug Fixes**
  * Improved inline error handling for workspace and conversation load failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->