### PR TITLE
Add typed raw accessors with drift logging; migrate workspace tabs and resolver

### DIFF
--- a/api/search.py
+++ b/api/search.py
@@ -159,7 +159,7 @@ def search():
                         bid = parts[2]
                         try:
                             bubble = Bubble.from_dict(json.loads(row["value"]), bubble_id=bid)
-                            text = extract_text_from_bubble(bubble.raw)
+                            text = extract_text_from_bubble(bubble)
                             bubble_map[bid] = {"text": text, "raw": bubble.raw}
                         except SchemaError as e:
                             # Drift logged so the operator can see why a chat dropped

--- a/models/conversation.py
+++ b/models/conversation.py
@@ -246,8 +246,18 @@ class Bubble:
         return value
 
     @property
-    def token_count(self) -> Any | None:
-        return self.raw.get("tokenCount")
+    def token_count(self) -> dict[str, Any] | None:
+        value = self.raw.get("tokenCount")
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            _logger.warning(
+                "Schema drift in Bubble %s: invalid type for tokenCount (expected dict, got %s)",
+                self.bubble_id,
+                type(value).__name__,
+            )
+            return None
+        return value
 
     @property
     def tool_former_data(self) -> dict[str, Any] | None:
@@ -279,11 +289,23 @@ class Bubble:
 
     @property
     def thinking(self) -> Any | None:
+        if "thinking" not in self.raw:
+            return None
         return self.raw.get("thinking")
 
     @property
-    def thinking_duration_ms(self) -> Any | None:
-        return self.raw.get("thinkingDurationMs")
+    def thinking_duration_ms(self) -> int | float | None:
+        value = self.raw.get("thinkingDurationMs")
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            _logger.warning(
+                "Schema drift in Bubble %s: invalid type for thinkingDurationMs (expected number, got %s)",
+                self.bubble_id,
+                type(value).__name__,
+            )
+            return None
+        return value
 
     @property
     def context_window_status_at_creation(self) -> dict[str, Any]:

