### PR TITLE
docs: promote CHANGELOG to v0.1.0 (closes #92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-06-04
+
 ### Added
 - **Summary disk cache (Phase 3)** — project list and tab summaries cached under
   `~/.cache/cursor-chat-browser/`, invalidated when global or per-workspace DB
@@ -23,26 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scoped KV loaders** in `services/workspace_db.py`:
   `load_bubbles_for_composer`, `load_message_request_context_for_composer`,
   `load_code_block_diffs_for_composer` — used by the single-tab path (#84)
-
-### Changed
-- **List-path performance** — skip full `messageRequestContext` scan unless
-  invalid workspace aliases are needed; filter `composerData` in SQL; skip
-  `Composer.from_dict` on list/summary paths; cache `composer_id_to_ws` mapping (#84)
-- **`GET /api/workspaces`** (`list_workspace_projects`) no longer performs a
-  global `bubbleId:%` scan; conversation presence is determined from
-  `fullConversationHeadersOnly` headers alone, and workspace assignment relies
-  on `composer_id_to_ws` (primary) plus `projectLayouts` from MRC (#84)
-- **`assemble_workspace_tabs`** inner per-composer loop refactored into a shared
-  `_assemble_tab_from_composer_data` helper reused by `assemble_single_tab`; full
-  path behaviour is unchanged (#84)
-
-### Deprecated
-- Direct use of `GET /api/workspaces/<id>/tabs` (no `?summary=1`) from the workspace
-  UI on page load; the UI now calls `?summary=1` for first paint and lazy-fetches
-  individual tabs. The full-assembly endpoint remains available for export,
-  search, and backward-compatible consumers (planned removal: post-1.0) (#84)
-
-
 - **Web UI** — browse and search all Cursor AI workspaces; conversation view with syntax-highlighted code blocks, dark/light mode, and bookmarkable chat URLs (#63)
 - **Export formats** — one-click export of chats as Markdown, HTML, PDF, JSON, and CSV from the web UI (#63)
 - **CLI export** (`cursor-chat-export` / `scripts/export.py`) — zip archive or individual Markdown files with YAML frontmatter; incremental mode (`--since last`) preserves state across runs (#63, #42, #61)
@@ -55,10 +37,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full-text search with workspace and log-type filters (#63)
 - Hypothesis property-based tests for blob and bubble parsing (#71, #81)
 - PDF export endpoint coverage in CI (#72)
+- Unit tests for `determine_project_for_conversation` fallback chain (#87, #89)
 
 ### Changed
+- **List-path performance** — skip full `messageRequestContext` scan unless
+  invalid workspace aliases are needed; filter `composerData` in SQL; skip
+  `Composer.from_dict` on list/summary paths; cache `composer_id_to_ws` mapping (#84)
+- **`GET /api/workspaces`** (`list_workspace_projects`) no longer performs a
+  global `bubbleId:%` scan; conversation presence is determined from
+  `fullConversationHeadersOnly` headers alone, and workspace assignment relies
+  on `composer_id_to_ws` (primary) plus `projectLayouts` from MRC (#84)
+- **`assemble_workspace_tabs`** inner per-composer loop refactored into a shared
+  `_assemble_tab_from_composer_data` helper reused by `assemble_single_tab`; full
+  path behaviour is unchanged (#84)
 - Extract shared `from_dict` validation helpers for model classes, reducing duplication (#70, #80)
 - Enable mypy `strict-optional` and fix nullability gaps across the codebase (#69, #79)
+
+### Deprecated
+- Direct use of `GET /api/workspaces/<id>/tabs` (no `?summary=1`) from the workspace
+  UI on page load; the UI now calls `?summary=1` for first paint and lazy-fetches
+  individual tabs. The full-assembly endpoint remains available for export,
+  search, and backward-compatible consumers (planned removal: post-1.0) (#84)
 
 ### Fixed
 - Path traversal and symlink-escape protection on `/api/set-workspace` (#15, #22)
@@ -73,4 +72,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace silent `except Exception: pass` with structured logging in workspace and bubble load paths (#66, #76)
 - Decouple API handlers from private `_`-prefixed service internals (#73)
 
-[Unreleased]: https://github.com/cppalliance/cppa-cursor-browser/commits/HEAD
+[Unreleased]: https://github.com/cppalliance/cppa-cursor-browser/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/cppalliance/cppa-cursor-browser/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

- Promote `CHANGELOG.md` `[Unreleased]` → `[0.1.0] - 2026-06-04` and add an empty `[Unreleased]` section for post-release work
- Fix changelog structure after #84: initial ship items (Web UI, export formats, CLI, packaging, etc.) were incorrectly nested under `### Deprecated`; restore proper `### Added` / `### Changed` / `### Deprecated` / `### Fixed` grouping
- Add `#87` / `#89` resolver test coverage under `### Added` (shipped on `master`, previously missing from the changelog)
- Update Keep a Changelog compare links: `[Unreleased]` → `v0.1.0...HEAD`, `[0.1.0]` → release tag

Closes #92

## Motivation

Release infrastructure was already in place (`pyproject.toml` `version = "0.1.0"`, README semver policy, `docs/API_DEPRECATION.md`) but no tagged release existed. Consumers could not pin to a known-good state. Remaining work is mechanical: finalize the changelog entry, merge, then tag and publish the GitHub release.

## Verified (no code changes in this PR)

| Item | Status |
|------|--------|
| `pyproject.toml` `version = "0.1.0"` | Already set — unchanged |
| `docs/API_DEPRECATION.md` | Already documents deprecation lifecycle — unchanged |
| README **Versioning** section | Already documents pre-1.0 semver — unchanged |

## Post-merge (maintainer)

Do **not** tag from the PR branch. After this PR merges to `master`:

```bash
git checkout master && git pull
git tag -a v0.1.0 -m "v0.1.0"
git push origin v0.1.0
gh release create v0.1.0 --title "v0.1.0" --notes-file -

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CHANGELOG with initial v0.1.0 release entry
  * Reorganized feature and change section listings
  * Updated deprecated section guidance regarding UI usage patterns
  * Refreshed version reference links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->