--- a/models/conversation.py
+++ b/models/conversation.py
@@ -4,8 +4,6 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
-_logger = logging.getLogger(__name__)
-
 from models.errors import SchemaError
 from models.from_dict_validation import (
     require_dict,
@@ -14,6 +12,8 @@ from models.from_dict_validation import (
     require_non_empty_str_field,
     require_type,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)

--- a/models/conversation.py
+++ b/models/conversation.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
+
+_logger = logging.getLogger(__name__)
 
 from models.errors import SchemaError
 from models.from_dict_validation import (
@@ -67,6 +70,84 @@ class Composer:
             raw=raw,
         )
 
+    @property
+    def newly_created_files(self) -> list[Any]:
+        value = self.raw.get("newlyCreatedFiles")
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            _logger.warning(
+                "Schema drift in Composer %s: invalid type for newlyCreatedFiles (expected list, got %s)",
+                self.composer_id,
+                type(value).__name__,
+            )
+            return []
+        return value
+
+    @property
+    def code_block_data(self) -> dict[str, Any] | None:
+        value = self.raw.get("codeBlockData")
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            _logger.warning(
+                "Schema drift in Composer %s: invalid type for codeBlockData (expected dict, got %s)",
+                self.composer_id,
+                type(value).__name__,
+            )
+            return None
+        return value
+
+    @property
+    def usage_data(self) -> dict[str, Any]:
+        """Composer cost rollup; empty dict when absent (common)."""
+        value = self.raw.get("usageData")
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            suffix = f" {self.composer_id}" if self.composer_id else ""
+            _logger.warning(
+                "Schema drift in Composer%s: invalid type for usageData (expected dict, got %s)",
+                suffix,
+                type(value).__name__,
+            )
+            return {}
+        return value
+
+    def _optional_counter(self, key: str) -> int | float:
+        value = self.raw.get(key, 0)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            if key in self.raw:
+                suffix = f" {self.composer_id}" if self.composer_id else ""
+                _logger.warning(
+                    "Schema drift in Composer%s: invalid type for %s (expected number, got %s)",
+                    suffix,
+                    key,
+                    type(value).__name__,
+                )
+            return 0
+        return value
+
+    @property
+    def total_lines_added(self) -> int | float:
+        return self._optional_counter("totalLinesAdded")
+
+    @property
+    def total_lines_removed(self) -> int | float:
+        return self._optional_counter("totalLinesRemoved")
+
+    @property
+    def added_files(self) -> int | float:
+        return self._optional_counter("addedFiles")
+
+    @property
+    def removed_files(self) -> int | float:
+        return self._optional_counter("removedFiles")
+
+    def model_name_from_config(self) -> str | None:
+        name = self.model_config.get("modelName")
+        return name if isinstance(name, str) and name else None
+
 
 @dataclass(frozen=True)
 class WorkspaceLocalComposer:
@@ -101,3 +182,141 @@ class Bubble:
         raw = require_dict(raw, model="Bubble", field="bubble")
         require_non_empty_str(bubble_id, model="Bubble", field="bubbleId")
         return cls(bubble_id=bubble_id, raw=raw)
+
+    @property
+    def text(self) -> str | None:
+        """Plain ``text`` field; richText is handled by :func:`extract_text_from_bubble`."""
+        value = self.raw.get("text")
+        return value if isinstance(value, str) else None
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        value = self.raw.get("metadata")
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            _logger.warning(
+                "Schema drift in Bubble %s: invalid type for metadata (expected dict, got %s)",
+                self.bubble_id,
+                type(value).__name__,
+            )
+            return {}
+        return value
+
+    @property
+    def relevant_files(self) -> list[Any]:
+        value = self.raw.get("relevantFiles")
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            _logger.warning(
+                "Schema drift in Bubble %s: invalid type for relevantFiles (expected list, got %s)",
+                self.bubble_id,
+                type(value).__name__,
+            )
+            return []
+        return value
+
+    @property
+    def attached_file_code_chunks_uris(self) -> list[Any]:
+        value = self.raw.get("attachedFileCodeChunksUris")
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            _logger.warning(
+                "Schema drift in Bubble %s: invalid type for attachedFileCodeChunksUris (expected list, got %s)",
+                self.bubble_id,
+                type(value).__name__,
+            )
+            return []
+        return value
+
+    @property
+    def context(self) -> dict[str, Any]:
+        value = self.raw.get("context")
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            _logger.warning(
+                "Schema drift in Bubble %s: invalid type for context (expected dict, got %s)",
+                self.bubble_id,
+                type(value).__name__,
+            )
+            return {}
+        return value
+
+    @property
+    def token_count(self) -> Any | None:
+        return self.raw.get("tokenCount")
+
+    @property
+    def tool_former_data(self) -> dict[str, Any] | None:
+        value = self.raw.get("toolFormerData")
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            _logger.warning(
+                "Schema drift in Bubble %s: invalid type for toolFormerData (expected dict, got %s)",
+                self.bubble_id,
+                type(value).__name__,
+            )
+            return None
+        return value
+
+    @property
+    def model_info(self) -> dict[str, Any]:
+        value = self.raw.get("modelInfo")
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            _logger.warning(
+                "Schema drift in Bubble %s: invalid type for modelInfo (expected dict, got %s)",
+                self.bubble_id,
+                type(value).__name__,
+            )
+            return {}
+        return value
+
+    @property
+    def thinking(self) -> Any | None:
+        return self.raw.get("thinking")
+
+    @property
+    def thinking_duration_ms(self) -> Any | None:
+        return self.raw.get("thinkingDurationMs")
+
+    @property
+    def context_window_status_at_creation(self) -> dict[str, Any]:
+        value = self.raw.get("contextWindowStatusAtCreation")
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            _logger.warning(
+                "Schema drift in Bubble %s: invalid type for contextWindowStatusAtCreation (expected dict, got %s)",
+                self.bubble_id,
+                type(value).__name__,
+            )
+            return {}
+        return value
+
+    @property
+    def tool_results(self) -> list[Any] | None:
+        value = self.raw.get("toolResults")
+        if value is None:
+            return None
+        if not isinstance(value, list):
+            _logger.warning(
+                "Schema drift in Bubble %s: invalid type for toolResults (expected list, got %s)",
+                self.bubble_id,
+                type(value).__name__,
+            )
+            return None
+        return value
+
+    def bubble_timestamp_ms(self) -> int | float | None:
+        """``createdAt`` or ``timestamp`` in milliseconds when present."""
+        for key in ("createdAt", "timestamp"):
+            value = self.raw.get(key)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return value
+        return None

--- a/models/conversation.py
+++ b/models/conversation.py
@@ -288,10 +288,18 @@ class Bubble:
         return value
 
     @property
-    def thinking(self) -> Any | None:
-        if "thinking" not in self.raw:
+    def thinking(self) -> str | dict[str, Any] | None:
+        value = self.raw.get("thinking")
+        if value is None:
             return None
-        return self.raw.get("thinking")
+        if isinstance(value, (str, dict)):
+            return value
+        _logger.warning(
+            "Schema drift in Bubble %s: invalid type for thinking (expected str or dict, got %s)",
+            self.bubble_id,
+            type(value).__name__,
+        )
+        return None
 
     @property
     def thinking_duration_ms(self) -> int | float | None:

--- a/models/raw_access.py
+++ b/models/raw_access.py
@@ -163,13 +163,19 @@ def composer_headers(
 
     if isinstance(data, Composer):
         return data.full_conversation_headers_only
-    headers = optional_raw_list(
-        data,
-        "fullConversationHeadersOnly",
-        model="Composer",
-        entity_id=composer_id,
-    )
-    return headers if headers is not None else []
+    if not isinstance(data, dict):
+        return []
+    value = data.get("fullConversationHeadersOnly")
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        _logger.warning(
+            "Schema drift in Composer %s: invalid type for fullConversationHeadersOnly (expected list, got %s)",
+            composer_id,
+            type(value).__name__,
+        )
+        return []
+    return value
 
 
 def composer_newly_created_files(data: Any, composer_id: str) -> list[Any]:
@@ -206,11 +212,13 @@ def bubble_relevant_files(bubble: Any, bubble_id: str = "") -> list[Any]:
     if isinstance(bubble, Bubble):
         return bubble.relevant_files
     if isinstance(bubble, dict):
-        value = bubble.get("relevantFiles")
-        if value is None:
-            return []
-        if isinstance(value, list):
-            return value
+        files = optional_raw_list(
+            bubble,
+            "relevantFiles",
+            model="Bubble",
+            entity_id=bubble_id,
+        )
+        return files if files is not None else []
     return []
 
 
@@ -220,11 +228,13 @@ def bubble_attached_file_uris(bubble: Any, bubble_id: str = "") -> list[Any]:
     if isinstance(bubble, Bubble):
         return bubble.attached_file_code_chunks_uris
     if isinstance(bubble, dict):
-        value = bubble.get("attachedFileCodeChunksUris")
-        if value is None:
-            return []
-        if isinstance(value, list):
-            return value
+        uris = optional_raw_list(
+            bubble,
+            "attachedFileCodeChunksUris",
+            model="Bubble",
+            entity_id=bubble_id,
+        )
+        return uris if uris is not None else []
     return []
 
 
@@ -232,11 +242,13 @@ def bubble_context(bubble: Any, bubble_id: str = "") -> dict[str, Any]:
     from models.conversation import Bubble
 
     if isinstance(bubble, Bubble):
-        return bubble.context or {}
+        return bubble.context
     if isinstance(bubble, dict):
-        ctx = bubble.get("context")
-        if ctx is None:
-            return {}
-        if isinstance(ctx, dict):
-            return ctx
+        ctx = optional_raw_dict(
+            bubble,
+            "context",
+            model="Bubble",
+            entity_id=bubble_id,
+        )
+        return ctx if ctx is not None else {}
     return {}

--- a/models/raw_access.py
+++ b/models/raw_access.py
@@ -1,0 +1,242 @@
+"""Optional-key reads from Cursor JSON blobs with schema-drift logging."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+
+def warn_missing_raw_key(
+    raw: dict[str, Any],
+    key: str,
+    *,
+    model: str,
+    entity_id: str = "",
+) -> None:
+    """Log when a frequently-used optional field is absent (likely key rename)."""
+    suffix = f" {entity_id}" if entity_id else ""
+    _logger.warning(
+        "Schema drift in %s%s: missing optional field %s",
+        model,
+        suffix,
+        key,
+    )
+
+
+def optional_raw_value(
+    raw: dict[str, Any],
+    key: str,
+    *,
+    model: str,
+    entity_id: str = "",
+    expected_type: type[Any] | tuple[type[Any], ...] | None = None,
+) -> Any | None:
+    """Return ``raw[key]`` when present and typed; log drift and return ``None`` otherwise."""
+    if key not in raw:
+        warn_missing_raw_key(raw, key, model=model, entity_id=entity_id)
+        return None
+    value = raw[key]
+    if expected_type is not None and not isinstance(value, expected_type):
+        suffix = f" {entity_id}" if entity_id else ""
+        _logger.warning(
+            "Schema drift in %s%s: invalid type for %s (expected %s, got %s)",
+            model,
+            suffix,
+            key,
+            expected_type,
+            type(value).__name__,
+        )
+        return None
+    return value
+
+
+def optional_raw_list(
+    raw: dict[str, Any],
+    key: str,
+    *,
+    model: str,
+    entity_id: str = "",
+) -> list[Any] | None:
+    return optional_raw_value(
+        raw,
+        key,
+        model=model,
+        entity_id=entity_id,
+        expected_type=list,
+    )
+
+
+def optional_raw_dict(
+    raw: dict[str, Any],
+    key: str,
+    *,
+    model: str,
+    entity_id: str = "",
+) -> dict[str, Any] | None:
+    return optional_raw_value(
+        raw,
+        key,
+        model=model,
+        entity_id=entity_id,
+        expected_type=dict,
+    )
+
+
+def optional_raw_str(
+    raw: dict[str, Any],
+    key: str,
+    *,
+    model: str,
+    entity_id: str = "",
+) -> str | None:
+    return optional_raw_value(
+        raw,
+        key,
+        model=model,
+        entity_id=entity_id,
+        expected_type=str,
+    )
+
+
+def optional_raw_number(
+    raw: dict[str, Any],
+    key: str,
+    *,
+    model: str,
+    entity_id: str = "",
+    default: int | float = 0,
+) -> int | float:
+    """Numeric composer counters; warn on missing key, return *default* when absent."""
+    if key not in raw:
+        warn_missing_raw_key(raw, key, model=model, entity_id=entity_id)
+        return default
+    value = raw[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        suffix = f" {entity_id}" if entity_id else ""
+        _logger.warning(
+            "Schema drift in %s%s: invalid type for %s (expected number, got %s)",
+            model,
+            suffix,
+            key,
+            type(value).__name__,
+        )
+        return default
+    return value
+
+
+def conversation_header_bubble_id(
+    header: dict[str, Any],
+    *,
+    composer_id: str = "",
+) -> str | None:
+    """``bubbleId`` from a ``fullConversationHeadersOnly`` entry."""
+    value = optional_raw_str(
+        header,
+        "bubbleId",
+        model="ConversationHeader",
+        entity_id=composer_id,
+    )
+    return value if value else None
+
+
+def message_request_context_project_layouts(
+    ctx: dict[str, Any],
+    *,
+    composer_id: str = "",
+) -> list[Any] | None:
+    """``projectLayouts`` from a messageRequestContext blob."""
+    return optional_raw_list(
+        ctx,
+        "projectLayouts",
+        model="MessageRequestContext",
+        entity_id=composer_id,
+    )
+
+
+def composer_headers(
+    data: Any,
+    composer_id: str,
+) -> list[dict[str, Any]]:
+    from models.conversation import Composer
+
+    if isinstance(data, Composer):
+        return data.full_conversation_headers_only
+    headers = optional_raw_list(
+        data,
+        "fullConversationHeadersOnly",
+        model="Composer",
+        entity_id=composer_id,
+    )
+    return headers if headers is not None else []
+
+
+def composer_newly_created_files(data: Any, composer_id: str) -> list[Any]:
+    from models.conversation import Composer
+
+    if isinstance(data, Composer):
+        return data.newly_created_files
+    value = data.get("newlyCreatedFiles") if isinstance(data, dict) else None
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        _logger.warning(
+            "Schema drift in Composer %s: invalid type for newlyCreatedFiles (expected list, got %s)",
+            composer_id,
+            type(value).__name__,
+        )
+        return []
+    return value
+
+
+def composer_code_block_data(data: Any, composer_id: str) -> dict[str, Any] | None:
+    from models.conversation import Composer
+
+    if isinstance(data, Composer):
+        return data.code_block_data
+    return optional_raw_dict(
+        data, "codeBlockData", model="Composer", entity_id=composer_id
+    )
+
+
+def bubble_relevant_files(bubble: Any, bubble_id: str = "") -> list[Any]:
+    from models.conversation import Bubble
+
+    if isinstance(bubble, Bubble):
+        return bubble.relevant_files
+    if isinstance(bubble, dict):
+        value = bubble.get("relevantFiles")
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+    return []
+
+
+def bubble_attached_file_uris(bubble: Any, bubble_id: str = "") -> list[Any]:
+    from models.conversation import Bubble
+
+    if isinstance(bubble, Bubble):
+        return bubble.attached_file_code_chunks_uris
+    if isinstance(bubble, dict):
+        value = bubble.get("attachedFileCodeChunksUris")
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+    return []
+
+
+def bubble_context(bubble: Any, bubble_id: str = "") -> dict[str, Any]:
+    from models.conversation import Bubble
+
+    if isinstance(bubble, Bubble):
+        return bubble.context or {}
+    if isinstance(bubble, dict):
+        ctx = bubble.get("context")
+        if ctx is None:
+            return {}
+        if isinstance(ctx, dict):
+            return ctx
+    return {}

--- a/models/raw_access.py
+++ b/models/raw_access.py
@@ -32,23 +32,35 @@ def optional_raw_value(
     model: str,
     entity_id: str = "",
     expected_type: type[Any] | tuple[type[Any], ...] | None = None,
+    warn_if_missing: bool = True,
 ) -> Any | None:
     """Return ``raw[key]`` when present and typed; log drift and return ``None`` otherwise."""
     if key not in raw:
-        warn_missing_raw_key(raw, key, model=model, entity_id=entity_id)
+        if warn_if_missing:
+            warn_missing_raw_key(raw, key, model=model, entity_id=entity_id)
         return None
     value = raw[key]
-    if expected_type is not None and not isinstance(value, expected_type):
-        suffix = f" {entity_id}" if entity_id else ""
-        _logger.warning(
-            "Schema drift in %s%s: invalid type for %s (expected %s, got %s)",
-            model,
-            suffix,
-            key,
-            expected_type,
-            type(value).__name__,
-        )
-        return None
+    if expected_type is not None:
+        if isinstance(value, bool) and expected_type in ((int, float), int, float):
+            suffix = f" {entity_id}" if entity_id else ""
+            _logger.warning(
+                "Schema drift in %s%s: invalid type for %s (expected number, got bool)",
+                model,
+                suffix,
+                key,
+            )
+            return None
+        if not isinstance(value, expected_type):
+            suffix = f" {entity_id}" if entity_id else ""
+            _logger.warning(
+                "Schema drift in %s%s: invalid type for %s (expected %s, got %s)",
+                model,
+                suffix,
+                key,
+                expected_type,
+                type(value).__name__,
+            )
+            return None
     return value
 
 
@@ -58,6 +70,7 @@ def optional_raw_list(
     *,
     model: str,
     entity_id: str = "",
+    warn_if_missing: bool = True,
 ) -> list[Any] | None:
     return optional_raw_value(
         raw,
@@ -65,6 +78,7 @@ def optional_raw_list(
         model=model,
         entity_id=entity_id,
         expected_type=list,
+        warn_if_missing=warn_if_missing,
     )
 
 
@@ -74,6 +88,7 @@ def optional_raw_dict(
     *,
     model: str,
     entity_id: str = "",
+    warn_if_missing: bool = True,
 ) -> dict[str, Any] | None:
     return optional_raw_value(
         raw,
@@ -81,7 +96,56 @@ def optional_raw_dict(
         model=model,
         entity_id=entity_id,
         expected_type=dict,
+        warn_if_missing=warn_if_missing,
     )
+
+
+def _optional_list_absent_ok(
+    raw: dict[str, Any],
+    key: str,
+    *,
+    model: str,
+    entity_id: str = "",
+) -> list[Any]:
+    """List field often omitted by Cursor; warn only on wrong type."""
+    value = raw.get(key)
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        suffix = f" {entity_id}" if entity_id else ""
+        _logger.warning(
+            "Schema drift in %s%s: invalid type for %s (expected list, got %s)",
+            model,
+            suffix,
+            key,
+            type(value).__name__,
+        )
+        return []
+    return value
+
+
+def _optional_dict_absent_ok(
+    raw: dict[str, Any],
+    key: str,
+    *,
+    model: str,
+    entity_id: str = "",
+) -> dict[str, Any] | None:
+    """Dict field often omitted; warn only on wrong type; ``None`` when absent."""
+    value = raw.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        suffix = f" {entity_id}" if entity_id else ""
+        _logger.warning(
+            "Schema drift in %s%s: invalid type for %s (expected dict, got %s)",
+            model,
+            suffix,
+            key,
+            type(value).__name__,
+        )
+        return None
+    return value
 
 
 def optional_raw_str(
@@ -100,29 +164,28 @@ def optional_raw_str(
     )
 
 
-def optional_raw_number(
+def _optional_str_absent_ok(
     raw: dict[str, Any],
     key: str,
     *,
     model: str,
     entity_id: str = "",
-    default: int | float = 0,
-) -> int | float:
-    """Numeric composer counters; warn on missing key, return *default* when absent."""
-    if key not in raw:
-        warn_missing_raw_key(raw, key, model=model, entity_id=entity_id)
-        return default
-    value = raw[key]
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        suffix = f" {entity_id}" if entity_id else ""
-        _logger.warning(
-            "Schema drift in %s%s: invalid type for %s (expected number, got %s)",
-            model,
-            suffix,
-            key,
-            type(value).__name__,
-        )
-        return default
+) -> str | None:
+    """String field often omitted on headers; warn only on wrong type."""
+    value = raw.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        if key in raw:
+            suffix = f" {entity_id}" if entity_id else ""
+            _logger.warning(
+                "Schema drift in %s%s: invalid type for %s (expected non-empty str, got %s)",
+                model,
+                suffix,
+                key,
+                type(value).__name__,
+            )
+        return None
     return value
 
 
@@ -132,13 +195,12 @@ def conversation_header_bubble_id(
     composer_id: str = "",
 ) -> str | None:
     """``bubbleId`` from a ``fullConversationHeadersOnly`` entry."""
-    value = optional_raw_str(
+    return _optional_str_absent_ok(
         header,
         "bubbleId",
         model="ConversationHeader",
         entity_id=composer_id,
     )
-    return value if value else None
 
 
 def message_request_context_project_layouts(
@@ -152,6 +214,7 @@ def message_request_context_project_layouts(
         "projectLayouts",
         model="MessageRequestContext",
         entity_id=composer_id,
+        warn_if_missing=False,
     )
 
 
@@ -165,17 +228,12 @@ def composer_headers(
         return data.full_conversation_headers_only
     if not isinstance(data, dict):
         return []
-    value = data.get("fullConversationHeadersOnly")
-    if value is None:
-        return []
-    if not isinstance(value, list):
-        _logger.warning(
-            "Schema drift in Composer %s: invalid type for fullConversationHeadersOnly (expected list, got %s)",
-            composer_id,
-            type(value).__name__,
-        )
-        return []
-    return value
+    return _optional_list_absent_ok(
+        data,
+        "fullConversationHeadersOnly",
+        model="Composer",
+        entity_id=composer_id,
+    )
 
 
 def composer_newly_created_files(data: Any, composer_id: str) -> list[Any]:
@@ -183,17 +241,14 @@ def composer_newly_created_files(data: Any, composer_id: str) -> list[Any]:
 
     if isinstance(data, Composer):
         return data.newly_created_files
-    value = data.get("newlyCreatedFiles") if isinstance(data, dict) else None
-    if value is None:
+    if not isinstance(data, dict):
         return []
-    if not isinstance(value, list):
-        _logger.warning(
-            "Schema drift in Composer %s: invalid type for newlyCreatedFiles (expected list, got %s)",
-            composer_id,
-            type(value).__name__,
-        )
-        return []
-    return value
+    return _optional_list_absent_ok(
+        data,
+        "newlyCreatedFiles",
+        model="Composer",
+        entity_id=composer_id,
+    )
 
 
 def composer_code_block_data(data: Any, composer_id: str) -> dict[str, Any] | None:
@@ -201,8 +256,13 @@ def composer_code_block_data(data: Any, composer_id: str) -> dict[str, Any] | No
 
     if isinstance(data, Composer):
         return data.code_block_data
-    return optional_raw_dict(
-        data, "codeBlockData", model="Composer", entity_id=composer_id
+    if not isinstance(data, dict):
+        return None
+    return _optional_dict_absent_ok(
+        data,
+        "codeBlockData",
+        model="Composer",
+        entity_id=composer_id,
     )
 
 
@@ -212,13 +272,12 @@ def bubble_relevant_files(bubble: Any, bubble_id: str = "") -> list[Any]:
     if isinstance(bubble, Bubble):
         return bubble.relevant_files
     if isinstance(bubble, dict):
-        files = optional_raw_list(
+        return _optional_list_absent_ok(
             bubble,
             "relevantFiles",
             model="Bubble",
             entity_id=bubble_id,
         )
-        return files if files is not None else []
     return []
 
 
@@ -228,13 +287,12 @@ def bubble_attached_file_uris(bubble: Any, bubble_id: str = "") -> list[Any]:
     if isinstance(bubble, Bubble):
         return bubble.attached_file_code_chunks_uris
     if isinstance(bubble, dict):
-        uris = optional_raw_list(
+        return _optional_list_absent_ok(
             bubble,
             "attachedFileCodeChunksUris",
             model="Bubble",
             entity_id=bubble_id,
         )
-        return uris if uris is not None else []
     return []
 
 
@@ -244,7 +302,7 @@ def bubble_context(bubble: Any, bubble_id: str = "") -> dict[str, Any]:
     if isinstance(bubble, Bubble):
         return bubble.context
     if isinstance(bubble, dict):
-        ctx = optional_raw_dict(
+        ctx = _optional_dict_absent_ok(
             bubble,
             "context",
             model="Bubble",

--- a/services/workspace_resolver.py
+++ b/services/workspace_resolver.py
@@ -6,8 +6,10 @@ import os
 import re
 import sqlite3
 import sys
+from collections.abc import Mapping
 from contextlib import closing
 from pathlib import Path
+from typing import Any
 
 _logger = logging.getLogger(__name__)
 
@@ -20,7 +22,7 @@ from utils.path_helpers import (
 from utils.workspace_descriptor import basename_from_pathish, read_json_file
 from services.workspace_db import open_global_db
 from models import SchemaError, Workspace
-from models.conversation import Composer
+from models.conversation import Bubble, Composer
 from models.raw_access import (
     bubble_attached_file_uris,
     bubble_context,
@@ -242,7 +244,7 @@ def determine_project_for_conversation(
     project_name_to_workspace_id: dict,
     workspace_path_to_id: dict,
     workspace_entries: list,
-    bubble_map: dict,
+    bubble_map: Mapping[str, Bubble | dict[str, Any]],
     composer_id_to_workspace_id: dict | None = None,
     invalid_workspace_ids: set[str] | None = None,
 ) -> str | None:
@@ -255,7 +257,7 @@ def determine_project_for_conversation(
         project_name_to_workspace_id: Basename-to-workspace-folder map.
         workspace_path_to_id: Normalized root path to workspace folder map.
         workspace_entries: Output of :func:`services.workspace_db.collect_workspace_entries`.
-        bubble_map: ``{bubble_id: bubble_dict}`` from global KV.
+        bubble_map: ``{bubble_id: Bubble | bubble_dict}`` from global KV.
         composer_id_to_workspace_id: Definitive per-workspace composer map; when
             ``None``, layout and path heuristics are used without this shortcut.
         invalid_workspace_ids: Workspace folders marked invalid; mapped IDs in
@@ -299,37 +301,9 @@ def determine_project_for_conversation(
             if pid:
                 return pid
 
-    # Fallback: conversation headers -> bubble references
+    # Fallback: conversation headers -> bubble references (single pass)
     headers = composer_headers(composer_data, composer_id)
-    for header in headers:
-        if not isinstance(header, dict):
-            continue
-        bubble_id = conversation_header_bubble_id(header, composer_id=composer_id)
-        if not bubble_id:
-            continue
-        bubble = bubble_map.get(bubble_id)
-        if not bubble:
-            continue
-        for fp in bubble_relevant_files(bubble, bubble_id):
-            if fp:
-                pid = get_project_from_file_path(fp, workspace_entries)
-                if pid:
-                    return pid
-        for uri in bubble_attached_file_uris(bubble, bubble_id):
-            if isinstance(uri, dict) and uri.get("path"):
-                pid = get_project_from_file_path(uri["path"], workspace_entries)
-                if pid:
-                    return pid
-        for fs_entry in (bubble_context(bubble, bubble_id).get("fileSelections") or []):
-            if isinstance(fs_entry, dict):
-                uri = fs_entry.get("uri")
-                if isinstance(uri, dict) and uri.get("path"):
-                    pid = get_project_from_file_path(uri["path"], workspace_entries)
-                    if pid:
-                        return pid
-
-    # Last fallback: path-segment matching
-    path_segments = []
+    path_segments: list[str] = []
     for f in newly:
         if isinstance(f, dict):
             uri = f.get("uri")
@@ -349,14 +323,23 @@ def determine_project_for_conversation(
             continue
         for fp in bubble_relevant_files(bubble, bubble_id):
             if fp:
+                pid = get_project_from_file_path(fp, workspace_entries)
+                if pid:
+                    return pid
                 path_segments.append(normalize_file_path(fp))
         for uri in bubble_attached_file_uris(bubble, bubble_id):
             if isinstance(uri, dict) and uri.get("path"):
+                pid = get_project_from_file_path(uri["path"], workspace_entries)
+                if pid:
+                    return pid
                 path_segments.append(normalize_file_path(uri["path"]))
         for fs_entry in (bubble_context(bubble, bubble_id).get("fileSelections") or []):
             if isinstance(fs_entry, dict):
                 uri = fs_entry.get("uri")
                 if isinstance(uri, dict) and uri.get("path"):
+                    pid = get_project_from_file_path(uri["path"], workspace_entries)
+                    if pid:
+                        return pid
                     path_segments.append(normalize_file_path(uri["path"]))
 
     sep = "\\" if sys.platform == "win32" else "/"
@@ -440,8 +423,17 @@ def infer_invalid_workspace_aliases(
                 type(cd).__name__,
             )
             continue
+        try:
+            composer = Composer.from_dict(cd, composer_id=cid)
+        except SchemaError as e:
+            _logger.warning(
+                "Failed to parse Composer from composerData:%s: %s",
+                cid,
+                e,
+            )
+            continue
         inferred = determine_project_for_conversation(
-            cd,
+            composer,
             cid,
             project_layouts_map,
             project_name_map,

--- a/services/workspace_resolver.py
+++ b/services/workspace_resolver.py
@@ -20,6 +20,17 @@ from utils.path_helpers import (
 from utils.workspace_descriptor import basename_from_pathish, read_json_file
 from services.workspace_db import open_global_db
 from models import SchemaError, Workspace
+from models.conversation import Composer
+from models.raw_access import (
+    bubble_attached_file_uris,
+    bubble_context,
+    bubble_relevant_files,
+    composer_code_block_data,
+    composer_headers,
+    composer_newly_created_files,
+    conversation_header_bubble_id,
+    message_request_context_project_layouts,
+)
 
 
 def lookup_workspace_display_name(workspace_path: str, workspace_id: str) -> str:
@@ -118,8 +129,8 @@ def infer_workspace_name_from_context(workspace_path: str, workspace_id: str) ->
                         e,
                     )
                     continue
-                layouts = ctx.get("projectLayouts")
-                if not isinstance(layouts, list):
+                layouts = message_request_context_project_layouts(ctx, composer_id=cid)
+                if not layouts:
                     continue
                 for layout in layouts:
                     obj = None
@@ -225,7 +236,7 @@ def create_workspace_path_to_id_map(workspace_entries):
 
 
 def determine_project_for_conversation(
-    composer_data: dict,
+    composer_data: Composer | dict,
     composer_id: str,
     project_layouts_map: dict,
     project_name_to_workspace_id: dict,
@@ -272,7 +283,7 @@ def determine_project_for_conversation(
             return workspace_id
 
     # Fallback: newlyCreatedFiles
-    newly = composer_data.get("newlyCreatedFiles") or []
+    newly = composer_newly_created_files(composer_data, composer_id)
     for file_entry in newly:
         uri = file_entry.get("uri") if isinstance(file_entry, dict) else None
         if isinstance(uri, dict) and uri.get("path"):
@@ -281,7 +292,7 @@ def determine_project_for_conversation(
                 return pid
 
     # Fallback: codeBlockData
-    cbd = composer_data.get("codeBlockData")
+    cbd = composer_code_block_data(composer_data, composer_id)
     if isinstance(cbd, dict):
         for fp in cbd.keys():
             pid = get_project_from_file_path(re.sub(r"^file://", "", fp), workspace_entries)
@@ -289,24 +300,27 @@ def determine_project_for_conversation(
                 return pid
 
     # Fallback: conversation headers -> bubble references
-    headers = composer_data.get("fullConversationHeadersOnly") or []
+    headers = composer_headers(composer_data, composer_id)
     for header in headers:
         if not isinstance(header, dict):
             continue
-        bubble = bubble_map.get(header.get("bubbleId"))
+        bubble_id = conversation_header_bubble_id(header, composer_id=composer_id)
+        if not bubble_id:
+            continue
+        bubble = bubble_map.get(bubble_id)
         if not bubble:
             continue
-        for fp in (bubble.get("relevantFiles") or []):
+        for fp in bubble_relevant_files(bubble, bubble_id):
             if fp:
                 pid = get_project_from_file_path(fp, workspace_entries)
                 if pid:
                     return pid
-        for uri in (bubble.get("attachedFileCodeChunksUris") or []):
+        for uri in bubble_attached_file_uris(bubble, bubble_id):
             if isinstance(uri, dict) and uri.get("path"):
                 pid = get_project_from_file_path(uri["path"], workspace_entries)
                 if pid:
                     return pid
-        for fs_entry in (bubble.get("context", {}).get("fileSelections") or []):
+        for fs_entry in (bubble_context(bubble, bubble_id).get("fileSelections") or []):
             if isinstance(fs_entry, dict):
                 uri = fs_entry.get("uri")
                 if isinstance(uri, dict) and uri.get("path"):
@@ -327,16 +341,19 @@ def determine_project_for_conversation(
     for header in headers:
         if not isinstance(header, dict):
             continue
-        bubble = bubble_map.get(header.get("bubbleId"))
+        bubble_id = conversation_header_bubble_id(header, composer_id=composer_id)
+        if not bubble_id:
+            continue
+        bubble = bubble_map.get(bubble_id)
         if not bubble:
             continue
-        for fp in (bubble.get("relevantFiles") or []):
+        for fp in bubble_relevant_files(bubble, bubble_id):
             if fp:
                 path_segments.append(normalize_file_path(fp))
-        for uri in (bubble.get("attachedFileCodeChunksUris") or []):
+        for uri in bubble_attached_file_uris(bubble, bubble_id):
             if isinstance(uri, dict) and uri.get("path"):
                 path_segments.append(normalize_file_path(uri["path"]))
-        for fs_entry in (bubble.get("context", {}).get("fileSelections") or []):
+        for fs_entry in (bubble_context(bubble, bubble_id).get("fileSelections") or []):
             if isinstance(fs_entry, dict):
                 uri = fs_entry.get("uri")
                 if isinstance(uri, dict) and uri.get("path"):

--- a/services/workspace_resolver.py
+++ b/services/workspace_resolver.py
@@ -376,7 +376,7 @@ def infer_invalid_workspace_aliases(
     project_name_map: dict,
     workspace_path_map: dict,
     workspace_entries: list,
-    bubble_map: dict,
+    bubble_map: Mapping[str, Bubble | dict[str, Any]],
     composer_id_to_ws: dict,
     invalid_workspace_ids: set[str],
 ) -> dict[str, str]:
@@ -392,7 +392,7 @@ def infer_invalid_workspace_aliases(
         project_name_map: Basename map for path resolution.
         workspace_path_map: Normalized path map for path resolution.
         workspace_entries: Workspace folder entries from storage scan.
-        bubble_map: Bubble KV map for path resolution.
+        bubble_map: ``{bubble_id: Bubble | bubble_dict}`` for path resolution.
         composer_id_to_ws: Composer-to-workspace map (may point at invalid IDs).
         invalid_workspace_ids: Workspace folder names to reassign.
 

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -21,6 +21,10 @@ from utils.text_extract import extract_text_from_bubble
 from utils.tool_parser import parse_tool_call
 from utils.workspace_descriptor import read_json_file
 from models import Bubble, Composer, ParseWarningCollector, SchemaError
+from models.raw_access import (
+    conversation_header_bubble_id,
+    message_request_context_project_layouts,
+)
 from services.summary_cache import (
     fingerprint_workspace_storage,
     get_cached_tab_summaries,
@@ -90,20 +94,20 @@ def _kv_payload_log_meta(value: object | None) -> tuple[int, str | None]:
 
 def _assemble_tab_from_composer_data(
     composer_id: str,
-    cd: dict,
-    bubble_map: dict[str, dict],
+    composer: Composer,
+    bubble_map: dict[str, Bubble | dict[str, Any]],
     contexts: list[dict],
     code_block_diffs: list[dict],
     workspace_display_name: str,
     rules: list,
     parse_warnings: ParseWarningCollector,
 ) -> dict | None:
-    """Assemble a single tab dict from an already-parsed composer dict.
+    """Assemble a single tab dict from a validated :class:`Composer`.
 
     Args:
         composer_id: Composer UUID.
-        cd: Raw ``composerData`` dict (``composer.raw``).
-        bubble_map: ``{bubble_id: bubble_dict}`` — may be global or scoped.
+        composer: Validated composer model (typed field access on ``.raw``).
+        bubble_map: ``{bubble_id: Bubble | bubble_dict}`` — global or scoped.
         contexts: ``messageRequestContext`` entries for *this* composer
             (list of dicts, each with an injected ``contextId`` key and a
             ``bubbleId`` field from the JSON value).
@@ -116,18 +120,31 @@ def _assemble_tab_from_composer_data(
         A tab dict on success, or ``None`` when the tab should be omitted
         (no renderable bubbles or excluded by rules).
     """
-    headers = cd.get("fullConversationHeadersOnly") or []
+    headers = composer.full_conversation_headers_only
 
     bubbles: list[dict[str, Any]] = []
     for header in headers:
         if not isinstance(header, dict):
             continue
-        bubble_id = header.get("bubbleId")
-        if not isinstance(bubble_id, str):
+        bubble_id = conversation_header_bubble_id(header, composer_id=composer_id)
+        if not bubble_id:
             continue
-        bubble = bubble_map.get(bubble_id)
-        if not bubble:
+        bubble_entry = bubble_map.get(bubble_id)
+        if not bubble_entry:
             continue
+        if isinstance(bubble_entry, Bubble):
+            bubble = bubble_entry
+        else:
+            try:
+                bubble = Bubble.from_dict(bubble_entry, bubble_id=bubble_id)
+            except SchemaError as e:
+                _logger.warning(
+                    "Failed to parse Bubble from bubbleId:%s: %s",
+                    bubble_id,
+                    e,
+                )
+                parse_warnings.record_bubble_skipped()
+                continue
 
         is_user = header.get("type") == 1
         msg_type = "user" if is_user else "ai"
@@ -174,11 +191,10 @@ def _assemble_tab_from_composer_data(
                         context_text += f"\n- {comp.get('name') or comp.get('composerId') or 'Conversation'}"
 
         full_text = text + context_text
-        raw = bubble
-        token_count = raw.get("tokenCount")
+        token_count = bubble.token_count
 
         tool_calls = None
-        tfd = raw.get("toolFormerData")
+        tfd = bubble.tool_former_data
         if isinstance(tfd, dict):
             tool_call = parse_tool_call(tfd)
             if isinstance(tool_call, dict):
@@ -186,15 +202,24 @@ def _assemble_tab_from_composer_data(
 
         thinking = None
         thinking_duration_ms = None
-        if raw.get("thinking"):
-            thinking = raw["thinking"] if isinstance(raw["thinking"], str) else (raw["thinking"].get("text") if isinstance(raw["thinking"], dict) else None)
-            thinking_duration_ms = raw.get("thinkingDurationMs")
+        thinking_raw = bubble.thinking
+        if thinking_raw:
+            thinking = (
+                thinking_raw
+                if isinstance(thinking_raw, str)
+                else (
+                    thinking_raw.get("text")
+                    if isinstance(thinking_raw, dict)
+                    else None
+                )
+            )
+            thinking_duration_ms = bubble.thinking_duration_ms
 
         has_content = full_text.strip() or tool_calls or thinking
         if not has_content:
             continue
 
-        ctx_window = raw.get("contextWindowStatusAtCreation") or {}
+        ctx_window = bubble.context_window_status_at_creation
         ctx_pct = None
         if isinstance(ctx_window, dict):
             if ctx_window.get("percentageRemainingFloat") is not None:
@@ -213,7 +238,7 @@ def _assemble_tab_from_composer_data(
             display_text = thinking
 
         bubble_meta = None
-        model_info = raw.get("modelInfo") or {}
+        model_info = bubble.model_info
         model_name = model_info.get("modelName")
         if model_name == "default":
             model_name = None
@@ -228,8 +253,8 @@ def _assemble_tab_from_composer_data(
                 "inputTokens": in_tok if in_tok > 0 else None,
                 "outputTokens": out_tok if out_tok > 0 else None,
                 "cachedTokens": cached_tok if cached_tok > 0 else None,
-                "toolResultsCount": (len(tool_calls) if tool_calls else None) or (len(raw["toolResults"]) if isinstance(raw.get("toolResults"), list) and raw["toolResults"] else None),
-                "toolResults": raw.get("toolResults") if isinstance(raw.get("toolResults"), list) and raw["toolResults"] else None,
+                "toolResultsCount": (len(tool_calls) if tool_calls else None) or (len(bubble.tool_results) if bubble.tool_results else None),
+                "toolResults": bubble.tool_results if bubble.tool_results else None,
                 "toolCalls": tool_calls,
                 "thinking": thinking,
                 "thinkingDurationMs": thinking_duration_ms,
@@ -256,7 +281,7 @@ def _assemble_tab_from_composer_data(
         b_entry = {
             "type": msg_type,
             "text": display_text,
-            "timestamp": to_epoch_ms(bubble.get("createdAt")) or to_epoch_ms(bubble.get("timestamp")) or int(datetime.now().timestamp() * 1000),
+            "timestamp": to_epoch_ms(bubble.bubble_timestamp_ms()) or int(datetime.now().timestamp() * 1000),
         }
         if bubble_meta:
             b_entry["metadata"] = bubble_meta
@@ -265,8 +290,8 @@ def _assemble_tab_from_composer_data(
     if not bubbles:
         return None
 
-    title = cd.get("name") or f"Conversation {composer_id[:8]}"
-    if not cd.get("name") and bubbles:
+    title = composer.name or f"Conversation {composer_id[:8]}"
+    if not composer.name and bubbles:
         first_msg = bubbles[0].get("text", "")
         if first_msg:
             first_lines = [ln for ln in first_msg.split("\n") if ln.strip()]
@@ -275,8 +300,7 @@ def _assemble_tab_from_composer_data(
                 if len(title) == 100:
                     title += "..."
 
-    _early_model_config = cd.get("modelConfig") or {}
-    _early_model_name = _early_model_config.get("modelName")
+    _early_model_name = composer.model_name_from_config()
     _early_model_names = [_early_model_name] if _early_model_name and _early_model_name != "default" else None
     if is_excluded_by_rules(rules, build_searchable_text(
         project_name=workspace_display_name,
@@ -324,15 +348,15 @@ def _assemble_tab_from_composer_data(
         if m.get("thinkingDurationMs"):
             total_thinking_ms += m["thinkingDurationMs"]
 
-    usage = cd.get("usageData") or {}
+    usage = composer.usage_data
     composer_cost = usage.get("cost") or usage.get("estimatedCost")
     if isinstance(composer_cost, (int, float)) and total_cost == 0:
         total_cost = composer_cost
 
-    lines_added = cd.get("totalLinesAdded", 0)
-    lines_removed = cd.get("totalLinesRemoved", 0)
-    files_added = cd.get("addedFiles", 0)
-    files_removed = cd.get("removedFiles", 0)
+    lines_added = composer.total_lines_added
+    lines_removed = composer.total_lines_removed
+    files_added = composer.added_files
+    files_removed = composer.removed_files
 
     max_ctx_tokens = 0
     ctx_token_limit = 0
@@ -367,8 +391,7 @@ def _assemble_tab_from_composer_data(
         }
         tab_meta = {k: v for k, v in tab_meta_raw.items() if v is not None}
 
-    model_config = cd.get("modelConfig") or {}
-    model_name_from_config = model_config.get("modelName")
+    model_name_from_config = composer.model_name_from_config()
     if model_name_from_config and model_name_from_config != "default":
         if not tab_meta:
             tab_meta = {}
@@ -381,7 +404,7 @@ def _assemble_tab_from_composer_data(
     tab: dict[str, Any] = {
         "id": composer_id,
         "title": title,
-        "timestamp": to_epoch_ms(cd.get("lastUpdatedAt")) or to_epoch_ms(cd.get("createdAt")) or int(datetime.now().timestamp() * 1000),
+        "timestamp": to_epoch_ms(composer.last_updated_at) or to_epoch_ms(composer.created_at) or int(datetime.now().timestamp() * 1000),
         "bubbles": [{
             "type": b["type"],
             "text": b.get("text", ""),
@@ -686,8 +709,6 @@ def assemble_single_tab(
             )
             return {"error": "Failed to parse conversation"}, 500
 
-        cd = composer.raw
-
         # Verify the conversation belongs to the requested workspace.
         # Always scoped: only load messageRequestContext rows for this composer.
         project_layouts_map: dict[str, list] = {}
@@ -711,7 +732,7 @@ def assemble_single_tab(
             )
 
         pid = determine_project_for_conversation(
-            cd, composer_id, project_layouts_map,
+            composer, composer_id, project_layouts_map,
             project_name_map, workspace_path_map,
             workspace_entries, {}, composer_id_to_ws, invalid_workspace_ids,
         )
@@ -730,7 +751,7 @@ def assemble_single_tab(
 
         tab = _assemble_tab_from_composer_data(
             composer_id=composer_id,
-            cd=cd,
+            composer=composer,
             bubble_map=bubble_map,
             contexts=contexts,
             code_block_diffs=code_block_diffs,
@@ -776,7 +797,7 @@ def assemble_workspace_tabs(
     composer_id_to_ws = ctx.composer_id_to_workspace_id
     matching_ws_ids = _build_matching_ws_ids(workspace_id, workspace_path, workspace_entries)
 
-    bubble_map: dict[str, dict] = {}
+    bubble_map: dict[str, Bubble] = {}
     code_block_diff_map: dict[str, list] = {}
     message_request_context_map: dict[str, list] = {}
 
@@ -816,7 +837,7 @@ def assemble_workspace_tabs(
                     continue
                 try:
                     bubble_obj = Bubble.from_dict(parsed, bubble_id=bid)
-                    bubble_map[bid] = bubble_obj.raw
+                    bubble_map[bid] = bubble_obj
                 except SchemaError as e:
                     # Drift logged so the operator can chase disappearing
                     # bubbles instead of guessing. Bad row still skipped so the
@@ -852,8 +873,8 @@ def assemble_workspace_tabs(
                 })
 
             # Project-layout map (root paths used by the resolver)
-            layouts = mrc.get("projectLayouts")
-            if isinstance(layouts, list):
+            layouts = message_request_context_project_layouts(mrc, composer_id=chat_id)
+            if layouts:
                 project_layouts_map.setdefault(chat_id, [])
                 for layout in layouts:
                     if isinstance(layout, str):
@@ -915,11 +936,9 @@ def assemble_workspace_tabs(
                 parse_warnings.record_composer_skipped()
                 continue
             try:
-                cd = composer.raw
-
                 # Determine project
                 pid = determine_project_for_conversation(
-                    cd, composer_id, project_layouts_map,
+                    composer, composer_id, project_layouts_map,
                     project_name_map, workspace_path_map,
                     workspace_entries, bubble_map, composer_id_to_ws, invalid_workspace_ids,
                 )
@@ -933,7 +952,7 @@ def assemble_workspace_tabs(
 
                 tab = _assemble_tab_from_composer_data(
                     composer_id=composer_id,
-                    cd=cd,
+                    composer=composer,
                     bubble_map=bubble_map,
                     contexts=message_request_context_map.get(composer_id, []),
                     code_block_diffs=code_block_diff_map.get(composer_id, []),

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -82,6 +82,21 @@ def _loads_kv_value_logged(key: str, raw: object | None) -> Any | None:
         return None
 
 
+def _bubble_entry_timestamp_ms(bubble: Bubble) -> int:
+    raw_ts = bubble.bubble_timestamp_ms()
+    if raw_ts is not None:
+        return to_epoch_ms(raw_ts)
+    return int(datetime.now().timestamp() * 1000)
+
+
+def _composer_tab_timestamp_ms(composer: Composer) -> int:
+    if composer.last_updated_at is not None:
+        return to_epoch_ms(composer.last_updated_at)
+    if composer.created_at is not None:
+        return to_epoch_ms(composer.created_at)
+    return int(datetime.now().timestamp() * 1000)
+
+
 def _kv_payload_log_meta(value: object | None) -> tuple[int, str | None]:
     """Byte length and short SHA-256 prefix for logs without emitting raw KV payloads."""
     if value is None:
@@ -245,7 +260,8 @@ def _assemble_tab_from_composer_data(
             model_name = None
 
         if msg_type == "ai":
-            tc_dict = token_count if isinstance(token_count, dict) else {}
+            tc_dict = token_count or {}
+            tool_results = bubble.tool_results
             in_tok = tc_dict.get("inputTokens") or 0
             out_tok = tc_dict.get("outputTokens") or 0
             cached_tok = tc_dict.get("cachedTokens") or 0
@@ -254,8 +270,8 @@ def _assemble_tab_from_composer_data(
                 "inputTokens": in_tok if in_tok > 0 else None,
                 "outputTokens": out_tok if out_tok > 0 else None,
                 "cachedTokens": cached_tok if cached_tok > 0 else None,
-                "toolResultsCount": (len(tool_calls) if tool_calls else None) or (len(bubble.tool_results) if bubble.tool_results else None),
-                "toolResults": bubble.tool_results if bubble.tool_results else None,
+                "toolResultsCount": (len(tool_calls) if tool_calls else None) or (len(tool_results) if tool_results else None),
+                "toolResults": tool_results if tool_results else None,
                 "toolCalls": tool_calls,
                 "thinking": thinking,
                 "thinkingDurationMs": thinking_duration_ms,
@@ -282,7 +298,7 @@ def _assemble_tab_from_composer_data(
         b_entry = {
             "type": msg_type,
             "text": display_text,
-            "timestamp": to_epoch_ms(bubble.bubble_timestamp_ms()) or int(datetime.now().timestamp() * 1000),
+            "timestamp": _bubble_entry_timestamp_ms(bubble),
         }
         if bubble_meta:
             b_entry["metadata"] = bubble_meta
@@ -405,7 +421,7 @@ def _assemble_tab_from_composer_data(
     tab: dict[str, Any] = {
         "id": composer_id,
         "title": title,
-        "timestamp": to_epoch_ms(composer.last_updated_at) or to_epoch_ms(composer.created_at) or int(datetime.now().timestamp() * 1000),
+        "timestamp": _composer_tab_timestamp_ms(composer),
         "bubbles": [{
             "type": b["type"],
             "text": b.get("text", ""),
@@ -624,7 +640,8 @@ def _build_workspace_tab_summaries_uncached(
                 tab_entry: dict = {
                     "id": composer_id,
                     "title": title,
-                    "timestamp": to_epoch_ms(composer.last_updated_at) or to_epoch_ms(composer.created_at) or int(datetime.now().timestamp() * 1000),
+                    "timestamp": _composer_tab_timestamp_ms(composer),
+                    # Header count (KV rows), not renderable bubbles after assembly filters.
                     "messageCount": len(headers),
                 }
                 if tab_meta:

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -131,7 +131,7 @@ def _assemble_tab_from_composer_data(
         if not bubble_id:
             continue
         bubble_entry = bubble_map.get(bubble_id)
-        if not bubble_entry:
+        if bubble_entry is None:
             continue
         if isinstance(bubble_entry, Bubble):
             bubble = bubble_entry
@@ -572,6 +572,16 @@ def _build_workspace_tab_summaries_uncached(
                 parse_warnings.record_composer_skipped()
                 continue
             try:
+                composer = Composer.from_dict(cd, composer_id=composer_id)
+            except SchemaError as e:
+                _logger.warning(
+                    "Failed to parse Composer from composerData:%s: %s",
+                    composer_id,
+                    e,
+                )
+                parse_warnings.record_composer_skipped()
+                continue
+            try:
                 if (
                     composer_id not in composer_id_to_ws
                     and composer_id not in project_layouts_map
@@ -580,7 +590,7 @@ def _build_workspace_tab_summaries_uncached(
                         global_db, composer_id,
                     )
                 pid = determine_project_for_conversation(
-                    cd, composer_id, project_layouts_map,
+                    composer, composer_id, project_layouts_map,
                     project_name_map, workspace_path_map,
                     workspace_entries, {}, composer_id_to_ws, invalid_workspace_ids,
                 )
@@ -592,14 +602,13 @@ def _build_workspace_tab_summaries_uncached(
                 if assigned not in matching_ws_ids:
                     continue
 
-                headers = cd.get("fullConversationHeadersOnly") or []
+                headers = composer.full_conversation_headers_only
                 if not headers:
                     continue
 
-                title = cd.get("name") or f"Conversation {composer_id[:8]}"
+                title = composer.name or f"Conversation {composer_id[:8]}"
 
-                _early_model_config = cd.get("modelConfig") or {}
-                _early_model_name = _early_model_config.get("modelName")
+                _early_model_name = composer.model_name_from_config()
                 _early_model_names = [_early_model_name] if _early_model_name and _early_model_name != "default" else None
                 if is_excluded_by_rules(rules, build_searchable_text(
                     project_name=workspace_display_name,
@@ -615,7 +624,7 @@ def _build_workspace_tab_summaries_uncached(
                 tab_entry: dict = {
                     "id": composer_id,
                     "title": title,
-                    "timestamp": to_epoch_ms(cd.get("lastUpdatedAt")) or to_epoch_ms(cd.get("createdAt")) or int(datetime.now().timestamp() * 1000),
+                    "timestamp": to_epoch_ms(composer.last_updated_at) or to_epoch_ms(composer.created_at) or int(datetime.now().timestamp() * 1000),
                     "messageCount": len(headers),
                 }
                 if tab_meta:

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import sqlite3
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
 
@@ -95,7 +96,7 @@ def _kv_payload_log_meta(value: object | None) -> tuple[int, str | None]:
 def _assemble_tab_from_composer_data(
     composer_id: str,
     composer: Composer,
-    bubble_map: dict[str, Bubble | dict[str, Any]],
+    bubble_map: Mapping[str, Bubble | dict[str, Any]],
     contexts: list[dict],
     code_block_diffs: list[dict],
     workspace_display_name: str,

--- a/tests/test_blob_parsing_fuzz.py
+++ b/tests/test_blob_parsing_fuzz.py
@@ -55,7 +55,10 @@ _BUBBLE_RAW_ANY = st.one_of(
 )
 
 _BUBBLE_ID = st.text(
-    alphabet=st.characters(blacklist_categories=("Cs",), blacklist_characters="\x00"),
+    alphabet=st.characters(
+        blacklist_categories=("Cs",),  # type: ignore[arg-type]
+        blacklist_characters="\x00",
+    ),
     min_size=1,
     max_size=80,
 )

--- a/tests/test_raw_accessors.py
+++ b/tests/test_raw_accessors.py
@@ -44,17 +44,47 @@ class TestRawAccessorDriftLogging(unittest.TestCase):
         with self.assertNoLogs("models.conversation", level="WARNING"):
             self.assertEqual(bubble.relevant_files, [])
 
-    def test_project_layouts_warns_when_key_missing(self) -> None:
-        with self.assertLogs("models.raw_access", level="WARNING") as logs:
+    def test_project_layouts_silent_when_key_missing(self) -> None:
+        with self.assertNoLogs("models.raw_access", level="WARNING"):
             layouts = message_request_context_project_layouts({}, composer_id="cmp-1")
+        self.assertIsNone(layouts)
+
+    def test_project_layouts_warns_on_wrong_type(self) -> None:
+        with self.assertLogs("models.raw_access", level="WARNING") as logs:
+            layouts = message_request_context_project_layouts(
+                {"projectLayouts": "not-a-list"},
+                composer_id="cmp-1",
+            )
         self.assertIsNone(layouts)
         self.assertTrue(any("projectLayouts" in m for m in logs.output), logs.output)
 
-    def test_conversation_header_bubble_id_warns_when_missing(self) -> None:
-        with self.assertLogs("models.raw_access", level="WARNING") as logs:
+    def test_conversation_header_bubble_id_silent_when_missing(self) -> None:
+        with self.assertNoLogs("models.raw_access", level="WARNING"):
             bid = conversation_header_bubble_id({"type": 1}, composer_id="cmp-1")
         self.assertIsNone(bid)
+
+    def test_conversation_header_bubble_id_warns_on_wrong_type(self) -> None:
+        with self.assertLogs("models.raw_access", level="WARNING") as logs:
+            bid = conversation_header_bubble_id(
+                {"bubbleId": 123, "type": 1},
+                composer_id="cmp-1",
+            )
+        self.assertIsNone(bid)
         self.assertTrue(any("bubbleId" in m for m in logs.output), logs.output)
+
+    def test_bubble_timestamp_ms_prefers_created_at_and_handles_zero(self) -> None:
+        b = Bubble.from_dict(
+            {"createdAt": 0, "timestamp": 99},
+            bubble_id="b-ts",
+        )
+        self.assertEqual(b.bubble_timestamp_ms(), 0)
+
+        no_ts = Bubble.from_dict({"text": "hi"}, bubble_id="b-none")
+        self.assertIsNone(no_ts.bubble_timestamp_ms())
+
+        bad_bool = Bubble.from_dict({"createdAt": True}, bubble_id="b-bool")
+        with self.assertNoLogs("models.conversation", level="WARNING"):
+            self.assertIsNone(bad_bool.bubble_timestamp_ms())
 
     def test_dict_bridge_newly_created_files_matches_composer_property(self) -> None:
         data = {**GOOD_COMPOSER_RAW, "newlyCreatedFiles": [{"uri": {"path": "/a"}}]}

--- a/tests/test_raw_accessors.py
+++ b/tests/test_raw_accessors.py
@@ -1,0 +1,88 @@
+"""Tests for typed raw accessors and schema-drift logging."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from models.conversation import Bubble, Composer
+from models.raw_access import (
+    composer_newly_created_files,
+    conversation_header_bubble_id,
+    message_request_context_project_layouts,
+    optional_raw_list,
+    warn_missing_raw_key,
+)
+from tests.test_models import GOOD_COMPOSER_RAW
+
+
+class TestRawAccessorDriftLogging(unittest.TestCase):
+    def test_composer_newly_created_files_empty_when_key_missing(self) -> None:
+        bare = Composer.from_dict(GOOD_COMPOSER_RAW, composer_id="cid-2")
+        with self.assertNoLogs("models.conversation", level="WARNING"):
+            self.assertEqual(bare.newly_created_files, [])
+
+    def test_composer_newly_created_files_warns_on_wrong_type(self) -> None:
+        bad = Composer.from_dict(
+            {**GOOD_COMPOSER_RAW, "newlyCreatedFiles": "not-a-list"},
+            composer_id="cid-bad",
+        )
+        with self.assertLogs("models.conversation", level="WARNING") as logs:
+            self.assertEqual(bad.newly_created_files, [])
+        self.assertTrue(any("newlyCreatedFiles" in m for m in logs.output), logs.output)
+
+    def test_bubble_relevant_files_empty_when_key_missing(self) -> None:
+        bubble = Bubble.from_dict({"type": "user", "text": "hi"}, bubble_id="b-1")
+        with self.assertNoLogs("models.conversation", level="WARNING"):
+            self.assertEqual(bubble.relevant_files, [])
+
+    def test_project_layouts_warns_when_key_missing(self) -> None:
+        with self.assertLogs("models.raw_access", level="WARNING") as logs:
+            layouts = message_request_context_project_layouts({}, composer_id="cmp-1")
+        self.assertIsNone(layouts)
+        self.assertTrue(any("projectLayouts" in m for m in logs.output), logs.output)
+
+    def test_conversation_header_bubble_id_warns_when_missing(self) -> None:
+        with self.assertLogs("models.raw_access", level="WARNING") as logs:
+            bid = conversation_header_bubble_id({"type": 1}, composer_id="cmp-1")
+        self.assertIsNone(bid)
+        self.assertTrue(any("bubbleId" in m for m in logs.output), logs.output)
+
+    def test_dict_bridge_newly_created_files_matches_composer_property(self) -> None:
+        data = {**GOOD_COMPOSER_RAW, "newlyCreatedFiles": [{"uri": {"path": "/a"}}]}
+        composer = Composer.from_dict(data, composer_id="cid-bridge")
+        self.assertEqual(
+            composer.newly_created_files,
+            composer_newly_created_files(composer, "cid-bridge"),
+        )
+
+    def test_optional_raw_list_no_warning_when_present(self) -> None:
+        with self.assertNoLogs("models.raw_access", level="WARNING"):
+            value = optional_raw_list(
+                {"items": [1]},
+                "items",
+                model="Test",
+                entity_id="e1",
+            )
+        self.assertEqual(value, [1])
+
+    def test_warn_missing_raw_key_message_format(self) -> None:
+        with self.assertLogs("models.raw_access", level="WARNING") as logs:
+            warn_missing_raw_key(
+                {},
+                "sampleKey",
+                model="SampleModel",
+                entity_id="ent-9",
+            )
+        self.assertIn("SampleModel ent-9", logs.output[0])
+        self.assertIn("sampleKey", logs.output[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_raw_accessors.py
+++ b/tests/test_raw_accessors.py
@@ -6,12 +6,14 @@ import logging
 import os
 import sys
 import unittest
+from unittest.mock import patch
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
 from models.conversation import Bubble, Composer
+from services.workspace_tabs import _bubble_entry_timestamp_ms
 from models.raw_access import (
     composer_newly_created_files,
     conversation_header_bubble_id,
@@ -85,6 +87,45 @@ class TestRawAccessorDriftLogging(unittest.TestCase):
         bad_bool = Bubble.from_dict({"createdAt": True}, bubble_id="b-bool")
         with self.assertNoLogs("models.conversation", level="WARNING"):
             self.assertIsNone(bad_bool.bubble_timestamp_ms())
+
+    def test_bubble_thinking_silent_when_missing(self) -> None:
+        bubble = Bubble.from_dict({"text": "hi"}, bubble_id="b-1")
+        with self.assertNoLogs("models.conversation", level="WARNING"):
+            self.assertIsNone(bubble.thinking)
+
+    def test_bubble_thinking_warns_on_wrong_type(self) -> None:
+        bubble = Bubble.from_dict({"thinking": 42}, bubble_id="b-bad")
+        with self.assertLogs("models.conversation", level="WARNING") as logs:
+            self.assertIsNone(bubble.thinking)
+        self.assertTrue(any("thinking" in m for m in logs.output), logs.output)
+
+    def test_bubble_thinking_accepts_str_or_dict(self) -> None:
+        s = Bubble.from_dict({"thinking": "trace"}, bubble_id="b-str")
+        self.assertEqual(s.thinking, "trace")
+        d = Bubble.from_dict({"thinking": {"text": "nested"}}, bubble_id="b-dict")
+        self.assertEqual(d.thinking, {"text": "nested"})
+
+    def test_bubble_entry_timestamp_ms_preserves_epoch_zero(self) -> None:
+        """Regression: falsy ``or now()`` must not replace a valid ``createdAt`` of 0."""
+        bubble = Bubble.from_dict({"createdAt": 0}, bubble_id="b-zero")
+        sentinel_now_ms = 9_999_000_000_000
+        with patch(
+            "services.workspace_tabs.datetime",
+        ) as mock_datetime:
+            mock_datetime.now.return_value.timestamp.return_value = sentinel_now_ms / 1000
+            ts = _bubble_entry_timestamp_ms(bubble)
+        self.assertEqual(ts, 0)
+        self.assertNotEqual(ts, sentinel_now_ms)
+
+    def test_bubble_entry_timestamp_ms_falls_back_when_no_timestamp(self) -> None:
+        bubble = Bubble.from_dict({"text": "hi"}, bubble_id="b-none")
+        sentinel_now_ms = 1_700_000_000_000
+        with patch(
+            "services.workspace_tabs.datetime",
+        ) as mock_datetime:
+            mock_datetime.now.return_value.timestamp.return_value = sentinel_now_ms / 1000
+            ts = _bubble_entry_timestamp_ms(bubble)
+        self.assertEqual(ts, sentinel_now_ms)
 
     def test_dict_bridge_newly_created_files_matches_composer_property(self) -> None:
         data = {**GOOD_COMPOSER_RAW, "newlyCreatedFiles": [{"uri": {"path": "/a"}}]}

--- a/tests/test_raw_accessors.py
+++ b/tests/test_raw_accessors.py
@@ -24,7 +24,9 @@ from tests.test_models import GOOD_COMPOSER_RAW
 
 class TestRawAccessorDriftLogging(unittest.TestCase):
     def test_composer_newly_created_files_empty_when_key_missing(self) -> None:
-        bare = Composer.from_dict(GOOD_COMPOSER_RAW, composer_id="cid-2")
+        raw = dict(GOOD_COMPOSER_RAW)
+        raw.pop("newlyCreatedFiles", None)
+        bare = Composer.from_dict(raw, composer_id="cid-2")
         with self.assertNoLogs("models.conversation", level="WARNING"):
             self.assertEqual(bare.newly_created_files, [])
 

--- a/utils/text_extract.py
+++ b/utils/text_extract.py
@@ -33,28 +33,27 @@ def extract_text_from_rich_text(children: list) -> str:
 
 def extract_text_from_bubble(bubble: HasBubbleRaw | dict[str, Any]) -> str:
     """Extract displayable text from a bubble object (text, richText, codeBlocks)."""
-    raw: dict[str, Any] = bubble if isinstance(bubble, dict) else bubble.raw
-    if not raw:
+    payload: dict[str, Any] = bubble if isinstance(bubble, dict) else bubble.raw
+    if not payload:
         return ""
-    bubble = raw
 
     text = ""
 
     # Try text field first (coerce non-str values — Cursor payloads can drift)
-    if bubble.get("text") and str(bubble["text"]).strip():
-        text = str(bubble["text"])
+    if payload.get("text") and str(payload["text"]).strip():
+        text = str(payload["text"])
 
     # Fall back to richText
-    if not text and bubble.get("richText"):
+    if not text and payload.get("richText"):
         try:
-            rich = json.loads(bubble["richText"]) if isinstance(bubble["richText"], str) else bubble["richText"]
+            rich = json.loads(payload["richText"]) if isinstance(payload["richText"], str) else payload["richText"]
             if isinstance(rich, dict) and rich.get("root") and rich["root"].get("children"):
                 text = extract_text_from_rich_text(rich["root"]["children"])
         except Exception:
             pass
 
     # Append code blocks if present
-    code_blocks = bubble.get("codeBlocks")
+    code_blocks = payload.get("codeBlocks")
     if isinstance(code_blocks, list):
         for cb in code_blocks:
             if isinstance(cb, dict) and cb.get("content"):

--- a/utils/text_extract.py
+++ b/utils/text_extract.py
@@ -1,7 +1,17 @@
 """Text extraction helpers mirroring the bubble/richText parsing in the Node.js codebase."""
 
+from __future__ import annotations
+
 import json
 import re
+from typing import Any, Protocol
+
+
+class HasBubbleRaw(Protocol):
+    """Bubble model or any object exposing a Cursor JSON ``raw`` dict."""
+
+    @property
+    def raw(self) -> dict[str, Any]: ...
 
 
 def extract_text_from_rich_text(children: list) -> str:
@@ -21,12 +31,12 @@ def extract_text_from_rich_text(children: list) -> str:
     return text
 
 
-def extract_text_from_bubble(bubble: dict | object) -> str:
+def extract_text_from_bubble(bubble: HasBubbleRaw | dict[str, Any]) -> str:
     """Extract displayable text from a bubble object (text, richText, codeBlocks)."""
-    if hasattr(bubble, "raw"):
-        bubble = bubble.raw  # type: ignore[union-attr]
-    if not bubble or not isinstance(bubble, dict):
+    raw: dict[str, Any] = bubble if isinstance(bubble, dict) else bubble.raw
+    if not raw:
         return ""
+    bubble = raw
 
     text = ""
 

--- a/utils/text_extract.py
+++ b/utils/text_extract.py
@@ -21,8 +21,10 @@ def extract_text_from_rich_text(children: list) -> str:
     return text
 
 
-def extract_text_from_bubble(bubble: dict) -> str:
+def extract_text_from_bubble(bubble: dict | object) -> str:
     """Extract displayable text from a bubble object (text, richText, codeBlocks)."""
+    if hasattr(bubble, "raw"):
+        bubble = bubble.raw  # type: ignore[union-attr]
     if not bubble or not isinstance(bubble, dict):
         return ""
 


### PR DESCRIPTION
## Summary

- Introduce `models/raw_access.py` with shared optional-key readers and schema-drift `WARNING` logging when structurally important keys are missing or mistyped (`projectLayouts`, `bubbleId` in headers, etc.).
- Add typed accessors on `Composer` and `Bubble` (`newly_created_files`, `relevant_files`, `usage_data`, `bubble_timestamp_ms()`, and related fields) so services can use model fields instead of silent `.get()` chains after `from_dict` validation.
- Migrate `services/workspace_tabs.py` and `services/workspace_resolver.py` to pass `Composer` / `Bubble` through the hot path (`bubble_map` stores `Bubble` instances; `determine_project_for_conversation` accepts `Composer | dict`).
- Add `tests/test_raw_accessors.py` for drift logging and bridge helpers.

Closes #90 

## Test plan

- [x] `python -m pytest tests/test_raw_accessors.py -v`
- [x] `python -m pytest tests/test_workspace_assignment_fallback.py tests/test_models.py -v`
- [x] `python -m pytest tests/ -q` (371 passed)
- [x] `python -m mypy models services/workspace_tabs.py services/workspace_resolver.py`
- [ ] Manual: open workspace tabs in the UI for a workspace with real Cursor data; confirm tabs load and logs do not spam warnings for normal composers missing optional keys (`newlyCreatedFiles`, `relevantFiles`)

## Notes

- Commonly absent optional fields return empty defaults without a missing-key warning; wrong types still log drift.
- Follow-up (out of scope here): migrate remaining `.get()` usage in `workspace_listing.py`, `api/search.py`, and `scripts/export.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversations and bubbles now expose richer usage/metrics, file-change rollups, model info, and more reliable timestamps; workspace tabs and project inference assemble from typed conversation/bubble objects for clearer displays.
  * Text extraction accepts broader bubble inputs for more reliable content display.

* **Bug Fixes**
  * Fewer crashes and incorrect displays when conversation JSON is malformed; safer defaults and schema-drift warnings replace errors.

* **Tests**
  * Added tests covering typed raw accessors and schema-drift logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->