### PR TITLE
Speed up workspace listing and search; add FTS index and fix search d…

### DIFF
--- a/api/search.py
+++ b/api/search.py
@@ -1,6 +1,6 @@
 """
 API route for search — mirrors src/app/api/search/route.ts
-GET /api/search?q=...&type=all|chat|composer
+GET /api/search?q=...&type=all|chat|composer&all_history=1
 """
 
 import logging
@@ -12,7 +12,9 @@ from api.flask_config import json_response
 
 from models import ParseWarningCollector, SearchResult
 from services.search import (
+    DEFAULT_SEARCH_WINDOW_DAYS,
     rank_results,
+    resolve_search_since_ms,
     search_cli_sessions,
     search_global_storage,
     search_legacy_workspaces,
@@ -23,12 +25,26 @@ bp = Blueprint("search", __name__)
 _logger = logging.getLogger(__name__)
 
 
+def _parse_since_days_param(raw: str | None) -> int | None:
+    if raw is None or not str(raw).strip():
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
 @bp.route("/api/search")
 def search() -> tuple[Response, int] | Response:
     try:
         query = request.args.get("q", "").strip()
         search_type = request.args.get("type", "all")
         rules = current_app.config.get("EXCLUSION_RULES") or []
+        all_history = request.args.get("all_history") in ("1", "true")
+        since_ms = resolve_search_since_ms(
+            all_history=all_history,
+            since_days=_parse_since_days_param(request.args.get("since_days")),
+        )
 
         if not query:
             return json_response({"error": "No search query provided"}, 400)
@@ -40,20 +56,46 @@ def search() -> tuple[Response, int] | Response:
         if search_type != "chat":
             results.extend(
                 search_global_storage(
-                    workspace_path, query, query_lower, rules, parse_warnings
+                    workspace_path,
+                    query,
+                    query_lower,
+                    rules,
+                    parse_warnings,
+                    since_ms=since_ms,
                 )
             )
         results.extend(
-            search_legacy_workspaces(workspace_path, query, query_lower, search_type, rules)
+            search_legacy_workspaces(
+                workspace_path,
+                query,
+                query_lower,
+                search_type,
+                rules,
+                since_ms=since_ms,
+            )
         )
         if search_type == "all":
             results.extend(
                 search_cli_sessions(
-                    get_cli_chats_path(), query, query_lower, rules, parse_warnings
+                    get_cli_chats_path(),
+                    query,
+                    query_lower,
+                    rules,
+                    parse_warnings,
+                    since_ms=since_ms,
                 )
             )
 
-        payload: dict[str, Any] = {"results": rank_results(results)}
+        payload: dict[str, Any] = {
+            "results": rank_results(results),
+            "allHistory": since_ms is None,
+            "searchWindowDays": (
+                None if since_ms is None else (
+                    _parse_since_days_param(request.args.get("since_days"))
+                    or DEFAULT_SEARCH_WINDOW_DAYS
+                )
+            ),
+        }
         return json_response(parse_warnings.attach_to(payload))
 
     except Exception:

--- a/api/search.py
+++ b/api/search.py
@@ -24,14 +24,19 @@ from utils.workspace_path import get_cli_chats_path, resolve_workspace_path
 bp = Blueprint("search", __name__)
 _logger = logging.getLogger(__name__)
 
+_MAX_SEARCH_SINCE_DAYS = 36_500  # ~100 years; avoids timedelta overflow on bad input
+
 
 def _parse_since_days_param(raw: str | None) -> int | None:
     if raw is None or not str(raw).strip():
         return None
     try:
-        return int(raw)
+        days = int(raw)
     except ValueError:
         return None
+    if days <= 0 or days > _MAX_SEARCH_SINCE_DAYS:
+        return None
+    return days
 
 
 @bp.route("/api/search")

--- a/app.py
+++ b/app.py
@@ -69,6 +69,17 @@ def create_app(exclusion_rules_path: str | None = None) -> Flask:
     app.register_blueprint(pdf_bp)
     app.register_blueprint(config_bp)
 
+    try:
+        from services.search_index import start_search_index_background
+        from utils.workspace_path import resolve_workspace_path
+
+        start_search_index_background(
+            resolve_workspace_path(),
+            app.config["EXCLUSION_RULES"],
+        )
+    except Exception:
+        logging.getLogger(__name__).exception("Failed to start search index background worker")
+
     # ---------- Page routes ----------
 
     @app.route("/")

--- a/scripts/profile_search.py
+++ b/scripts/profile_search.py
@@ -1,0 +1,66 @@
+"""One-off search profiler — run: python scripts/profile_search.py [query]"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from models import ParseWarningCollector
+from services.search import search_global_storage
+from services.workspace_db import (
+    COMPOSER_ROWS_WITH_HEADERS_SQL,
+    build_composer_id_to_workspace_id_cached,
+    collect_workspace_entries,
+    open_global_db,
+)
+from services.search import _index_bubble_texts_matching_query, _sql_like_substring
+from utils.workspace_path import resolve_workspace_path
+
+
+def main() -> None:
+    query = sys.argv[1] if len(sys.argv) > 1 else "export"
+    q = query.lower()
+    wp = resolve_workspace_path()
+    entries = collect_workspace_entries(wp)
+
+    t0 = time.perf_counter()
+    build_composer_id_to_workspace_id_cached(wp, entries, [])
+    print(f"composer_map: {time.perf_counter() - t0:.2f}s")
+
+    with open_global_db(wp) as (conn, _):
+        if conn is None:
+            print("no global db")
+            return
+        t0 = time.perf_counter()
+        rows = conn.execute(COMPOSER_ROWS_WITH_HEADERS_SQL).fetchall()
+        print(f"composer_rows {len(rows)}: {time.perf_counter() - t0:.2f}s")
+
+        t0 = time.perf_counter()
+        bubble_count = conn.execute(
+            "SELECT count(*) FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'"
+        ).fetchone()[0]
+        print(f"bubble_count {bubble_count}: {time.perf_counter() - t0:.2f}s")
+
+        t0 = time.perf_counter()
+        idx = _index_bubble_texts_matching_query(conn, q)
+        print(f"bubble_index {len(idx)} composers: {time.perf_counter() - t0:.2f}s")
+
+        pattern = _sql_like_substring(q)
+        t0 = time.perf_counter()
+        raw_hits = sum(
+            1 for row in rows
+            if q in (row["value"] or "").lower()
+        )
+        print(f"composer_raw_hits {raw_hits}: {time.perf_counter() - t0:.2f}s")
+
+    t0 = time.perf_counter()
+    results = search_global_storage(wp, query, q, [], ParseWarningCollector())
+    print(f"search_global_storage {len(results)} hits: {time.perf_counter() - t0:.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_search_breakdown.py
+++ b/scripts/profile_search_breakdown.py
@@ -26,7 +26,7 @@ from services.workspace_db import (
 from utils.workspace_path import resolve_workspace_path
 
 
-def profile_window(since_ms, label: str) -> None:
+def profile_window(since_ms: int | None, label: str) -> None:
     query = "export"
     q = query.lower()
     wp = resolve_workspace_path()
@@ -71,7 +71,11 @@ def profile_window(since_ms, label: str) -> None:
 
         t0 = time.perf_counter()
         idx = _index_bubble_texts_matching_query(conn, q, composer_ids=window_ids)
-        mode = "scoped" if window_ids is not None and len(window_ids) <= 500 else "full_scan"
+        mode = (
+            "full_scan_python_filter"
+            if window_ids is not None and len(window_ids) <= 500
+            else "full_scan"
+        )
         print(
             f"  bubble_index ({len(idx)} hits, {mode}): "
             f"{time.perf_counter() - t0:.2f}s"

--- a/scripts/profile_search_breakdown.py
+++ b/scripts/profile_search_breakdown.py
@@ -1,0 +1,99 @@
+"""Break down where search time goes with vs without window."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from services.search import (
+    _composer_dict_timestamp_ms,
+    _composer_row_raw_text,
+    _index_bubble_texts_matching_query,
+    _timestamp_in_search_window,
+    resolve_search_since_ms,
+)
+from services.workspace_db import (
+    COMPOSER_ROWS_WITH_HEADERS_SQL,
+    build_composer_id_to_workspace_id_cached,
+    collect_workspace_entries,
+    open_global_db,
+)
+from utils.workspace_path import resolve_workspace_path
+
+
+def profile_window(since_ms, label: str) -> None:
+    query = "export"
+    q = query.lower()
+    wp = resolve_workspace_path()
+    entries = collect_workspace_entries(wp)
+
+    t0 = time.perf_counter()
+    build_composer_id_to_workspace_id_cached(wp, entries, [])
+    print(f"  composer_map: {time.perf_counter() - t0:.2f}s")
+
+    with open_global_db(wp) as (conn, _):
+        if conn is None:
+            return
+        t0 = time.perf_counter()
+        composer_rows = conn.execute(COMPOSER_ROWS_WITH_HEADERS_SQL).fetchall()
+        print(f"  load_composer_rows ({len(composer_rows)}): {time.perf_counter() - t0:.2f}s")
+
+        window_ids = None
+        if since_ms is not None:
+            t0 = time.perf_counter()
+            window_ids = set()
+            in_window_rows = []
+            for row in composer_rows:
+                composer_id = row["key"].split(":")[1]
+                raw_text = _composer_row_raw_text(row)
+                try:
+                    cd_probe = json.loads(raw_text)
+                except Exception:
+                    continue
+                if not isinstance(cd_probe, dict):
+                    continue
+                if not _timestamp_in_search_window(
+                    _composer_dict_timestamp_ms(cd_probe), since_ms
+                ):
+                    continue
+                window_ids.add(composer_id)
+                in_window_rows.append(row)
+            composer_rows = in_window_rows
+            print(
+                f"  window_filter ({len(window_ids)} composers): "
+                f"{time.perf_counter() - t0:.2f}s"
+            )
+
+        t0 = time.perf_counter()
+        idx = _index_bubble_texts_matching_query(conn, q, composer_ids=window_ids)
+        mode = "scoped" if window_ids is not None and len(window_ids) <= 500 else "full_scan"
+        print(
+            f"  bubble_index ({len(idx)} hits, {mode}): "
+            f"{time.perf_counter() - t0:.2f}s"
+        )
+
+        t0 = time.perf_counter()
+        hits = 0
+        for row in composer_rows:
+            raw = _composer_row_raw_text(row)
+            cid = row["key"].split(":")[1]
+            if q in raw.lower() or cid in idx:
+                hits += 1
+        print(f"  composer_match_loop ({hits} candidates): {time.perf_counter() - t0:.2f}s")
+
+
+def main() -> None:
+    since = resolve_search_since_ms(all_history=False)
+    print("=== 30-day window ===")
+    profile_window(since, "30d")
+    print("=== all history ===")
+    profile_window(None, "all")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_search_window.py
+++ b/scripts/profile_search_window.py
@@ -29,6 +29,7 @@ def main() -> None:
     q = query.lower()
     wp = resolve_workspace_path()
     since = resolve_search_since_ms(all_history=False)
+    assert since is not None
     print(
         f"since_ms={since} "
         f"({datetime.fromtimestamp(since / 1000, tz=timezone.utc).isoformat()})"
@@ -58,7 +59,7 @@ def main() -> None:
 
     print(f"composers total={total} in_30d_window={in_window} unknown_ts={unknown_ts}")
     print(f"bubble_rows={bubble_count}")
-    print(f"scoped_bubble_scan={in_window <= 500}")
+    print(f"below_bubble_threshold={in_window <= 500}")
 
     pw = ParseWarningCollector()
     for label, since_ms in [("30d", since), ("all", None)]:

--- a/scripts/profile_search_window.py
+++ b/scripts/profile_search_window.py
@@ -1,0 +1,84 @@
+"""Profile search with 30-day window vs all history."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from models import ParseWarningCollector
+from services.search import (
+    _composer_dict_timestamp_ms,
+    _timestamp_in_search_window,
+    resolve_search_since_ms,
+    search_cli_sessions,
+    search_global_storage,
+    search_legacy_workspaces,
+)
+from services.workspace_db import COMPOSER_ROWS_WITH_HEADERS_SQL, open_global_db
+from utils.workspace_path import get_cli_chats_path, resolve_workspace_path
+
+
+def main() -> None:
+    query = sys.argv[1] if len(sys.argv) > 1 else "export"
+    q = query.lower()
+    wp = resolve_workspace_path()
+    since = resolve_search_since_ms(all_history=False)
+    print(
+        f"since_ms={since} "
+        f"({datetime.fromtimestamp(since / 1000, tz=timezone.utc).isoformat()})"
+    )
+
+    with open_global_db(wp) as (conn, _):
+        if conn is None:
+            print("no global db")
+            return
+        rows = conn.execute(COMPOSER_ROWS_WITH_HEADERS_SQL).fetchall()
+        total = len(rows)
+        in_window = 0
+        unknown_ts = 0
+        for row in rows:
+            try:
+                cd = json.loads(row["value"])
+            except Exception:
+                continue
+            ts = _composer_dict_timestamp_ms(cd)
+            if ts <= 0:
+                unknown_ts += 1
+            if _timestamp_in_search_window(ts, since):
+                in_window += 1
+        bubble_count = conn.execute(
+            "SELECT count(*) FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'"
+        ).fetchone()[0]
+
+    print(f"composers total={total} in_30d_window={in_window} unknown_ts={unknown_ts}")
+    print(f"bubble_rows={bubble_count}")
+    print(f"scoped_bubble_scan={in_window <= 500}")
+
+    pw = ParseWarningCollector()
+    for label, since_ms in [("30d", since), ("all", None)]:
+        t0 = time.perf_counter()
+        r1 = search_global_storage(wp, query, q, [], pw, since_ms=since_ms)
+        t1 = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        r2 = search_legacy_workspaces(wp, query, q, "all", [], since_ms=since_ms)
+        t2 = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        r3 = search_cli_sessions(get_cli_chats_path(), query, q, [], pw, since_ms=since_ms)
+        t3 = time.perf_counter() - t0
+        total_hits = len(r1) + len(r2) + len(r3)
+        total_s = t1 + t2 + t3
+        print(
+            f"{label}: global={len(r1)} ({t1:.2f}s) "
+            f"legacy={len(r2)} ({t2:.2f}s) cli={len(r3)} ({t3:.2f}s) "
+            f"total={total_hits} ({total_s:.2f}s)"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/search.py
+++ b/services/search.py
@@ -22,23 +22,34 @@ import logging
 import os
 import sqlite3
 from contextlib import closing
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 __all__ = [
+    "DEFAULT_SEARCH_WINDOW_DAYS",
     "rank_results",
+    "resolve_search_since_ms",
     "search_cli_sessions",
     "search_global_storage",
     "search_legacy_workspaces",
 ]
 from models import Composer, ParseWarningCollector, SchemaError, SearchResult
+from services.workspace_composer_scan import assign_composer_workspace
+from services.workspace_context import (
+    WorkspaceContext,
+    enrich_workspace_context_from_global_db,
+    resolve_workspace_context_cached,
+)
 from services.workspace_db import (
+    COMPOSER_ROWS_WITH_HEADERS_SQL,
     build_composer_id_to_workspace_id_cached,
     collect_workspace_entries,
-    load_bubble_map,
     open_global_db,
+    safe_fetchall,
 )
+from services.workspace_resolver import infer_invalid_workspace_aliases
 from utils.cli_chat_reader import list_cli_projects, messages_to_bubbles, traverse_blobs
 from utils.exclusion_rules import build_searchable_text, is_excluded_by_rules
 from utils.path_helpers import (
@@ -46,12 +57,49 @@ from utils.path_helpers import (
     to_epoch_ms,
     warn_workspace_json_read,
 )
-from utils.text_extract import extract_text_from_bubble
 
 _logger = logging.getLogger(__name__)
 
 # Missing/unparseable timestamps sort last in rank_results() (treated as 0.0 s).
 _UNKNOWN_SEARCH_TIMESTAMP: int = 0
+
+DEFAULT_SEARCH_WINDOW_DAYS = 30
+
+# When a date window is active, chats with no parseable timestamp stay searchable.
+_INCLUDE_UNKNOWN_TIMESTAMPS_IN_WINDOW = True
+
+
+def resolve_search_since_ms(
+    *,
+    all_history: bool = False,
+    since_days: int | None = None,
+    now: datetime | None = None,
+) -> int | None:
+    """Return epoch-ms cutoff for search, or ``None`` to search all history."""
+    if all_history:
+        return None
+    days = since_days if since_days is not None else DEFAULT_SEARCH_WINDOW_DAYS
+    if days <= 0:
+        return None
+    ref = now or datetime.now(timezone.utc)
+    cutoff = ref - timedelta(days=days)
+    return int(cutoff.timestamp() * 1000)
+
+
+def _timestamp_in_search_window(timestamp_ms: int, since_ms: int | None) -> bool:
+    if since_ms is None:
+        return True
+    if timestamp_ms <= 0:
+        return _INCLUDE_UNKNOWN_TIMESTAMPS_IN_WINDOW
+    return timestamp_ms >= since_ms
+
+
+def _composer_dict_timestamp_ms(cd: dict[str, Any]) -> int:
+    return (
+        to_epoch_ms(cd.get("lastUpdatedAt"))
+        or to_epoch_ms(cd.get("createdAt"))
+        or 0
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -86,6 +134,110 @@ def _build_exclusion_searchable(
         chat_title=chat_title,
         model_names=model_names,
         chat_content_snippet="\n\n".join(combined) if combined else None,
+    )
+
+
+def _sql_like_substring(query_lower: str) -> str:
+    """Escape *query_lower* for use in a case-insensitive SQL ``LIKE``."""
+    escaped = (
+        query_lower
+        .replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+    )
+    return f"%{escaped}%"
+
+
+def _quick_bubble_text(raw_value: object) -> str:
+    """Extract searchable text from a bubble KV value without full model validation."""
+    try:
+        if isinstance(raw_value, (bytes, bytearray)):
+            raw_value = raw_value.decode("utf-8", errors="replace")
+        obj = json.loads(raw_value)
+        if isinstance(obj, dict):
+            for key in ("text", "rawText", "content"):
+                val = obj.get(key)
+                if isinstance(val, str) and val:
+                    return val
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+    return ""
+
+
+def _index_bubble_texts_matching_query(
+    conn: sqlite3.Connection,
+    query_lower: str,
+    *,
+    composer_ids: set[str] | None = None,
+) -> dict[str, list[str]]:
+    """Index composer ID -> bubble texts containing *query_lower*.
+
+    Always uses one SQL pass over ``bubbleId:%`` rows (LIKE prefilter), then
+    optionally filters to *composer_ids* in Python. Per-composer SQL queries
+    are slower than a single scan even when the date window is narrow.
+    """
+    if not query_lower:
+        return {}
+    if composer_ids is not None and not composer_ids:
+        return {}
+
+    pattern = _sql_like_substring(query_lower)
+    by_composer: dict[str, list[str]] = {}
+
+    def _ingest_row(row_key: str, row_value: object) -> None:
+        parts = row_key.split(":")
+        if len(parts) < 2 or not parts[1]:
+            return
+        composer_id = parts[1]
+        if composer_ids is not None and composer_id not in composer_ids:
+            return
+        text = _quick_bubble_text(row_value)
+        if text and query_lower in text.lower():
+            by_composer.setdefault(composer_id, []).append(text)
+
+    try:
+        rows = conn.execute(
+            "SELECT key, value FROM cursorDiskKV"
+            " WHERE key LIKE 'bubbleId:%'"
+            " AND value IS NOT NULL"
+            " AND LOWER(value) LIKE ? ESCAPE '\\'",
+            (pattern,),
+        ).fetchall()
+        for row in rows:
+            _ingest_row(row["key"], row["value"])
+    except sqlite3.Error:
+        return by_composer
+    return by_composer
+
+
+def _composer_row_raw_text(row: sqlite3.Row) -> str:
+    raw = row["value"]
+    if raw is None:
+        return ""
+    if isinstance(raw, (bytes, bytearray)):
+        return raw.decode("utf-8", errors="replace")
+    return str(raw)
+
+
+def _light_composer_exclusion_text(
+    *,
+    project_name: str,
+    title: str,
+    model_names: list[str] | None,
+    model_config: dict[str, Any],
+    cd: dict[str, Any],
+) -> str:
+    """Exclusion text from title/metadata only (no bubble scan)."""
+    return _build_exclusion_searchable(
+        project_name=project_name,
+        chat_title=title,
+        model_names=model_names,
+        metadata_parts=[
+            _json_dump_safe(model_config),
+            _json_dump_safe(cd.get("conversationSummary")),
+            _json_dump_safe(cd.get("usage")),
+            _json_dump_safe(cd.get("requestMetadata")),
+        ],
     )
 
 
@@ -154,6 +306,78 @@ def _build_ws_id_to_name(
     return mapping
 
 
+@dataclass(frozen=True)
+class _SearchWorkspaceAssigner:
+    """Workspace assignment aligned with tab summaries (not roster map alone)."""
+
+    ws_id_to_name: dict[str, str]
+    ctx: WorkspaceContext
+    invalid_workspace_aliases: dict[str, str]
+
+    def workspace_for_composer(self, composer: Composer) -> str:
+        return assign_composer_workspace(
+            composer,
+            project_layouts_map=self.ctx.project_layouts_map,
+            project_name_map=self.ctx.project_name_to_workspace_id,
+            workspace_path_map=self.ctx.workspace_path_to_id,
+            workspace_entries=self.ctx.workspace_entries,
+            bubble_map={},
+            composer_id_to_ws=self.ctx.composer_id_to_workspace_id,
+            invalid_workspace_ids=self.ctx.invalid_workspace_ids,
+            invalid_workspace_aliases=self.invalid_workspace_aliases,
+        )
+
+
+def _load_search_workspace_assigner(
+    workspace_path: str,
+    rules: list[Any],
+    workspace_entries: list[dict[str, Any]],
+) -> _SearchWorkspaceAssigner | None:
+    ctx = resolve_workspace_context_cached(
+        workspace_path, rules, workspace_entries=workspace_entries,
+    )
+    with open_global_db(workspace_path) as (global_db, _):
+        if global_db is None:
+            return None
+        ctx = enrich_workspace_context_from_global_db(
+            ctx, global_db, populate_project_layouts=True,
+        )
+        invalid_workspace_aliases: dict[str, str] = {}
+        if ctx.invalid_workspace_ids:
+            composer_rows = safe_fetchall(global_db, COMPOSER_ROWS_WITH_HEADERS_SQL)
+            invalid_workspace_aliases = infer_invalid_workspace_aliases(
+                composer_rows=composer_rows,
+                project_layouts_map=ctx.project_layouts_map,
+                project_name_map=ctx.project_name_to_workspace_id,
+                workspace_path_map=ctx.workspace_path_to_id,
+                workspace_entries=ctx.workspace_entries,
+                bubble_map={},
+                composer_id_to_ws=ctx.composer_id_to_workspace_id,
+                invalid_workspace_ids=ctx.invalid_workspace_ids,
+            )
+    return _SearchWorkspaceAssigner(
+        ws_id_to_name=_build_ws_id_to_name(workspace_entries),
+        ctx=ctx,
+        invalid_workspace_aliases=invalid_workspace_aliases,
+    )
+
+
+def _workspace_id_for_search_hit(
+    *,
+    composer_id: str,
+    cd: dict[str, Any],
+    assigner: _SearchWorkspaceAssigner | None,
+    composer_id_to_ws: dict[str, str],
+) -> str:
+    if assigner is None:
+        return composer_id_to_ws.get(composer_id, "global")
+    try:
+        composer = Composer.from_dict(cd, composer_id=composer_id)
+    except SchemaError:
+        return composer_id_to_ws.get(composer_id, "global")
+    return assigner.workspace_for_composer(composer)
+
+
 # ---------------------------------------------------------------------------
 # Public: per-source search functions
 # ---------------------------------------------------------------------------
@@ -165,6 +389,8 @@ def search_global_storage(
     query_lower: str,
     rules: list[Any],
     parse_warnings: ParseWarningCollector,
+    *,
+    since_ms: int | None = None,
 ) -> list[SearchResult]:
     """Search composer conversations stored in the global ``cursorDiskKV`` table.
 
@@ -176,104 +402,178 @@ def search_global_storage(
         query_lower: ``query.lower()`` (pre-computed by caller).
         rules: Parsed exclusion rules from app config.
         parse_warnings: Collector that accumulates parse/schema failures.
+        since_ms: When set, only composers updated/created on or after this
+            epoch-ms cutoff are searched. ``None`` searches all history.
 
     Returns:
         List of search result dicts with keys ``workspaceId``, ``workspaceFolder``,
         ``chatId``, ``chatTitle``, ``timestamp``, ``matchingText``, ``type``.
     """
+    from services.search_index import index_is_usable
+
+    if index_is_usable(workspace_path, rules):
+        indexed = _search_global_storage_via_index(
+            workspace_path,
+            query,
+            query_lower,
+            rules,
+            parse_warnings,
+            since_ms=since_ms,
+        )
+        if indexed is not None:
+            return indexed
+
+    return _search_global_storage_live_scan(
+        workspace_path,
+        query,
+        query_lower,
+        rules,
+        parse_warnings,
+        since_ms=since_ms,
+    )
+
+
+def _search_global_storage_via_index(
+    workspace_path: str,
+    query: str,
+    query_lower: str,
+    rules: list[Any],
+    parse_warnings: ParseWarningCollector,
+    *,
+    since_ms: int | None = None,
+) -> list[SearchResult] | None:
+    """Search using local FTS index. Returns ``None`` to fall back to live scan."""
+    from services.search_index import (
+        query_composer_bubble_hits,
+        query_composer_rows_in_window,
+        query_composer_title_hits,
+    )
+
     results: list[SearchResult] = []
     try:
         workspace_entries = collect_workspace_entries(workspace_path)
-        ws_id_to_name = _build_ws_id_to_name(workspace_entries)
-        composer_id_to_ws = build_composer_id_to_workspace_id_cached(
-            workspace_path, workspace_entries, rules
+        assigner = _load_search_workspace_assigner(
+            workspace_path, rules, workspace_entries,
+        )
+        if assigner is not None:
+            ws_id_to_name = assigner.ws_id_to_name
+            composer_id_to_ws = assigner.ctx.composer_id_to_workspace_id
+        else:
+            ws_id_to_name = _build_ws_id_to_name(workspace_entries)
+            composer_id_to_ws = build_composer_id_to_workspace_id_cached(
+                workspace_path, workspace_entries, rules,
+            )
+
+        composers_in_window = query_composer_rows_in_window(since_ms)
+        if since_ms is not None and not composers_in_window:
+            return results
+
+        window_ids = set(composers_in_window.keys()) if since_ms is not None else None
+        bubble_texts_by_composer = query_composer_bubble_hits(
+            query_lower,
+            since_ms=since_ms,
+            composer_ids_filter=window_ids,
         )
 
-        with open_global_db(workspace_path) as (conn, _db_path):
-            if conn is None:
-                return results
-            bubble_map = load_bubble_map(conn, parse_warnings=parse_warnings)
-            composer_rows = conn.execute(
-                "SELECT key, value FROM cursorDiskKV"
-                " WHERE key LIKE 'composerData:%' AND LENGTH(value) > 10"
-            ).fetchall()
+        candidate_ids: set[str] = set(bubble_texts_by_composer.keys())
+        for row in query_composer_title_hits(query_lower, since_ms=since_ms):
+            candidate_ids.add(row["composer_id"])
 
-        for row in composer_rows:
-            composer_id = row["key"].split(":")[1]
-            try:
-                composer = Composer.from_dict(
-                    json.loads(row["value"]), composer_id=composer_id
-                )
-            except SchemaError as exc:
-                _logger.warning(
-                    "Schema drift in composer %s: %s (%s)",
-                    composer_id,
-                    exc,
-                    type(exc).__name__,
-                )
-                parse_warnings.record_composer_skipped()
+        search_pool = composers_in_window if since_ms is not None else query_composer_rows_in_window(None)
+        for composer_id, row in search_pool.items():
+            raw_lower = (row["raw_json"] or "").lower()
+            if query_lower in raw_lower:
+                candidate_ids.add(composer_id)
+
+        for composer_id in candidate_ids:
+            row = composers_in_window.get(composer_id) if since_ms is not None else search_pool.get(composer_id)
+            if row is None:
+                row = query_composer_rows_in_window(None).get(composer_id)
+            if row is None:
                 continue
+
+            raw_text = row["raw_json"] or ""
+            try:
+                cd = json.loads(raw_text)
             except (json.JSONDecodeError, TypeError, ValueError) as exc:
                 _logger.warning(
-                    "Failed to decode Composer from composerData:%s: %s",
+                    "Failed to decode Composer from index composerData:%s: %s",
                     composer_id,
                     exc,
                 )
                 parse_warnings.record_composer_skipped()
                 continue
+            if not isinstance(cd, dict):
+                parse_warnings.record_composer_skipped()
+                continue
 
             try:
-                headers = composer.full_conversation_headers_only
+                headers = cd.get("fullConversationHeadersOnly") or []
                 if not headers:
                     continue
 
-                title = composer.name or ""
-                ws_id = composer_id_to_ws.get(composer_id, "global")
+                title = row["title"] or cd.get("name") or ""
+                if not isinstance(title, str):
+                    title = str(title) if title else ""
+
+                ws_id = _workspace_id_for_search_hit(
+                    composer_id=composer_id,
+                    cd=cd,
+                    assigner=assigner,
+                    composer_id_to_ws=composer_id_to_ws,
+                )
                 ws_name = ws_id_to_name.get(ws_id)
                 project_name = ws_name or ("Other chats" if ws_id == "global" else ws_id)
 
-                cd = composer.raw
-                model_config = composer.model_config
+                model_config = cd.get("modelConfig") if isinstance(cd.get("modelConfig"), dict) else {}
                 model_name = model_config.get("modelName")
                 model_names = (
-                    [model_name] if model_name and model_name != "default" else None
+                    [str(model_name)] if model_name and model_name != "default" else None
                 )
 
+                in_raw = query_lower in raw_text.lower()
+                title_match = bool(title and query_lower in title.lower())
                 bubble_texts: list[str] = []
-                bubble_meta: list[str] = []
-                for header in headers:
-                    bid = header.get("bubbleId")
-                    if not bid:
-                        continue
-                    bubble = bubble_map.get(bid)
-                    if bubble is None:
-                        continue
-                    text = extract_text_from_bubble(bubble)
-                    if text:
-                        bubble_texts.append(text)
-                    bubble_meta.append(_json_dump_safe(bubble.raw))
 
-                exclusion_text = _build_exclusion_searchable(
-                    project_name=project_name,
-                    chat_title=title,
-                    model_names=model_names,
-                    content_parts=bubble_texts,
-                    metadata_parts=[
-                        _json_dump_safe(model_config),
-                        _json_dump_safe(cd.get("conversationSummary")),
-                        _json_dump_safe(cd.get("usage")),
-                        _json_dump_safe(cd.get("requestMetadata")),
-                        "\n".join(bubble_meta),
-                    ],
-                )
-                if is_excluded_by_rules(rules, exclusion_text):
-                    continue
+                if title_match:
+                    exclusion_text = _light_composer_exclusion_text(
+                        project_name=project_name,
+                        title=title,
+                        model_names=model_names,
+                        model_config=model_config,
+                        cd=cd,
+                    )
+                    if is_excluded_by_rules(rules, exclusion_text):
+                        continue
+                    has_match, matching_text = True, title
+                else:
+                    has_match, matching_text = _find_match(title, [], query_lower, query)
+                    if not has_match and in_raw:
+                        has_match, matching_text = _find_match(
+                            title, [raw_text], query_lower, query
+                        )
+                    if not has_match:
+                        bubble_texts = bubble_texts_by_composer.get(composer_id, [])
+                        has_match, matching_text = _find_match(
+                            title, bubble_texts, query_lower, query
+                        )
+                    if not has_match:
+                        continue
 
-                has_match, matching_text = _find_match(
-                    title, bubble_texts, query_lower, query
-                )
-                if not has_match:
-                    continue
+                    exclusion_text = _build_exclusion_searchable(
+                        project_name=project_name,
+                        chat_title=title,
+                        model_names=model_names,
+                        content_parts=bubble_texts or None,
+                        metadata_parts=[
+                            _json_dump_safe(model_config),
+                            _json_dump_safe(cd.get("conversationSummary")),
+                            _json_dump_safe(cd.get("usage")),
+                            _json_dump_safe(cd.get("requestMetadata")),
+                        ],
+                    )
+                    if is_excluded_by_rules(rules, exclusion_text):
+                        continue
 
                 if not title:
                     for text in bubble_texts:
@@ -291,8 +591,8 @@ def search_global_storage(
                     "chatId": composer_id,
                     "chatTitle": title,
                     "timestamp": (
-                        to_epoch_ms(composer.last_updated_at)
-                        or to_epoch_ms(composer.created_at)
+                        to_epoch_ms(cd.get("lastUpdatedAt"))
+                        or to_epoch_ms(cd.get("createdAt"))
                         or _UNKNOWN_SEARCH_TIMESTAMP
                     ),
                     "matchingText": matching_text,
@@ -300,11 +600,196 @@ def search_global_storage(
                 })
             except Exception as exc:
                 _logger.warning(
-                    "Failed to process Composer from composerData:%s during search: %s",
+                    "Failed to process indexed Composer %s during search: %s",
                     composer_id,
                     exc,
                 )
                 parse_warnings.record_composer_processing_failure()
+
+    except Exception as exc:
+        _logger.warning("Indexed search failed, falling back to live scan: %s", exc)
+        return None
+
+    return results
+
+
+def _search_global_storage_live_scan(
+    workspace_path: str,
+    query: str,
+    query_lower: str,
+    rules: list[Any],
+    parse_warnings: ParseWarningCollector,
+    *,
+    since_ms: int | None = None,
+) -> list[SearchResult]:
+    """Search composer conversations by scanning Cursor's global ``cursorDiskKV``."""
+    results: list[SearchResult] = []
+    try:
+        workspace_entries = collect_workspace_entries(workspace_path)
+        assigner = _load_search_workspace_assigner(
+            workspace_path, rules, workspace_entries,
+        )
+        if assigner is not None:
+            ws_id_to_name = assigner.ws_id_to_name
+            composer_id_to_ws = assigner.ctx.composer_id_to_workspace_id
+        else:
+            ws_id_to_name = _build_ws_id_to_name(workspace_entries)
+            composer_id_to_ws = build_composer_id_to_workspace_id_cached(
+                workspace_path, workspace_entries, rules,
+            )
+
+        with open_global_db(workspace_path) as (conn, _db_path):
+            if conn is None:
+                return results
+
+            composer_rows = conn.execute(COMPOSER_ROWS_WITH_HEADERS_SQL).fetchall()
+
+            window_composer_ids: set[str] | None = None
+            if since_ms is not None:
+                window_composer_ids = set()
+                in_window_rows: list[sqlite3.Row] = []
+                for row in composer_rows:
+                    composer_id = row["key"].split(":")[1]
+                    raw_text = _composer_row_raw_text(row)
+                    try:
+                        cd_probe = json.loads(raw_text)
+                    except (json.JSONDecodeError, TypeError, ValueError):
+                        continue
+                    if not isinstance(cd_probe, dict):
+                        continue
+                    if not _timestamp_in_search_window(
+                        _composer_dict_timestamp_ms(cd_probe), since_ms,
+                    ):
+                        continue
+                    window_composer_ids.add(composer_id)
+                    in_window_rows.append(row)
+                composer_rows = in_window_rows
+
+            bubble_texts_by_composer = _index_bubble_texts_matching_query(
+                conn, query_lower, composer_ids=window_composer_ids,
+            )
+
+            for row in composer_rows:
+                composer_id = row["key"].split(":")[1]
+                raw_text = _composer_row_raw_text(row)
+                raw_lower = raw_text.lower()
+                in_raw = query_lower in raw_lower
+                if not in_raw and composer_id not in bubble_texts_by_composer:
+                    continue
+
+                try:
+                    cd = json.loads(raw_text)
+                except (json.JSONDecodeError, TypeError, ValueError) as exc:
+                    _logger.warning(
+                        "Failed to decode Composer from composerData:%s: %s",
+                        composer_id,
+                        exc,
+                    )
+                    parse_warnings.record_composer_skipped()
+                    continue
+                if not isinstance(cd, dict):
+                    parse_warnings.record_composer_skipped()
+                    continue
+
+                try:
+                    headers = cd.get("fullConversationHeadersOnly") or []
+                    if not headers:
+                        continue
+
+                    title = cd.get("name") or ""
+                    if not isinstance(title, str):
+                        title = str(title) if title else ""
+
+                    ws_id = _workspace_id_for_search_hit(
+                        composer_id=composer_id,
+                        cd=cd,
+                        assigner=assigner,
+                        composer_id_to_ws=composer_id_to_ws,
+                    )
+                    ws_name = ws_id_to_name.get(ws_id)
+                    project_name = ws_name or ("Other chats" if ws_id == "global" else ws_id)
+
+                    model_config = cd.get("modelConfig") if isinstance(cd.get("modelConfig"), dict) else {}
+                    model_name = model_config.get("modelName")
+                    model_names = (
+                        [str(model_name)] if model_name and model_name != "default" else None
+                    )
+
+                    title_match = bool(title and query_lower in title.lower())
+                    bubble_texts: list[str] = []
+
+                    if title_match:
+                        exclusion_text = _light_composer_exclusion_text(
+                            project_name=project_name,
+                            title=title,
+                            model_names=model_names,
+                            model_config=model_config,
+                            cd=cd,
+                        )
+                        if is_excluded_by_rules(rules, exclusion_text):
+                            continue
+                        has_match, matching_text = True, title
+                    else:
+                        has_match, matching_text = _find_match(
+                            title, [], query_lower, query
+                        )
+                        if not has_match and in_raw:
+                            has_match, matching_text = _find_match(
+                                title, [raw_text], query_lower, query
+                            )
+                        if not has_match:
+                            bubble_texts = bubble_texts_by_composer.get(composer_id, [])
+                            has_match, matching_text = _find_match(
+                                title, bubble_texts, query_lower, query
+                            )
+                        if not has_match:
+                            continue
+
+                        exclusion_text = _build_exclusion_searchable(
+                            project_name=project_name,
+                            chat_title=title,
+                            model_names=model_names,
+                            content_parts=bubble_texts or None,
+                            metadata_parts=[
+                                _json_dump_safe(model_config),
+                                _json_dump_safe(cd.get("conversationSummary")),
+                                _json_dump_safe(cd.get("usage")),
+                                _json_dump_safe(cd.get("requestMetadata")),
+                            ],
+                        )
+                        if is_excluded_by_rules(rules, exclusion_text):
+                            continue
+
+                    if not title:
+                        for text in bubble_texts:
+                            if text:
+                                first_lines = [ln for ln in text.split("\n") if ln.strip()]
+                                if first_lines:
+                                    title = first_lines[0][:100]
+                                break
+                        if not title:
+                            title = f"Conversation {composer_id[:8]}"
+
+                    results.append({
+                        "workspaceId": ws_id,
+                        "workspaceFolder": ws_name,
+                        "chatId": composer_id,
+                        "chatTitle": title,
+                        "timestamp": (
+                            to_epoch_ms(cd.get("lastUpdatedAt"))
+                            or to_epoch_ms(cd.get("createdAt"))
+                            or _UNKNOWN_SEARCH_TIMESTAMP
+                        ),
+                        "matchingText": matching_text,
+                        "type": "composer",
+                    })
+                except Exception as exc:
+                    _logger.warning(
+                        "Failed to process Composer from composerData:%s during search: %s",
+                        composer_id,
+                        exc,
+                    )
+                    parse_warnings.record_composer_processing_failure()
 
     except Exception as exc:
         _logger.exception("Error searching global storage")
@@ -319,6 +804,8 @@ def search_legacy_workspaces(
     query_lower: str,
     search_type: str,
     rules: list[Any],
+    *,
+    since_ms: int | None = None,
 ) -> list[SearchResult]:
     """Search legacy per-workspace ItemTable chat data.
 
@@ -371,7 +858,13 @@ def search_legacy_workspaces(
                 if not (chat_row and chat_row[0]):
                     continue
 
-                data = json.loads(chat_row[0])
+                raw_chat = chat_row[0]
+                if isinstance(raw_chat, (bytes, bytearray)):
+                    raw_chat = raw_chat.decode("utf-8", errors="replace")
+                if query_lower not in str(raw_chat).lower():
+                    continue
+
+                data = json.loads(raw_chat)
                 for tab in (data.get("tabs") or []):
                     ct = tab.get("chatTitle") or ""
                     tab_id = str(tab.get("tabId") or "")
@@ -409,12 +902,16 @@ def search_legacy_workspaces(
                     if not has_match:
                         continue
 
+                    tab_ts = to_epoch_ms(tab.get("lastSendTime")) or _UNKNOWN_SEARCH_TIMESTAMP
+                    if not _timestamp_in_search_window(tab_ts, since_ms):
+                        continue
+
                     results.append({
                         "workspaceId": name,
                         "workspaceFolder": workspace_name,
                         "chatId": tab_id,
                         "chatTitle": ct or f"Chat {tab_id[:8]}",
-                        "timestamp": to_epoch_ms(tab.get("lastSendTime")) or _UNKNOWN_SEARCH_TIMESTAMP,
+                        "timestamp": tab_ts,
                         "matchingText": matching_text,
                         "type": "chat",
                     })
@@ -441,6 +938,8 @@ def search_cli_sessions(
     query_lower: str,
     rules: list[Any],
     parse_warnings: ParseWarningCollector | None = None,
+    *,
+    since_ms: int | None = None,
 ) -> list[SearchResult]:
     """Search Cursor CLI agent sessions stored as JSONL + blob files.
 
@@ -466,7 +965,29 @@ def search_cli_sessions(
                 meta = session.get("meta", {})
                 session_id = session["session_id"]
                 created_ms: int = to_epoch_ms(meta.get("createdAt"))
+                if not _timestamp_in_search_window(created_ms, since_ms):
+                    continue
                 session_name: str = meta.get("name") or f"Session {session_id[:8]}"
+                title_match = bool(session_name and query_lower in session_name.lower())
+
+                if title_match:
+                    exclusion_text = _build_exclusion_searchable(
+                        project_name=ws_name,
+                        chat_title=session_name,
+                    )
+                    if is_excluded_by_rules(rules, exclusion_text):
+                        continue
+                    results.append({
+                        "workspaceId": f"cli:{cp['project_id']}",
+                        "workspaceFolder": ws_name,
+                        "chatId": session_id,
+                        "chatTitle": session_name,
+                        "timestamp": created_ms,
+                        "matchingText": session_name,
+                        "type": "cli_agent",
+                        "source": "cli",
+                    })
+                    continue
 
                 try:
                     messages = traverse_blobs(session["db_path"])

--- a/services/search.py
+++ b/services/search.py
@@ -76,7 +76,11 @@ def resolve_search_since_ms(
     since_days: int | None = None,
     now: datetime | None = None,
 ) -> int | None:
-    """Return epoch-ms cutoff for search, or ``None`` to search all history."""
+    """Return epoch-ms cutoff for search, or ``None`` to search all history.
+
+    Composers with no parseable timestamp (``updated_ms <= 0``) remain
+    searchable when a window is active; see ``_INCLUDE_UNKNOWN_TIMESTAMPS_IN_WINDOW``.
+    """
     if all_history:
         return None
     days = since_days if since_days is not None else DEFAULT_SEARCH_WINDOW_DAYS
@@ -348,6 +352,7 @@ class _SearchWorkspaceAssigner:
     invalid_workspace_aliases: dict[str, str]
 
     def workspace_for_composer(self, composer: Composer) -> str:
+        # Deliberately omit global bubble index (same as list/summary paths).
         return assign_composer_workspace(
             composer,
             project_layouts_map=self.ctx.project_layouts_map,
@@ -477,7 +482,7 @@ def _search_global_storage_via_index(
 ) -> list[SearchResult] | None:
     """Search using local FTS index. Returns ``None`` to fall back to live scan."""
     from services.search_index import (
-        query_all_composer_bubble_texts,
+        query_all_bubble_texts_for_composer_ids,
         query_composer_bubble_hits,
         query_composer_rows_in_window,
         query_composer_title_hits,
@@ -519,6 +524,8 @@ def _search_global_storage_via_index(
             raw_lower = (row["raw_json"] or "").lower()
             if query_lower in raw_lower:
                 candidate_ids.add(composer_id)
+
+        all_bubbles_by_composer = query_all_bubble_texts_for_composer_ids(candidate_ids)
 
         for composer_id in candidate_ids:
             composer_row = search_pool.get(composer_id)
@@ -584,7 +591,7 @@ def _search_global_storage_via_index(
                     if not has_match:
                         continue
 
-                all_bubble_texts = query_all_composer_bubble_texts(composer_id)
+                all_bubble_texts = all_bubbles_by_composer.get(composer_id, [])
                 exclusion_text = _composer_exclusion_text(
                     project_name=project_name,
                     title=title,

--- a/services/search.py
+++ b/services/search.py
@@ -52,6 +52,7 @@ from services.workspace_db import (
 from services.workspace_resolver import infer_invalid_workspace_aliases
 from utils.cli_chat_reader import list_cli_projects, messages_to_bubbles, traverse_blobs
 from utils.exclusion_rules import build_searchable_text, is_excluded_by_rules
+from utils.text_extract import extract_text_from_bubble
 from utils.path_helpers import (
     get_workspace_display_name,
     to_epoch_ms,
@@ -79,6 +80,8 @@ def resolve_search_since_ms(
     if all_history:
         return None
     days = since_days if since_days is not None else DEFAULT_SEARCH_WINDOW_DAYS
+    if days > 36_500:
+        days = 36_500
     if days <= 0:
         return None
     ref = now or datetime.now(timezone.utc)
@@ -152,16 +155,68 @@ def _quick_bubble_text(raw_value: object) -> str:
     """Extract searchable text from a bubble KV value without full model validation."""
     try:
         if isinstance(raw_value, (bytes, bytearray)):
-            raw_value = raw_value.decode("utf-8", errors="replace")
-        obj = json.loads(raw_value)
+            text_value = raw_value.decode("utf-8", errors="replace")
+        elif isinstance(raw_value, str):
+            text_value = raw_value
+        else:
+            return ""
+        obj = json.loads(text_value)
         if isinstance(obj, dict):
-            for key in ("text", "rawText", "content"):
-                val = obj.get(key)
-                if isinstance(val, str) and val:
-                    return val
+            text = extract_text_from_bubble(obj)
+            if text:
+                return text
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
     return ""
+
+
+def _model_config_from_composer_dict(cd: dict[str, Any]) -> dict[str, Any]:
+    raw = cd.get("modelConfig")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _all_bubble_texts_for_composer(
+    conn: sqlite3.Connection,
+    composer_id: str,
+) -> list[str]:
+    """Load all bubble texts for one composer (exclusion-rule checks)."""
+    texts: list[str] = []
+    try:
+        rows = conn.execute(
+            "SELECT value FROM cursorDiskKV"
+            " WHERE key LIKE ? AND value IS NOT NULL",
+            (f"bubbleId:{composer_id}:%",),
+        ).fetchall()
+    except sqlite3.Error:
+        return texts
+    for row in rows:
+        text = _quick_bubble_text(row["value"])
+        if text:
+            texts.append(text)
+    return texts
+
+
+def _composer_exclusion_text(
+    *,
+    project_name: str,
+    title: str,
+    model_names: list[str] | None,
+    model_config: dict[str, Any],
+    cd: dict[str, Any],
+    all_bubble_texts: list[str],
+) -> str:
+    return _build_exclusion_searchable(
+        project_name=project_name,
+        chat_title=title,
+        model_names=model_names,
+        content_parts=all_bubble_texts or None,
+        metadata_parts=[
+            _json_dump_safe(model_config),
+            _json_dump_safe(cd.get("conversationSummary")),
+            _json_dump_safe(cd.get("usage")),
+            _json_dump_safe(cd.get("requestMetadata")),
+        ],
+    )
 
 
 def _index_bubble_texts_matching_query(
@@ -217,28 +272,6 @@ def _composer_row_raw_text(row: sqlite3.Row) -> str:
     if isinstance(raw, (bytes, bytearray)):
         return raw.decode("utf-8", errors="replace")
     return str(raw)
-
-
-def _light_composer_exclusion_text(
-    *,
-    project_name: str,
-    title: str,
-    model_names: list[str] | None,
-    model_config: dict[str, Any],
-    cd: dict[str, Any],
-) -> str:
-    """Exclusion text from title/metadata only (no bubble scan)."""
-    return _build_exclusion_searchable(
-        project_name=project_name,
-        chat_title=title,
-        model_names=model_names,
-        metadata_parts=[
-            _json_dump_safe(model_config),
-            _json_dump_safe(cd.get("conversationSummary")),
-            _json_dump_safe(cd.get("usage")),
-            _json_dump_safe(cd.get("requestMetadata")),
-        ],
-    )
 
 
 def _extract_snippet(text: str, query: str, query_lower: str) -> str:
@@ -444,6 +477,7 @@ def _search_global_storage_via_index(
 ) -> list[SearchResult] | None:
     """Search using local FTS index. Returns ``None`` to fall back to live scan."""
     from services.search_index import (
+        query_all_composer_bubble_texts,
         query_composer_bubble_hits,
         query_composer_rows_in_window,
         query_composer_title_hits,
@@ -486,13 +520,16 @@ def _search_global_storage_via_index(
                 candidate_ids.add(composer_id)
 
         for composer_id in candidate_ids:
-            row = composers_in_window.get(composer_id) if since_ms is not None else search_pool.get(composer_id)
-            if row is None:
-                row = query_composer_rows_in_window(None).get(composer_id)
-            if row is None:
+            composer_row: sqlite3.Row | None = (
+                composers_in_window.get(composer_id) if since_ms is not None
+                else search_pool.get(composer_id)
+            )
+            if composer_row is None:
+                composer_row = query_composer_rows_in_window(None).get(composer_id)
+            if composer_row is None:
                 continue
 
-            raw_text = row["raw_json"] or ""
+            raw_text = composer_row["raw_json"] or ""
             try:
                 cd = json.loads(raw_text)
             except (json.JSONDecodeError, TypeError, ValueError) as exc:
@@ -512,7 +549,7 @@ def _search_global_storage_via_index(
                 if not headers:
                     continue
 
-                title = row["title"] or cd.get("name") or ""
+                title = composer_row["title"] or cd.get("name") or ""
                 if not isinstance(title, str):
                     title = str(title) if title else ""
 
@@ -525,7 +562,7 @@ def _search_global_storage_via_index(
                 ws_name = ws_id_to_name.get(ws_id)
                 project_name = ws_name or ("Other chats" if ws_id == "global" else ws_id)
 
-                model_config = cd.get("modelConfig") if isinstance(cd.get("modelConfig"), dict) else {}
+                model_config = _model_config_from_composer_dict(cd)
                 model_name = model_config.get("modelName")
                 model_names = (
                     [str(model_name)] if model_name and model_name != "default" else None
@@ -536,15 +573,6 @@ def _search_global_storage_via_index(
                 bubble_texts: list[str] = []
 
                 if title_match:
-                    exclusion_text = _light_composer_exclusion_text(
-                        project_name=project_name,
-                        title=title,
-                        model_names=model_names,
-                        model_config=model_config,
-                        cd=cd,
-                    )
-                    if is_excluded_by_rules(rules, exclusion_text):
-                        continue
                     has_match, matching_text = True, title
                 else:
                     has_match, matching_text = _find_match(title, [], query_lower, query)
@@ -560,20 +588,20 @@ def _search_global_storage_via_index(
                     if not has_match:
                         continue
 
-                    exclusion_text = _build_exclusion_searchable(
-                        project_name=project_name,
-                        chat_title=title,
-                        model_names=model_names,
-                        content_parts=bubble_texts or None,
-                        metadata_parts=[
-                            _json_dump_safe(model_config),
-                            _json_dump_safe(cd.get("conversationSummary")),
-                            _json_dump_safe(cd.get("usage")),
-                            _json_dump_safe(cd.get("requestMetadata")),
-                        ],
-                    )
-                    if is_excluded_by_rules(rules, exclusion_text):
-                        continue
+                all_bubble_texts = query_all_composer_bubble_texts(composer_id)
+                exclusion_text = _composer_exclusion_text(
+                    project_name=project_name,
+                    title=title,
+                    model_names=model_names,
+                    model_config=model_config,
+                    cd=cd,
+                    all_bubble_texts=all_bubble_texts,
+                )
+                if is_excluded_by_rules(rules, exclusion_text):
+                    continue
+
+                if not title_match:
+                    bubble_texts = bubble_texts or bubble_texts_by_composer.get(composer_id, [])
 
                 if not title:
                     for text in bubble_texts:
@@ -709,7 +737,7 @@ def _search_global_storage_live_scan(
                     ws_name = ws_id_to_name.get(ws_id)
                     project_name = ws_name or ("Other chats" if ws_id == "global" else ws_id)
 
-                    model_config = cd.get("modelConfig") if isinstance(cd.get("modelConfig"), dict) else {}
+                    model_config = _model_config_from_composer_dict(cd)
                     model_name = model_config.get("modelName")
                     model_names = (
                         [str(model_name)] if model_name and model_name != "default" else None
@@ -719,15 +747,6 @@ def _search_global_storage_live_scan(
                     bubble_texts: list[str] = []
 
                     if title_match:
-                        exclusion_text = _light_composer_exclusion_text(
-                            project_name=project_name,
-                            title=title,
-                            model_names=model_names,
-                            model_config=model_config,
-                            cd=cd,
-                        )
-                        if is_excluded_by_rules(rules, exclusion_text):
-                            continue
                         has_match, matching_text = True, title
                     else:
                         has_match, matching_text = _find_match(
@@ -745,20 +764,20 @@ def _search_global_storage_live_scan(
                         if not has_match:
                             continue
 
-                        exclusion_text = _build_exclusion_searchable(
-                            project_name=project_name,
-                            chat_title=title,
-                            model_names=model_names,
-                            content_parts=bubble_texts or None,
-                            metadata_parts=[
-                                _json_dump_safe(model_config),
-                                _json_dump_safe(cd.get("conversationSummary")),
-                                _json_dump_safe(cd.get("usage")),
-                                _json_dump_safe(cd.get("requestMetadata")),
-                            ],
-                        )
-                        if is_excluded_by_rules(rules, exclusion_text):
-                            continue
+                    all_bubble_texts = _all_bubble_texts_for_composer(conn, composer_id)
+                    exclusion_text = _composer_exclusion_text(
+                        project_name=project_name,
+                        title=title,
+                        model_names=model_names,
+                        model_config=model_config,
+                        cd=cd,
+                        all_bubble_texts=all_bubble_texts,
+                    )
+                    if is_excluded_by_rules(rules, exclusion_text):
+                        continue
+
+                    if not title_match:
+                        bubble_texts = bubble_texts or bubble_texts_by_composer.get(composer_id, [])
 
                     if not title:
                         for text in bubble_texts:
@@ -965,7 +984,12 @@ def search_cli_sessions(
                 meta = session.get("meta", {})
                 session_id = session["session_id"]
                 created_ms: int = to_epoch_ms(meta.get("createdAt"))
-                if not _timestamp_in_search_window(created_ms, since_ms):
+                try:
+                    session_ts = int(os.path.getmtime(session["db_path"]) * 1000)
+                except OSError:
+                    session_ts = 0
+                effective_ms = max(created_ms or 0, session_ts)
+                if not _timestamp_in_search_window(effective_ms, since_ms):
                     continue
                 session_name: str = meta.get("name") or f"Session {session_id[:8]}"
                 title_match = bool(session_name and query_lower in session_name.lower())
@@ -982,7 +1006,7 @@ def search_cli_sessions(
                         "workspaceFolder": ws_name,
                         "chatId": session_id,
                         "chatTitle": session_name,
-                        "timestamp": created_ms,
+                        "timestamp": effective_ms,
                         "matchingText": session_name,
                         "type": "cli_agent",
                         "source": "cli",
@@ -1007,7 +1031,7 @@ def search_cli_sessions(
                         session["db_path"],
                     )
 
-                bubbles = messages_to_bubbles(messages, created_ms)
+                bubbles = messages_to_bubbles(messages, effective_ms)
                 if not bubbles:
                     continue
 
@@ -1047,7 +1071,7 @@ def search_cli_sessions(
                     "workspaceFolder": ws_name,
                     "chatId": session_id,
                     "chatTitle": title,
-                    "timestamp": created_ms,
+                    "timestamp": effective_ms,
                     "matchingText": matching_text,
                     "type": "cli_agent",
                     "source": "cli",

--- a/services/search.py
+++ b/services/search.py
@@ -502,6 +502,8 @@ def _search_global_storage_via_index(
         if since_ms is not None and not composers_in_window:
             return results
 
+        search_pool = composers_in_window
+
         window_ids = set(composers_in_window.keys()) if since_ms is not None else None
         bubble_texts_by_composer = query_composer_bubble_hits(
             query_lower,
@@ -513,19 +515,13 @@ def _search_global_storage_via_index(
         for row in query_composer_title_hits(query_lower, since_ms=since_ms):
             candidate_ids.add(row["composer_id"])
 
-        search_pool = composers_in_window if since_ms is not None else query_composer_rows_in_window(None)
         for composer_id, row in search_pool.items():
             raw_lower = (row["raw_json"] or "").lower()
             if query_lower in raw_lower:
                 candidate_ids.add(composer_id)
 
         for composer_id in candidate_ids:
-            composer_row: sqlite3.Row | None = (
-                composers_in_window.get(composer_id) if since_ms is not None
-                else search_pool.get(composer_id)
-            )
-            if composer_row is None:
-                composer_row = query_composer_rows_in_window(None).get(composer_id)
+            composer_row = search_pool.get(composer_id)
             if composer_row is None:
                 continue
 
@@ -888,6 +884,10 @@ def search_legacy_workspaces(
                     ct = tab.get("chatTitle") or ""
                     tab_id = str(tab.get("tabId") or "")
 
+                    tab_ts = to_epoch_ms(tab.get("lastSendTime")) or _UNKNOWN_SEARCH_TIMESTAMP
+                    if not _timestamp_in_search_window(tab_ts, since_ms):
+                        continue
+
                     tab_model_names: list[str] | None = None
                     tab_meta = tab.get("metadata")
                     if isinstance(tab_meta, dict):
@@ -919,10 +919,6 @@ def search_legacy_workspaces(
                         ct, tab_bubble_texts, query_lower, query
                     )
                     if not has_match:
-                        continue
-
-                    tab_ts = to_epoch_ms(tab.get("lastSendTime")) or _UNKNOWN_SEARCH_TIMESTAMP
-                    if not _timestamp_in_search_window(tab_ts, since_ms):
                         continue
 
                     results.append({

--- a/services/search_index.py
+++ b/services/search_index.py
@@ -43,6 +43,7 @@ from utils.workspace_path import get_cli_chats_path
 
 __all__ = [
     "SEARCH_INDEX_FILE",
+    "SEARCH_INDEX_POINTER_FILE",
     "ensure_search_index",
     "index_is_usable",
     "index_search_enabled",

--- a/services/search_index.py
+++ b/services/search_index.py
@@ -1,0 +1,484 @@
+"""Local FTS search index over Cursor global composer + bubble storage.
+
+Phase 2: derived ``search_index.sqlite`` under ``~/.cache/cursor-chat-browser/``.
+Cursor's ``state.vscdb`` remains source of truth; this index is rebuilt when
+storage mtimes change (same fingerprint as summary_cache).
+
+Bypass: ``CURSOR_CHAT_BROWSER_NO_SEARCH_INDEX=1`` or ``CURSOR_CHAT_BROWSER_NOCACHE=1``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sqlite3
+import threading
+import time
+import uuid
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+from services.search import (
+    _composer_dict_timestamp_ms,
+    _composer_row_raw_text,
+    _quick_bubble_text,
+)
+from services.summary_cache import (
+    CACHE_DIR,
+    fingerprint_workspace_storage,
+    nocache_enabled,
+)
+from services.workspace_db import (
+    COMPOSER_ROWS_WITH_HEADERS_SQL,
+    collect_workspace_entries,
+    global_storage_db_path,
+    open_global_db,
+)
+from utils.path_helpers import to_epoch_ms
+from utils.workspace_path import get_cli_chats_path
+
+__all__ = [
+    "SEARCH_INDEX_FILE",
+    "ensure_search_index",
+    "index_is_usable",
+    "index_search_enabled",
+    "query_composer_bubble_hits",
+    "query_composer_title_hits",
+    "query_composer_rows_in_window",
+    "start_search_index_background",
+]
+
+_logger = logging.getLogger(__name__)
+
+INDEX_VERSION = 1
+SEARCH_INDEX_POINTER_FILE = CACHE_DIR / "search_index.active"
+# Legacy single-file path (pre-pointer builds); still honored when no pointer exists.
+SEARCH_INDEX_FILE = CACHE_DIR / "search_index.sqlite"
+
+_index_lock = threading.Lock()
+_index_build_lock = threading.Lock()
+_background_started = False
+
+
+def _resolve_active_index_db_path() -> Path | None:
+    """Return the SQLite path for the current search index generation."""
+    if SEARCH_INDEX_POINTER_FILE.is_file():
+        try:
+            name = SEARCH_INDEX_POINTER_FILE.read_text(encoding="utf-8").strip()
+        except OSError:
+            name = ""
+        if name:
+            candidate = CACHE_DIR / name
+            if candidate.is_file():
+                return candidate
+    if SEARCH_INDEX_FILE.is_file():
+        return SEARCH_INDEX_FILE
+    return None
+
+
+def _publish_active_index(new_db_path: Path) -> None:
+    """Point readers at *new_db_path* without replacing an open SQLite file (Windows)."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    pointer_tmp = SEARCH_INDEX_POINTER_FILE.with_suffix(".active.tmp")
+    pointer_tmp.write_text(new_db_path.name, encoding="utf-8")
+    try:
+        pointer_tmp.replace(SEARCH_INDEX_POINTER_FILE)
+    except OSError:
+        SEARCH_INDEX_POINTER_FILE.write_text(new_db_path.name, encoding="utf-8")
+        try:
+            pointer_tmp.unlink()
+        except OSError:
+            pass
+    _prune_stale_index_files(keep=new_db_path)
+
+
+def _prune_stale_index_files(*, keep: Path) -> None:
+    """Best-effort removal of superseded index files (may stay locked on Windows)."""
+    for pattern in ("search_index.*.sqlite", "search_index.sqlite"):
+        for path in CACHE_DIR.glob(pattern):
+            if path.resolve() == keep.resolve():
+                continue
+            try:
+                path.unlink()
+            except OSError:
+                pass
+    for suffix in (".sqlite.tmp", ".active.tmp"):
+        for path in CACHE_DIR.glob(f"search_index*{suffix}"):
+            try:
+                path.unlink()
+            except OSError:
+                pass
+
+
+def index_search_enabled() -> bool:
+    if nocache_enabled():
+        return False
+    return os.environ.get("CURSOR_CHAT_BROWSER_NO_SEARCH_INDEX", "").strip().lower() not in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _storage_fingerprint(workspace_path: str, rules: list[Any]) -> dict[str, Any]:
+    entries = collect_workspace_entries(workspace_path)
+    gdb = global_storage_db_path(workspace_path)
+    cli_path = get_cli_chats_path()
+    return fingerprint_workspace_storage(
+        workspace_path,
+        entries,
+        global_db_path=gdb if os.path.isfile(gdb) else None,
+        rules=rules,
+        cli_chats_path=cli_path if os.path.isdir(cli_path) else None,
+    )
+
+
+def _open_index_db(*, readonly: bool = True) -> sqlite3.Connection | None:
+    db_path = _resolve_active_index_db_path()
+    if db_path is None:
+        return None
+    uri = db_path.resolve().as_uri()
+    if readonly:
+        uri += "?mode=ro"
+    try:
+        conn = sqlite3.connect(uri, uri=True, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        return conn
+    except sqlite3.Error as exc:
+        _logger.debug("Failed to open search index: %s", exc)
+        return None
+
+
+def _read_stored_fingerprint(conn: sqlite3.Connection) -> dict[str, Any] | None:
+    try:
+        row = conn.execute(
+            "SELECT value FROM index_meta WHERE key = 'fingerprint'"
+        ).fetchone()
+        if not row or not row[0]:
+            return None
+        data = json.loads(row[0])
+        return data if isinstance(data, dict) else None
+    except (sqlite3.Error, json.JSONDecodeError):
+        return None
+
+
+def _fingerprints_match(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    from services.summary_cache import _fingerprint_equal
+
+    return _fingerprint_equal(a, b)
+
+
+def _fts_match_query(query_lower: str) -> str | None:
+    """Build an FTS5 prefix query from user input."""
+    tokens = [t for t in re.split(r"\W+", query_lower) if t]
+    if not tokens:
+        return None
+    parts: list[str] = []
+    for token in tokens:
+        escaped = token.replace('"', '""')
+        parts.append(f'"{escaped}"*')
+    return " AND ".join(parts)
+
+
+def _create_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS index_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS composers (
+            composer_id TEXT PRIMARY KEY,
+            title TEXT NOT NULL DEFAULT '',
+            created_ms INTEGER NOT NULL DEFAULT 0,
+            updated_ms INTEGER NOT NULL DEFAULT 0,
+            raw_json TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_composers_updated_ms
+            ON composers(updated_ms);
+        CREATE VIRTUAL TABLE IF NOT EXISTS bubbles_fts USING fts5(
+            composer_id UNINDEXED,
+            text,
+            tokenize='unicode61'
+        );
+        """
+    )
+
+
+def build_search_index(
+    workspace_path: str,
+    rules: list[Any],
+    *,
+    force: bool = False,
+) -> bool:
+    """Rebuild search index when fingerprint differs. Returns True if rebuilt."""
+    if not index_search_enabled():
+        return False
+
+    fingerprint = _storage_fingerprint(workspace_path, rules)
+    gdb = global_storage_db_path(workspace_path)
+    if not os.path.isfile(gdb):
+        return False
+
+    with _index_build_lock:
+        active_path = _resolve_active_index_db_path()
+        if not force and active_path is not None:
+            with closing(_open_index_db(readonly=True)) as existing:
+                if existing is not None:
+                    stored = _read_stored_fingerprint(existing)
+                    if stored is not None and _fingerprints_match(stored, fingerprint):
+                        return False
+
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        new_path = CACHE_DIR / f"search_index.{uuid.uuid4().hex[:12]}.sqlite"
+
+        try:
+            with closing(sqlite3.connect(new_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                _create_schema(conn)
+                composer_count = 0
+                bubble_count = 0
+
+                with open_global_db(workspace_path) as (src_conn, _):
+                    if src_conn is None:
+                        return False
+                    composer_rows = src_conn.execute(
+                        COMPOSER_ROWS_WITH_HEADERS_SQL
+                    ).fetchall()
+                    for row in composer_rows:
+                        composer_id = row["key"].split(":")[1]
+                        raw_text = _composer_row_raw_text(row)
+                        try:
+                            cd = json.loads(raw_text)
+                        except (json.JSONDecodeError, TypeError, ValueError):
+                            continue
+                        if not isinstance(cd, dict):
+                            continue
+                        title = cd.get("name") or ""
+                        if not isinstance(title, str):
+                            title = str(title) if title else ""
+                        conn.execute(
+                            "INSERT OR REPLACE INTO composers"
+                            " (composer_id, title, created_ms, updated_ms, raw_json)"
+                            " VALUES (?, ?, ?, ?, ?)",
+                            (
+                                composer_id,
+                                title,
+                                to_epoch_ms(cd.get("createdAt")) or 0,
+                                _composer_dict_timestamp_ms(cd),
+                                raw_text,
+                            ),
+                        )
+                        composer_count += 1
+
+                    bubble_rows = src_conn.execute(
+                        "SELECT key, value FROM cursorDiskKV"
+                        " WHERE key LIKE 'bubbleId:%' AND value IS NOT NULL"
+                    ).fetchall()
+                    for row in bubble_rows:
+                        parts = row["key"].split(":")
+                        if len(parts) < 2 or not parts[1]:
+                            continue
+                        composer_id = parts[1]
+                        text = _quick_bubble_text(row["value"])
+                        if not text:
+                            continue
+                        conn.execute(
+                            "INSERT INTO bubbles_fts(composer_id, text) VALUES (?, ?)",
+                            (composer_id, text),
+                        )
+                        bubble_count += 1
+
+                conn.execute(
+                    "INSERT OR REPLACE INTO index_meta(key, value) VALUES (?, ?)",
+                    ("fingerprint", json.dumps(fingerprint, ensure_ascii=False)),
+                )
+                conn.execute(
+                    "INSERT OR REPLACE INTO index_meta(key, value) VALUES (?, ?)",
+                    ("version", str(INDEX_VERSION)),
+                )
+                conn.execute(
+                    "INSERT OR REPLACE INTO index_meta(key, value) VALUES (?, ?)",
+                    (
+                        "stats",
+                        json.dumps(
+                            {"composers": composer_count, "bubbles": bubble_count}
+                        ),
+                    ),
+                )
+                conn.commit()
+
+            _publish_active_index(new_path)
+            _logger.info(
+                "Search index rebuilt: %d composers, %d bubbles -> %s",
+                composer_count,
+                bubble_count,
+                new_path.name,
+            )
+            return True
+        except Exception:
+            _logger.exception("Search index rebuild failed")
+            if new_path.is_file():
+                try:
+                    new_path.unlink()
+                except OSError:
+                    pass
+            return False
+
+
+def ensure_search_index(workspace_path: str, rules: list[Any]) -> None:
+    """Build index synchronously if missing or stale."""
+    if not index_search_enabled():
+        return
+    if _resolve_active_index_db_path() is None:
+        build_search_index(workspace_path, rules)
+        return
+    fingerprint = _storage_fingerprint(workspace_path, rules)
+    with closing(_open_index_db(readonly=True)) as conn:
+        if conn is None:
+            build_search_index(workspace_path, rules)
+            return
+        stored = _read_stored_fingerprint(conn)
+        if stored is None or not _fingerprints_match(stored, fingerprint):
+            build_search_index(workspace_path, rules)
+
+
+def start_search_index_background(
+    workspace_path: str,
+    rules: list[Any],
+    *,
+    poll_seconds: int = 60,
+) -> None:
+    """Kick off initial + periodic index refresh in a daemon thread."""
+    global _background_started
+    if not index_search_enabled():
+        return
+    with _index_lock:
+        if _background_started:
+            return
+        _background_started = True
+
+    def _worker() -> None:
+        while True:
+            try:
+                ensure_search_index(workspace_path, rules)
+            except Exception:
+                _logger.exception("Background search index refresh failed")
+            time.sleep(poll_seconds)
+
+    thread = threading.Thread(target=_worker, name="search-index-refresh", daemon=True)
+    thread.start()
+
+
+def query_composer_bubble_hits(
+    query_lower: str,
+    *,
+    since_ms: int | None,
+    composer_ids_filter: set[str] | None = None,
+) -> dict[str, list[str]]:
+    """Return composer_id -> matching bubble texts using the local FTS index."""
+    if not query_lower or not index_search_enabled():
+        return {}
+
+    fts_q = _fts_match_query(query_lower)
+    if not fts_q:
+        return {}
+
+    with closing(_open_index_db(readonly=True)) as conn:
+        if conn is None:
+            return {}
+        try:
+            rows = conn.execute(
+                "SELECT composer_id, text FROM bubbles_fts WHERE bubbles_fts MATCH ?",
+                (fts_q,),
+            ).fetchall()
+        except sqlite3.Error as exc:
+            _logger.debug("FTS query failed (%s); index may be rebuilding", exc)
+            return {}
+
+        by_composer: dict[str, list[str]] = {}
+        for row in rows:
+            composer_id = row["composer_id"]
+            if composer_ids_filter is not None and composer_id not in composer_ids_filter:
+                continue
+            text = row["text"] or ""
+            if query_lower not in text.lower():
+                continue
+            by_composer.setdefault(composer_id, []).append(text)
+        return by_composer
+
+
+def query_composer_title_hits(
+    query_lower: str,
+    *,
+    since_ms: int | None,
+) -> list[sqlite3.Row]:
+    """Composers whose title matches *query_lower* and pass the date window."""
+    if not query_lower or not index_search_enabled():
+        return []
+
+    pattern = f"%{query_lower}%"
+    with closing(_open_index_db(readonly=True)) as conn:
+        if conn is None:
+            return []
+        try:
+            if since_ms is None:
+                return list(
+                    conn.execute(
+                        "SELECT composer_id, title, created_ms, updated_ms, raw_json"
+                        " FROM composers WHERE LOWER(title) LIKE ?",
+                        (pattern,),
+                    ).fetchall()
+                )
+            return list(
+                conn.execute(
+                    "SELECT composer_id, title, created_ms, updated_ms, raw_json"
+                    " FROM composers"
+                    " WHERE LOWER(title) LIKE ?"
+                    " AND (updated_ms >= ? OR updated_ms <= 0)",
+                    (pattern, since_ms),
+                ).fetchall()
+            )
+        except sqlite3.Error as exc:
+            _logger.debug("Title query on search index failed: %s", exc)
+            return []
+
+
+def query_composer_rows_in_window(
+    since_ms: int | None,
+) -> dict[str, sqlite3.Row]:
+    """All indexed composers, optionally filtered by ``since_ms``."""
+    with closing(_open_index_db(readonly=True)) as conn:
+        if conn is None:
+            return {}
+        try:
+            if since_ms is None:
+                rows = conn.execute(
+                    "SELECT composer_id, title, created_ms, updated_ms, raw_json"
+                    " FROM composers"
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT composer_id, title, created_ms, updated_ms, raw_json"
+                    " FROM composers"
+                    " WHERE updated_ms >= ? OR updated_ms <= 0",
+                    (since_ms,),
+                ).fetchall()
+        except sqlite3.Error:
+            return {}
+        return {row["composer_id"]: row for row in rows}
+
+
+def index_is_usable(workspace_path: str, rules: list[Any]) -> bool:
+    """True when the on-disk index matches the current Cursor storage fingerprint."""
+    if not index_search_enabled() or _resolve_active_index_db_path() is None:
+        return False
+    fingerprint = _storage_fingerprint(workspace_path, rules)
+    with closing(_open_index_db(readonly=True)) as conn:
+        if conn is None:
+            return False
+        stored = _read_stored_fingerprint(conn)
+        return stored is not None and _fingerprints_match(stored, fingerprint)

--- a/services/search_index.py
+++ b/services/search_index.py
@@ -17,7 +17,8 @@ import sqlite3
 import threading
 import time
 import uuid
-from contextlib import closing
+from collections.abc import Iterator
+from contextlib import closing, contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +46,7 @@ __all__ = [
     "ensure_search_index",
     "index_is_usable",
     "index_search_enabled",
+    "query_all_composer_bubble_texts",
     "query_composer_bubble_hits",
     "query_composer_title_hits",
     "query_composer_rows_in_window",
@@ -152,6 +154,20 @@ def _open_index_db(*, readonly: bool = True) -> sqlite3.Connection | None:
         return None
 
 
+@contextmanager
+def _index_db_conn(*, readonly: bool = True) -> Iterator[sqlite3.Connection | None]:
+    conn = _open_index_db(readonly=readonly)
+    try:
+        yield conn
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+class _IndexBuildSkipped(Exception):
+    """Raised when index build cannot read the source global database."""
+
+
 def _read_stored_fingerprint(conn: sqlite3.Connection) -> dict[str, Any] | None:
     try:
         row = conn.execute(
@@ -226,7 +242,7 @@ def build_search_index(
     with _index_build_lock:
         active_path = _resolve_active_index_db_path()
         if not force and active_path is not None:
-            with closing(_open_index_db(readonly=True)) as existing:
+            with _index_db_conn(readonly=True) as existing:
                 if existing is not None:
                     stored = _read_stored_fingerprint(existing)
                     if stored is not None and _fingerprints_match(stored, fingerprint):
@@ -244,7 +260,7 @@ def build_search_index(
 
                 with open_global_db(workspace_path) as (src_conn, _):
                     if src_conn is None:
-                        return False
+                        raise _IndexBuildSkipped()
                     composer_rows = src_conn.execute(
                         COMPOSER_ROWS_WITH_HEADERS_SQL
                     ).fetchall()
@@ -319,6 +335,13 @@ def build_search_index(
                 new_path.name,
             )
             return True
+        except _IndexBuildSkipped:
+            if new_path.is_file():
+                try:
+                    new_path.unlink()
+                except OSError:
+                    pass
+            return False
         except Exception:
             _logger.exception("Search index rebuild failed")
             if new_path.is_file():
@@ -337,7 +360,7 @@ def ensure_search_index(workspace_path: str, rules: list[Any]) -> None:
         build_search_index(workspace_path, rules)
         return
     fingerprint = _storage_fingerprint(workspace_path, rules)
-    with closing(_open_index_db(readonly=True)) as conn:
+    with _index_db_conn(readonly=True) as conn:
         if conn is None:
             build_search_index(workspace_path, rules)
             return
@@ -387,14 +410,24 @@ def query_composer_bubble_hits(
     if not fts_q:
         return {}
 
-    with closing(_open_index_db(readonly=True)) as conn:
+    with _index_db_conn(readonly=True) as conn:
         if conn is None:
             return {}
         try:
-            rows = conn.execute(
-                "SELECT composer_id, text FROM bubbles_fts WHERE bubbles_fts MATCH ?",
-                (fts_q,),
-            ).fetchall()
+            if since_ms is None:
+                rows = conn.execute(
+                    "SELECT composer_id, text FROM bubbles_fts WHERE bubbles_fts MATCH ?",
+                    (fts_q,),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT b.composer_id, b.text"
+                    " FROM bubbles_fts b"
+                    " JOIN composers c ON c.composer_id = b.composer_id"
+                    " WHERE bubbles_fts MATCH ?"
+                    " AND (c.updated_ms >= ? OR c.updated_ms <= 0)",
+                    (fts_q, since_ms),
+                ).fetchall()
         except sqlite3.Error as exc:
             _logger.debug("FTS query failed (%s); index may be rebuilding", exc)
             return {}
@@ -421,7 +454,7 @@ def query_composer_title_hits(
         return []
 
     pattern = f"%{query_lower}%"
-    with closing(_open_index_db(readonly=True)) as conn:
+    with _index_db_conn(readonly=True) as conn:
         if conn is None:
             return []
         try:
@@ -447,11 +480,29 @@ def query_composer_title_hits(
             return []
 
 
+def query_all_composer_bubble_texts(composer_id: str) -> list[str]:
+    """All indexed bubble texts for one composer (exclusion-rule checks)."""
+    if not composer_id or not index_search_enabled():
+        return []
+
+    with _index_db_conn(readonly=True) as conn:
+        if conn is None:
+            return []
+        try:
+            rows = conn.execute(
+                "SELECT text FROM bubbles_fts WHERE composer_id = ?",
+                (composer_id,),
+            ).fetchall()
+        except sqlite3.Error:
+            return []
+        return [row["text"] for row in rows if row["text"]]
+
+
 def query_composer_rows_in_window(
     since_ms: int | None,
 ) -> dict[str, sqlite3.Row]:
     """All indexed composers, optionally filtered by ``since_ms``."""
-    with closing(_open_index_db(readonly=True)) as conn:
+    with _index_db_conn(readonly=True) as conn:
         if conn is None:
             return {}
         try:
@@ -477,7 +528,7 @@ def index_is_usable(workspace_path: str, rules: list[Any]) -> bool:
     if not index_search_enabled() or _resolve_active_index_db_path() is None:
         return False
     fingerprint = _storage_fingerprint(workspace_path, rules)
-    with closing(_open_index_db(readonly=True)) as conn:
+    with _index_db_conn(readonly=True) as conn:
         if conn is None:
             return False
         stored = _read_stored_fingerprint(conn)

--- a/services/search_index.py
+++ b/services/search_index.py
@@ -47,6 +47,7 @@ __all__ = [
     "ensure_search_index",
     "index_is_usable",
     "index_search_enabled",
+    "query_all_bubble_texts_for_composer_ids",
     "query_all_composer_bubble_texts",
     "query_composer_bubble_hits",
     "query_composer_title_hits",
@@ -258,6 +259,7 @@ def build_search_index(
                 _create_schema(conn)
                 composer_count = 0
                 bubble_count = 0
+                indexed_composer_ids: set[str] = set()
 
                 with open_global_db(workspace_path) as (src_conn, _):
                     if src_conn is None:
@@ -267,6 +269,7 @@ def build_search_index(
                     ).fetchall()
                     for row in composer_rows:
                         composer_id = row["key"].split(":")[1]
+                        indexed_composer_ids.add(composer_id)
                         raw_text = _composer_row_raw_text(row)
                         try:
                             cd = json.loads(raw_text)
@@ -300,6 +303,8 @@ def build_search_index(
                         if len(parts) < 2 or not parts[1]:
                             continue
                         composer_id = parts[1]
+                        if composer_id not in indexed_composer_ids:
+                            continue
                         text = _quick_bubble_text(row["value"])
                         if not text:
                             continue
@@ -485,18 +490,38 @@ def query_all_composer_bubble_texts(composer_id: str) -> list[str]:
     """All indexed bubble texts for one composer (exclusion-rule checks)."""
     if not composer_id or not index_search_enabled():
         return []
+    by_id = query_all_bubble_texts_for_composer_ids({composer_id})
+    return by_id.get(composer_id, [])
 
+
+def query_all_bubble_texts_for_composer_ids(
+    composer_ids: set[str] | frozenset[str],
+) -> dict[str, list[str]]:
+    """Batch-load all indexed bubble texts for exclusion-rule checks."""
+    if not composer_ids or not index_search_enabled():
+        return {}
+
+    ids = list(composer_ids)
+    result: dict[str, list[str]] = {}
     with _index_db_conn(readonly=True) as conn:
         if conn is None:
-            return []
+            return {}
         try:
-            rows = conn.execute(
-                "SELECT text FROM bubbles_fts WHERE composer_id = ?",
-                (composer_id,),
-            ).fetchall()
+            for offset in range(0, len(ids), 500):
+                chunk = ids[offset : offset + 500]
+                placeholders = ",".join("?" * len(chunk))
+                rows = conn.execute(
+                    "SELECT composer_id, text FROM bubbles_fts"
+                    f" WHERE composer_id IN ({placeholders})",
+                    chunk,
+                ).fetchall()
+                for row in rows:
+                    text = row["text"]
+                    if text:
+                        result.setdefault(row["composer_id"], []).append(text)
         except sqlite3.Error:
-            return []
-        return [row["text"] for row in rows if row["text"]]
+            return {}
+    return result
 
 
 def query_composer_rows_in_window(

--- a/services/search_index.py
+++ b/services/search_index.py
@@ -269,7 +269,6 @@ def build_search_index(
                     ).fetchall()
                     for row in composer_rows:
                         composer_id = row["key"].split(":")[1]
-                        indexed_composer_ids.add(composer_id)
                         raw_text = _composer_row_raw_text(row)
                         try:
                             cd = json.loads(raw_text)
@@ -293,6 +292,7 @@ def build_search_index(
                             ),
                         )
                         composer_count += 1
+                        indexed_composer_ids.add(composer_id)
 
                     bubble_rows = src_conn.execute(
                         "SELECT key, value FROM cursorDiskKV"

--- a/services/summary_cache.py
+++ b/services/summary_cache.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
@@ -62,16 +63,26 @@ def fingerprint_workspace_storage(
 ) -> dict[str, Any]:
     """Build a fingerprint dict for cache invalidation."""
     ws_mt: list[list[str | int]] = []
-    for entry in workspace_entries:
+
+    def _entry_mtimes(entry: dict[str, Any]) -> list[list[str | int]]:
+        rows: list[list[str | int]] = []
         name = entry.get("name")
         if not isinstance(name, str):
-            continue
+            return rows
         base = os.path.join(workspace_path, name)
         for rel in ("state.vscdb", "workspace.json"):
             p = os.path.join(base, rel)
             mtime = _file_mtime_ns(p)
             if mtime is not None:
-                ws_mt.append([f"{name}/{rel}", mtime])
+                rows.append([f"{name}/{rel}", mtime])
+        return rows
+
+    if workspace_entries:
+        max_workers = min(32, len(workspace_entries))
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = [pool.submit(_entry_mtimes, entry) for entry in workspace_entries]
+            for fut in as_completed(futures):
+                ws_mt.extend(fut.result())
     ws_mt.sort(key=lambda row: row[0])
 
     return {

--- a/services/workspace_composer_scan.py
+++ b/services/workspace_composer_scan.py
@@ -1,0 +1,128 @@
+"""Shared composerData scan helpers for list and summary paths (issue #95).
+
+Keeps conversation filtering, exclusion rules, and placeholder handling
+aligned between ``list_workspace_projects`` and ``list_workspace_tab_summaries``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from models import Bubble, Composer, ParseWarningCollector, SchemaError
+from utils.exclusion_rules import build_searchable_text, is_excluded_by_rules
+from services.workspace_resolver import determine_project_for_conversation
+
+_logger = logging.getLogger(__name__)
+
+
+def parse_composer_data_row(
+    row_key: str,
+    raw_value: object | None,
+    *,
+    parse_warnings: ParseWarningCollector,
+) -> Composer | None:
+    """Parse a ``composerData:*`` KV row into a :class:`Composer`.
+
+    Returns ``None`` for null/placeholder payloads (e.g. ``empty-state-draft``)
+    without emitting decode warnings. Logs and records skips for malformed JSON.
+    """
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, (str, bytes, bytearray)):
+        parse_warnings.record_composer_skipped()
+        return None
+    if not row_key.startswith("composerData:"):
+        return None
+    composer_id = row_key.split(":", 1)[1]
+    if not composer_id:
+        parse_warnings.record_composer_skipped()
+        return None
+    try:
+        cd = json.loads(raw_value)
+    except (json.JSONDecodeError, TypeError, ValueError) as e:
+        _logger.warning(
+            "Failed to decode Composer from composerData:%s: %s",
+            composer_id,
+            e,
+        )
+        parse_warnings.record_composer_skipped()
+        return None
+    if not isinstance(cd, dict):
+        parse_warnings.record_composer_skipped()
+        return None
+    try:
+        composer = Composer.from_dict(cd, composer_id=composer_id)
+    except SchemaError as e:
+        _logger.warning(
+            "Failed to parse Composer from composerData:%s: %s",
+            composer_id,
+            e,
+        )
+        parse_warnings.record_composer_skipped()
+        return None
+    if not composer.full_conversation_headers_only:
+        return None
+    return composer
+
+
+def composer_model_names(composer: Composer) -> list[str] | None:
+    """Model names used for exclusion-rule matching (summary/list parity)."""
+    model_name = composer.model_name_from_config()
+    if model_name and model_name != "default":
+        return [model_name]
+    return None
+
+
+def composer_chat_title(composer: Composer) -> str:
+    return composer.name or f"Conversation {composer.composer_id[:8]}"
+
+
+def is_composer_excluded(
+    rules: list[Any],
+    *,
+    project_name: str,
+    composer: Composer,
+) -> bool:
+    """Return ``True`` when *composer* matches an exclusion rule."""
+    return is_excluded_by_rules(
+        rules,
+        build_searchable_text(
+            project_name=project_name,
+            chat_title=composer_chat_title(composer),
+            model_names=composer_model_names(composer),
+        ),
+    )
+
+
+def assign_composer_workspace(
+    composer: Composer,
+    *,
+    project_layouts_map: dict[str, list[str]],
+    project_name_map: dict[str, str],
+    workspace_path_map: dict[str, str],
+    workspace_entries: list[dict[str, Any]],
+    bubble_map: Mapping[str, Bubble],
+    composer_id_to_ws: dict[str, str],
+    invalid_workspace_ids: set[str],
+    invalid_workspace_aliases: dict[str, str],
+) -> str:
+    """Resolve owning workspace folder id, or ``\"global\"`` when unassigned."""
+    composer_id = composer.composer_id
+    pid = determine_project_for_conversation(
+        composer,
+        composer_id,
+        project_layouts_map,
+        project_name_map,
+        workspace_path_map,
+        workspace_entries,
+        bubble_map,
+        composer_id_to_ws,
+        invalid_workspace_ids,
+    )
+    mapped_ws = composer_id_to_ws.get(composer_id)
+    if not pid and mapped_ws in invalid_workspace_ids:
+        pid = invalid_workspace_aliases.get(mapped_ws)
+    return pid if pid else "global"

--- a/services/workspace_composer_scan.py
+++ b/services/workspace_composer_scan.py
@@ -29,12 +29,12 @@ def parse_composer_data_row(
     Returns ``None`` for null/placeholder payloads (e.g. ``empty-state-draft``)
     without emitting decode warnings. Logs and records skips for malformed JSON.
     """
+    if not row_key.startswith("composerData:"):
+        return None
     if raw_value is None:
         return None
     if not isinstance(raw_value, (str, bytes, bytearray)):
         parse_warnings.record_composer_skipped()
-        return None
-    if not row_key.startswith("composerData:"):
         return None
     composer_id = row_key.split(":", 1)[1]
     if not composer_id:

--- a/services/workspace_db.py
+++ b/services/workspace_db.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sqlite3
 from collections.abc import Iterator
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing, contextmanager
 from pathlib import Path
 from typing import Any, cast
@@ -418,9 +418,10 @@ def build_composer_id_to_workspace_id(
             pool.submit(_composer_ids_for_workspace_entry, workspace_path, entry)
             for entry in workspace_entries
         ]
-        for fut in as_completed(futures):
+        for _entry, fut in zip(workspace_entries, futures):
             for cid, ws_name in fut.result():
-                mapping[cid] = ws_name
+                if cid not in mapping:
+                    mapping[cid] = ws_name
     return mapping
 
 

--- a/services/workspace_db.py
+++ b/services/workspace_db.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sqlite3
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import closing, contextmanager
 from pathlib import Path
 from typing import Any, cast
@@ -356,13 +357,50 @@ def global_storage_db_path(workspace_path: str) -> str:
     return os.path.normpath(os.path.join(workspace_path, "..", "globalStorage", "state.vscdb"))
 
 
+def _composer_ids_for_workspace_entry(
+    workspace_path: str,
+    entry: dict[str, Any],
+) -> list[tuple[str, str]]:
+    """Read ``composer.composerData`` from one workspace folder (parallel-safe)."""
+    pairs: list[tuple[str, str]] = []
+    db_path = os.path.join(workspace_path, entry["name"], "state.vscdb")
+    if not os.path.isfile(db_path):
+        return pairs
+    db_uri = Path(db_path).resolve().as_uri() + "?mode=ro"
+    try:
+        with closing(sqlite3.connect(db_uri, uri=True)) as conn:
+            row = conn.execute(
+                "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
+            ).fetchone()
+    except sqlite3.Error:
+        return pairs
+    if not (row and row[0]):
+        return pairs
+    try:
+        data = json.loads(row[0])
+    except (json.JSONDecodeError, ValueError):
+        return pairs
+    all_composers = data.get("allComposers") if isinstance(data, dict) else None
+    if not isinstance(all_composers, list):
+        return pairs
+    ws_name = entry["name"]
+    for c in all_composers:
+        if not isinstance(c, dict):
+            continue
+        cid = c.get("composerId")
+        if cid:
+            pairs.append((cid, ws_name))
+    return pairs
+
+
 def build_composer_id_to_workspace_id(
     workspace_path: str, workspace_entries: list[dict[str, Any]],
 ) -> dict[str, str]:
     """Build mapping from composer ID to workspace folder name.
 
     Reads ``composer.composerData`` from each workspace's ``state.vscdb``.
-    Skips workspaces with missing databases or malformed JSON.
+    Skips workspaces with missing databases or malformed JSON. Workspace
+    folders are scanned in parallel (issue #95).
 
     Args:
         workspace_path: Cursor workspace storage root.
@@ -371,38 +409,18 @@ def build_composer_id_to_workspace_id(
     Returns:
         Dict mapping ``composerId`` strings to workspace folder names.
     """
+    if not workspace_entries:
+        return {}
     mapping: dict[str, str] = {}
-    for entry in workspace_entries:
-        db_path = os.path.join(workspace_path, entry["name"], "state.vscdb")
-        if not os.path.isfile(db_path):
-            continue
-        # closing() guarantees .close() on scope exit (issue #17).
-        # Path.as_uri() percent-encodes reserved chars; ``f"file:{path}"``
-        # breaks sqlite URI parsing on paths with spaces, ``#``, etc.
-        db_uri = Path(db_path).resolve().as_uri() + "?mode=ro"
-        row: tuple[Any, ...] | None = None
-        try:
-            with closing(sqlite3.connect(db_uri, uri=True)) as conn:
-                row = conn.execute(
-                    "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
-                ).fetchone()
-        except sqlite3.Error:
-            continue
-        if not (row and row[0]):
-            continue
-        try:
-            data = json.loads(row[0])
-        except (json.JSONDecodeError, ValueError):
-            continue
-        all_composers = data.get("allComposers") if isinstance(data, dict) else None
-        if not isinstance(all_composers, list):
-            continue
-        for c in all_composers:
-            if not isinstance(c, dict):
-                continue
-            cid = c.get("composerId")
-            if cid:
-                mapping[cid] = entry["name"]
+    max_workers = min(32, len(workspace_entries))
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = [
+            pool.submit(_composer_ids_for_workspace_entry, workspace_path, entry)
+            for entry in workspace_entries
+        ]
+        for fut in as_completed(futures):
+            for cid, ws_name in fut.result():
+                mapping[cid] = ws_name
     return mapping
 
 

--- a/services/workspace_listing.py
+++ b/services/workspace_listing.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import json
 import logging
 import os
-import sqlite3
 from datetime import datetime, timezone
 from typing import Any
 
@@ -20,6 +18,12 @@ from utils.path_helpers import (
 from utils.workspace_descriptor import read_json_file
 from models import Bubble, ParseWarningCollector
 from services.export_engine import WorkspaceOrchestration, prepare_workspace_orchestration
+from services.workspace_composer_scan import (
+    assign_composer_workspace,
+    composer_chat_title,
+    composer_model_names,
+    parse_composer_data_row,
+)
 from services.summary_cache import (
     fingerprint_workspace_storage,
     get_cached_projects,
@@ -30,46 +34,17 @@ from services.workspace_db import (
     COMPOSER_ROWS_WITH_HEADERS_SQL,
     collect_workspace_entries,
     global_storage_db_path,
-    load_project_layouts_for_composer,
     load_project_layouts_map,
     open_global_db,
     safe_fetchall,
 )
 from utils.workspace_path import get_cli_chats_path
 from services.workspace_resolver import (
-    determine_project_for_conversation,
+    build_composer_ids_by_workspace,
     infer_invalid_workspace_aliases,
-    infer_workspace_name_from_context,
+    infer_workspace_name_from_layouts,
     lookup_workspace_display_name,
 )
-
-
-def _composer_valid_for_listing(
-    cd: dict[str, Any],
-    composer_id: str,
-    parse_warnings: ParseWarningCollector,
-) -> bool:
-    """Lightweight list-path checks aligned with :class:`models.Composer` requirements."""
-    if "fullConversationHeadersOnly" not in cd:
-        return False
-    created_at = cd.get("createdAt")
-    if not isinstance(created_at, (int, float)) or isinstance(created_at, bool):
-        _logger.warning(
-            "Failed to parse Composer from composerData:%s: expected timestamp number for createdAt, got %s",
-            composer_id,
-            type(created_at).__name__,
-        )
-        parse_warnings.record_composer_skipped()
-        return False
-    headers = cd.get("fullConversationHeadersOnly")
-    if not isinstance(headers, list):
-        _logger.warning(
-            "Failed to parse Composer from composerData:%s: fullConversationHeadersOnly must be a list",
-            composer_id,
-        )
-        parse_warnings.record_composer_skipped()
-        return False
-    return True
 
 
 def list_workspace_projects(
@@ -137,17 +112,16 @@ def _build_workspace_projects_uncached(
     project_name_map = ctx.project_name_to_workspace_id
     workspace_path_map = ctx.workspace_path_to_id
     composer_id_to_ws = ctx.composer_id_to_workspace_id
+    composer_ids_by_ws = build_composer_ids_by_workspace(composer_id_to_ws)
 
     conversation_map: dict[str, list[dict[str, Any]]] = {}
+    project_layouts_map: dict[str, list[str]] = {}
 
     with open_global_db(workspace_path) as (global_db, _):
         if global_db:
             try:
                 composer_rows = safe_fetchall(global_db, COMPOSER_ROWS_WITH_HEADERS_SQL)
-
-                project_layouts_map: dict[str, list[str]] = {}
-                if invalid_workspace_ids:
-                    project_layouts_map = load_project_layouts_map(global_db)
+                project_layouts_map = load_project_layouts_map(global_db)
 
                 bubble_map: dict[str, Bubble] = {}
                 invalid_workspace_aliases: dict[str, str] = {}
@@ -164,54 +138,35 @@ def _build_workspace_projects_uncached(
                     )
 
                 for row in composer_rows:
-                    cid = row["key"].split(":")[1]
+                    composer = parse_composer_data_row(
+                        row["key"], row["value"], parse_warnings=parse_warnings,
+                    )
+                    if composer is None:
+                        continue
+                    cid = composer.composer_id
                     try:
-                        cd = json.loads(row["value"])
-                    except (json.JSONDecodeError, TypeError, ValueError) as e:
-                        _logger.warning(
-                            "Failed to decode Composer from composerData:%s: %s",
-                            cid,
-                            e,
+                        assigned = assign_composer_workspace(
+                            composer,
+                            project_layouts_map=project_layouts_map,
+                            project_name_map=project_name_map,
+                            workspace_path_map=workspace_path_map,
+                            workspace_entries=workspace_entries,
+                            bubble_map=bubble_map,
+                            composer_id_to_ws=composer_id_to_ws,
+                            invalid_workspace_ids=invalid_workspace_ids,
+                            invalid_workspace_aliases=invalid_workspace_aliases,
                         )
-                        parse_warnings.record_composer_skipped()
-                        continue
-                    if not isinstance(cd, dict):
-                        _logger.warning(
-                            "Failed to parse Composer from composerData:%s: expected object, got %s",
-                            cid,
-                            type(cd).__name__,
-                        )
-                        parse_warnings.record_composer_skipped()
-                        continue
-                    if not _composer_valid_for_listing(cd, cid, parse_warnings):
-                        continue
-                    try:
-                        if (
-                            cid not in composer_id_to_ws
-                            and cid not in project_layouts_map
-                        ):
-                            project_layouts_map[cid] = load_project_layouts_for_composer(
-                                global_db, cid,
-                            )
-                        pid = determine_project_for_conversation(
-                            cd, cid, project_layouts_map,
-                            project_name_map, workspace_path_map,
-                            workspace_entries, bubble_map, composer_id_to_ws, invalid_workspace_ids,
-                        )
-                        mapped_ws = composer_id_to_ws.get(cid)
-                        if not pid and mapped_ws in invalid_workspace_ids:
-                            pid = invalid_workspace_aliases.get(mapped_ws)
-                        assigned = pid if pid else "global"
-
-                        headers = cd.get("fullConversationHeadersOnly") or []
-                        if not headers:
-                            continue
 
                         conversation_map.setdefault(assigned, []).append({
                             "composerId": cid,
-                            "name": cd.get("name") or f"Conversation {cid[:8]}",
-                            "lastUpdatedAt": to_epoch_ms(cd.get("lastUpdatedAt")) or to_epoch_ms(cd.get("createdAt")) or 0,
-                            "createdAt": to_epoch_ms(cd.get("createdAt")) or 0,
+                            "name": composer_chat_title(composer),
+                            "modelNames": composer_model_names(composer),
+                            "lastUpdatedAt": (
+                                to_epoch_ms(composer.last_updated_at)
+                                or to_epoch_ms(composer.created_at)
+                                or 0
+                            ),
+                            "createdAt": to_epoch_ms(composer.created_at) or 0,
                         })
                     except Exception as e:
                         _logger.warning(
@@ -227,7 +182,7 @@ def _build_workspace_projects_uncached(
                     exc_info=True,
                 )
 
-    # Group workspace entries by normalized folder path
+    # Group workspace entries by normalized folder path (first folder in workspace.json).
     folder_to_entries: dict[str, list[dict[str, Any]]] = {}
     entry_folder_map: dict[str, str] = {}
     for entry in workspace_entries:
@@ -241,7 +196,7 @@ def _build_workspace_projects_uncached(
         except Exception as e:
             warn_workspace_json_read(_logger, entry["name"], e)
         if not norm_folder:
-            norm_folder = entry["name"]  # fallback to workspace ID
+            norm_folder = entry["name"]
         entry_folder_map[entry["name"]] = norm_folder
         folder_to_entries.setdefault(norm_folder, []).append(entry)
 
@@ -273,7 +228,10 @@ def _build_workspace_projects_uncached(
 
         workspace_name = lookup_workspace_display_name(workspace_path, primary["name"])
         if workspace_name == primary["name"]:
-            inferred = infer_workspace_name_from_context(workspace_path, primary["name"])
+            inferred = infer_workspace_name_from_layouts(
+                [cid for ws_id in all_ws_ids for cid in composer_ids_by_ws.get(ws_id, [])],
+                project_layouts_map,
+            )
             workspace_name = inferred or f"Project {primary['name'][:8]}"
 
         if is_excluded_by_rules(rules, workspace_name):
@@ -285,6 +243,7 @@ def _build_workspace_projects_uncached(
                 searchable = build_searchable_text(
                     project_name=workspace_name,
                     chat_title=c.get("name"),
+                    model_names=c.get("modelNames"),
                 )
                 if not is_excluded_by_rules(rules, searchable):
                     convos.append(c)
@@ -306,7 +265,11 @@ def _build_workspace_projects_uncached(
         c for c in conversation_map.get("global", [])
         if not is_excluded_by_rules(
             rules,
-            build_searchable_text(project_name="Other chats", chat_title=c.get("name")),
+            build_searchable_text(
+                project_name="Other chats",
+                chat_title=c.get("name"),
+                model_names=c.get("modelNames"),
+            ),
         )
     ]
     if global_convos:

--- a/services/workspace_listing.py
+++ b/services/workspace_listing.py
@@ -151,6 +151,7 @@ def _build_workspace_projects_uncached(
                             project_name_map=project_name_map,
                             workspace_path_map=workspace_path_map,
                             workspace_entries=workspace_entries,
+                            # Empty bubble map matches summary assignment (#95 perf tradeoff).
                             bubble_map=bubble_map,
                             composer_id_to_ws=composer_id_to_ws,
                             invalid_workspace_ids=invalid_workspace_ids,

--- a/services/workspace_resolver.py
+++ b/services/workspace_resolver.py
@@ -109,7 +109,7 @@ def matching_workspace_ids_for_folder(
         first_folder = folders[0] if folders else None
         if first_folder:
             target_folder = normalize_file_path(first_folder)
-    except Exception as e:
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
         warn_workspace_json_read(_logger, workspace_id, e)
     if not target_folder:
         return matching
@@ -120,7 +120,7 @@ def matching_workspace_ids_for_folder(
             f2 = folders2[0] if folders2 else None
             if f2 and normalize_file_path(f2) == target_folder:
                 matching.add(entry["name"])
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             warn_workspace_json_read(_logger, entry["name"], e)
     return matching
 
@@ -433,7 +433,7 @@ def infer_invalid_workspace_aliases(
             continue
         try:
             cd = json.loads(row["value"])
-        except Exception as e:
+        except (json.JSONDecodeError, TypeError, ValueError) as e:
             _logger.warning(
                 "Failed to decode Composer from composerData:%s: %s",
                 cid,

--- a/services/workspace_resolver.py
+++ b/services/workspace_resolver.py
@@ -20,7 +20,7 @@ from utils.path_helpers import (
     warn_workspace_json_read,
 )
 from utils.workspace_descriptor import basename_from_pathish, read_json_file
-from services.workspace_db import open_global_db
+from services.workspace_db import load_project_layouts_map, open_global_db
 from models import SchemaError, Workspace
 from models.conversation import Bubble, Composer
 from models.raw_access import (
@@ -31,7 +31,6 @@ from models.raw_access import (
     composer_headers,
     composer_newly_created_files,
     conversation_header_bubble_id,
-    message_request_context_project_layouts,
 )
 
 
@@ -63,6 +62,96 @@ def lookup_workspace_display_name(workspace_path: str, workspace_id: str) -> str
     return workspace_id
 
 
+def build_composer_ids_by_workspace(
+    composer_id_to_workspace_id: dict[str, str],
+) -> dict[str, list[str]]:
+    """Invert ``composer_id → workspace_id`` for batch layout-based name inference."""
+    out: dict[str, list[str]] = {}
+    for composer_id, ws_id in composer_id_to_workspace_id.items():
+        out.setdefault(ws_id, []).append(composer_id)
+    return out
+
+
+def infer_workspace_name_from_layouts(
+    composer_ids: list[str],
+    project_layouts_map: dict[str, list[str]],
+) -> str | None:
+    """Infer a display name from preloaded ``messageRequestContext`` layouts.
+
+    Avoids per-workspace SQLite opens when the global layout map is already
+    loaded for listing or tab-summary paths.
+    """
+    counts: dict[str, int] = {}
+    for composer_id in composer_ids:
+        for root_path in project_layouts_map.get(composer_id, []):
+            hint = basename_from_pathish(root_path)
+            if hint:
+                counts[hint] = counts.get(hint, 0) + 1
+    if not counts:
+        return None
+    return max(counts.items(), key=lambda kv: kv[1])[0]
+
+
+def matching_workspace_ids_for_folder(
+    workspace_id: str,
+    workspace_path: str,
+    workspace_entries: list[dict[str, Any]],
+) -> set[str]:
+    """Return workspace folder IDs that share the same on-disk project folder."""
+    matching: set[str] = {workspace_id}
+    if workspace_id == "global":
+        return matching
+    target_folder = ""
+    wj_path = os.path.join(workspace_path, workspace_id, "workspace.json")
+    try:
+        wd = read_json_file(wj_path)
+        folders = get_workspace_folder_paths(wd)
+        first_folder = folders[0] if folders else None
+        if first_folder:
+            target_folder = normalize_file_path(first_folder)
+    except Exception as e:
+        warn_workspace_json_read(_logger, workspace_id, e)
+    if not target_folder:
+        return matching
+    for entry in workspace_entries:
+        try:
+            wd2 = read_json_file(entry["workspaceJsonPath"])
+            folders2 = get_workspace_folder_paths(wd2)
+            f2 = folders2[0] if folders2 else None
+            if f2 and normalize_file_path(f2) == target_folder:
+                matching.add(entry["name"])
+        except Exception as e:
+            warn_workspace_json_read(_logger, entry["name"], e)
+    return matching
+
+
+def _composer_ids_from_workspace_db(workspace_path: str, workspace_id: str) -> list[str]:
+    """Read composer IDs registered in a workspace folder's ``state.vscdb``."""
+    local_db_path = os.path.join(workspace_path, workspace_id, "state.vscdb")
+    if not os.path.isfile(local_db_path):
+        return []
+    composer_ids: list[str] = []
+    _db_uri = Path(local_db_path).resolve().as_uri() + "?mode=ro"
+    try:
+        with closing(sqlite3.connect(_db_uri, uri=True)) as lconn:
+            row = lconn.execute(
+                "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
+            ).fetchone()
+    except sqlite3.Error:
+        return []
+    if not (row and row[0]):
+        return []
+    try:
+        data = json.loads(row[0])
+    except (json.JSONDecodeError, ValueError):
+        return []
+    for c in (data.get("allComposers") or []):
+        cid = c.get("composerId") if isinstance(c, dict) else None
+        if cid:
+            composer_ids.append(cid)
+    return composer_ids
+
+
 def infer_workspace_name_from_context(workspace_path: str, workspace_id: str) -> str | None:
     """Infer workspace name from ``projectLayouts`` when ``workspace.json`` is opaque.
 
@@ -77,86 +166,15 @@ def infer_workspace_name_from_context(workspace_path: str, workspace_id: str) ->
     if workspace_id == "global":
         return "Other chats"
 
-    # Composer IDs from per-workspace state db
-    local_db_path = os.path.join(workspace_path, workspace_id, "state.vscdb")
-    if not os.path.isfile(local_db_path):
-        return None
-    composer_ids: list[str] = []
-    # closing() guarantees .close() on scope exit (issue #17).
-    # Path.as_uri() percent-encodes reserved chars (#, ?, spaces, etc.);
-    # naive f"file:{path}" breaks sqlite URI parsing.
-    _db_uri = Path(local_db_path).resolve().as_uri() + "?mode=ro"
-    row: tuple[Any, ...] | None = None
-    try:
-        with closing(sqlite3.connect(_db_uri, uri=True)) as lconn:
-            row = lconn.execute(
-                "SELECT value FROM ItemTable WHERE [key] = 'composer.composerData'"
-            ).fetchone()
-    except sqlite3.Error:
-        return None
-    if row and row[0]:
-        try:
-            data = json.loads(row[0])
-        except (json.JSONDecodeError, ValueError):
-            return None
-        for c in (data.get("allComposers") or []):
-            cid = c.get("composerId") if isinstance(c, dict) else None
-            if cid:
-                composer_ids.append(cid)
+    composer_ids = _composer_ids_from_workspace_db(workspace_path, workspace_id)
     if not composer_ids:
         return None
 
-    # Gather folder-name hints from global messageRequestContext.projectLayouts
-    counts: dict[str, int] = {}
     with open_global_db(workspace_path) as (gconn, _):
         if not gconn:
             return None
-        for cid in composer_ids:
-            try:
-                rows = gconn.execute(
-                    "SELECT value FROM cursorDiskKV WHERE key LIKE ?",
-                    (f"messageRequestContext:{cid}:%",),
-                ).fetchall()
-            except sqlite3.Error:
-                continue
-            for row in rows:
-                if not row or row[0] is None:
-                    continue
-                try:
-                    ctx = json.loads(row[0])
-                except (json.JSONDecodeError, ValueError) as e:
-                    _logger.debug(
-                        "Skipping malformed messageRequestContext for %s: %s",
-                        cid,
-                        e,
-                    )
-                    continue
-                layouts = message_request_context_project_layouts(ctx, composer_id=cid)
-                if not layouts:
-                    continue
-                for layout in layouts:
-                    obj = None
-                    if isinstance(layout, str):
-                        try:
-                            obj = json.loads(layout)
-                        except (json.JSONDecodeError, ValueError) as e:
-                            _logger.debug(
-                                "Skipping malformed projectLayout for %s: %s",
-                                cid,
-                                e,
-                            )
-                            obj = None
-                    elif isinstance(layout, dict):
-                        obj = layout
-                    if not isinstance(obj, dict):
-                        continue
-                    hint = basename_from_pathish(obj.get("rootPath"))
-                    if hint:
-                        counts[hint] = counts.get(hint, 0) + 1
-
-    if not counts:
-        return None
-    return max(counts.items(), key=lambda kv: kv[1])[0]
+        layouts_map = load_project_layouts_map(gconn)
+    return infer_workspace_name_from_layouts(composer_ids, layouts_map)
 
 
 def get_project_from_file_path(

--- a/services/workspace_resolver.py
+++ b/services/workspace_resolver.py
@@ -145,6 +145,8 @@ def _composer_ids_from_workspace_db(workspace_path: str, workspace_id: str) -> l
         data = json.loads(row[0])
     except (json.JSONDecodeError, ValueError):
         return []
+    if not isinstance(data, dict):
+        return []
     for c in (data.get("allComposers") or []):
         cid = c.get("composerId") if isinstance(c, dict) else None
         if cid:

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -37,6 +37,13 @@ from models.raw_access import (
     conversation_header_bubble_id,
     message_request_context_project_layouts,
 )
+from services.workspace_composer_scan import (
+    assign_composer_workspace,
+    composer_chat_title,
+    composer_model_names,
+    is_composer_excluded,
+    parse_composer_data_row,
+)
 from services.summary_cache import (
     fingerprint_workspace_storage,
     get_cached_tab_summaries,
@@ -63,6 +70,7 @@ from services.workspace_resolver import (
     determine_project_for_conversation,
     infer_invalid_workspace_aliases,
     lookup_workspace_display_name,
+    matching_workspace_ids_for_folder,
 )
 
 
@@ -362,36 +370,8 @@ def _build_matching_ws_ids(
     workspace_path: str,
     workspace_entries: list[dict[str, Any]],
 ) -> set[str]:
-    """Return the set of workspace folder IDs that share the same project folder as *workspace_id*.
-
-    Cursor sometimes creates multiple workspace entries for the same on-disk
-    project; conversations recorded under any of those IDs belong to the same
-    project view.
-    """
-    matching: set[str] = {workspace_id}
-    if workspace_id == "global":
-        return matching
-    target_folder = ""
-    wj_path = os.path.join(workspace_path, workspace_id, "workspace.json")
-    try:
-        wd = read_json_file(wj_path)
-        folders = get_workspace_folder_paths(wd)
-        first_folder = folders[0] if folders else None
-        if first_folder:
-            target_folder = normalize_file_path(first_folder)
-    except Exception as e:
-        warn_workspace_json_read(_logger, workspace_id, e)
-    if target_folder:
-        for entry in workspace_entries:
-            try:
-                wd2 = read_json_file(entry["workspaceJsonPath"])
-                folders2 = get_workspace_folder_paths(wd2)
-                f2 = folders2[0] if folders2 else None
-                if f2 and normalize_file_path(f2) == target_folder:
-                    matching.add(entry["name"])
-            except Exception as e:
-                warn_workspace_json_read(_logger, entry["name"], e)
-    return matching
+    """Return workspace folder IDs sharing the same on-disk project folder."""
+    return matching_workspace_ids_for_folder(workspace_id, workspace_path, workspace_entries)
 
 
 def list_workspace_tab_summaries(
@@ -470,9 +450,7 @@ def _build_workspace_tab_summaries_uncached(
 
         workspace_display_name = lookup_workspace_display_name(workspace_path, workspace_id)
 
-        project_layouts_map: dict[str, list[str]] = {}
-        if invalid_workspace_ids:
-            project_layouts_map = load_project_layouts_map(global_db)
+        project_layouts_map = load_project_layouts_map(global_db)
 
         composer_rows = safe_fetchall(global_db, COMPOSER_ROWS_WITH_HEADERS_SQL)
 
@@ -490,69 +468,39 @@ def _build_workspace_tab_summaries_uncached(
             )
 
         for row in composer_rows:
-            composer_id = row["key"].split(":")[1]
-            try:
-                cd = json.loads(row["value"])
-            except (json.JSONDecodeError, TypeError, ValueError) as e:
-                payload_len, payload_fp = _kv_payload_log_meta(row["value"])
-                _logger.warning(
-                    "Failed to decode Composer from composerData:%s: %s (payload_len=%d, payload_sha256=%s)",
-                    composer_id,
-                    e,
-                    payload_len,
-                    payload_fp,
-                )
-                parse_warnings.record_composer_skipped()
+            composer = parse_composer_data_row(
+                row["key"], row["value"], parse_warnings=parse_warnings,
+            )
+            if composer is None:
                 continue
-            if not isinstance(cd, dict):
-                parse_warnings.record_composer_skipped()
-                continue
+            composer_id = composer.composer_id
             try:
-                composer = Composer.from_dict(cd, composer_id=composer_id)
-            except SchemaError as e:
-                _logger.warning(
-                    "Failed to parse Composer from composerData:%s: %s",
-                    composer_id,
-                    e,
+                assigned = assign_composer_workspace(
+                    composer,
+                    project_layouts_map=project_layouts_map,
+                    project_name_map=project_name_map,
+                    workspace_path_map=workspace_path_map,
+                    workspace_entries=workspace_entries,
+                    bubble_map={},
+                    composer_id_to_ws=composer_id_to_ws,
+                    invalid_workspace_ids=invalid_workspace_ids,
+                    invalid_workspace_aliases=invalid_workspace_aliases,
                 )
-                parse_warnings.record_composer_skipped()
-                continue
-            try:
-                if (
-                    composer_id not in composer_id_to_ws
-                    and composer_id not in project_layouts_map
-                ):
-                    project_layouts_map[composer_id] = load_project_layouts_for_composer(
-                        global_db, composer_id,
-                    )
-                pid = determine_project_for_conversation(
-                    composer, composer_id, project_layouts_map,
-                    project_name_map, workspace_path_map,
-                    workspace_entries, {}, composer_id_to_ws, invalid_workspace_ids,
-                )
-                mapped_ws = composer_id_to_ws.get(composer_id)
-                if not pid and mapped_ws in invalid_workspace_ids:
-                    pid = invalid_workspace_aliases.get(mapped_ws)
-                assigned = pid if pid else "global"
 
                 if assigned not in matching_ws_ids:
                     continue
 
-                headers = composer.full_conversation_headers_only
-                if not headers:
-                    continue
-
-                title = composer.name or f"Conversation {composer_id[:8]}"
-
-                _early_model_name = composer.model_name_from_config()
-                _early_model_names = [_early_model_name] if _early_model_name and _early_model_name != "default" else None
-                if is_excluded_by_rules(rules, build_searchable_text(
+                if is_composer_excluded(
+                    rules,
                     project_name=workspace_display_name,
-                    chat_title=title,
-                    model_names=_early_model_names,
-                )):
+                    composer=composer,
+                ):
                     continue
 
+                headers = composer.full_conversation_headers_only
+                title = composer_chat_title(composer)
+
+                _early_model_names = composer_model_names(composer)
                 tab_meta: dict[str, Any] | None = None
                 if _early_model_names:
                     tab_meta = {"modelsUsed": _early_model_names}
@@ -561,7 +509,6 @@ def _build_workspace_tab_summaries_uncached(
                     "id": composer_id,
                     "title": title,
                     "timestamp": _composer_tab_timestamp_ms(composer),
-                    # Header count (KV rows), not renderable bubbles after assembly filters.
                     "messageCount": len(headers),
                 }
                 if tab_meta:

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -741,13 +741,7 @@ def assemble_workspace_tabs(
                         project_layouts_map[chat_id].append(layout["rootPath"])
 
         # Get composer data entries with conversations
-        composer_rows = safe_fetchall(
-            global_db,
-            "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
-            " AND value IS NOT NULL"
-            " AND value LIKE '%fullConversationHeadersOnly%'"
-            " AND value NOT LIKE '%fullConversationHeadersOnly\":[]%'",
-        )
+        composer_rows = safe_fetchall(global_db, COMPOSER_ROWS_WITH_HEADERS_SQL)
 
         invalid_workspace_aliases = infer_invalid_workspace_aliases(
             composer_rows=composer_rows,
@@ -761,34 +755,12 @@ def assemble_workspace_tabs(
         )
 
         for row in composer_rows:
-            composer_id = row["key"].split(":")[1]
-            try:
-                parsed = json.loads(row["value"])
-            except (json.JSONDecodeError, TypeError, ValueError) as e:
-                payload_len, payload_fp = _kv_payload_log_meta(row["value"])
-                _logger.warning(
-                    "Failed to decode Composer from composerData:%s: %s (key=%s, payload_len=%d, payload_sha256=%s)",
-                    composer_id,
-                    e,
-                    row["key"],
-                    payload_len,
-                    payload_fp,
-                )
-                parse_warnings.record_composer_skipped()
+            composer = parse_composer_data_row(
+                row["key"], row["value"], parse_warnings=parse_warnings,
+            )
+            if composer is None:
                 continue
-            try:
-                composer = Composer.from_dict(parsed, composer_id=composer_id)
-            except SchemaError as e:
-                # Drift skipped + logged so the two primary conversation
-                # paths (list_workspaces + get_workspace_tabs) agree on what
-                # counts as a valid composer.
-                _logger.warning(
-                    "Failed to parse Composer from composerData:%s: %s",
-                    composer_id,
-                    e,
-                )
-                parse_warnings.record_composer_skipped()
-                continue
+            composer_id = composer.composer_id
             try:
                 # Determine project
                 pid = determine_project_for_conversation(

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -67,7 +67,6 @@ from services.workspace_db import (
 )
 from utils.workspace_path import get_cli_chats_path
 from services.workspace_resolver import (
-    determine_project_for_conversation,
     infer_invalid_workspace_aliases,
     lookup_workspace_display_name,
     matching_workspace_ids_for_folder,
@@ -576,38 +575,18 @@ def assemble_single_tab(
             return {"error": "Conversation not found"}, 404
 
         row = rows[0]
-        try:
-            parsed = json.loads(row["value"])
-        except (json.JSONDecodeError, TypeError, ValueError) as e:
-            payload_len, payload_fp = _kv_payload_log_meta(row["value"])
-            _logger.warning(
-                "Failed to decode Composer from composerData:%s: %s (payload_len=%d, payload_sha256=%s)",
-                composer_id,
-                e,
-                payload_len,
-                payload_fp,
-            )
-            return {"error": "Failed to parse conversation"}, 500
-        try:
-            composer = Composer.from_dict(parsed, composer_id=composer_id)
-        except SchemaError as e:
-            _logger.warning(
-                "Failed to parse Composer from composerData:%s: %s",
-                composer_id,
-                e,
-            )
-            return {"error": "Failed to parse conversation"}, 500
+        composer = parse_composer_data_row(
+            row["key"], row["value"], parse_warnings=parse_warnings,
+        )
+        if composer is None:
+            return {"error": "Conversation not found"}, 404
 
-        # Verify the conversation belongs to the requested workspace.
-        # Always scoped: only load messageRequestContext rows for this composer.
         project_layouts_map: dict[str, list[str]] = {}
         invalid_workspace_aliases: dict[str, str] = {}
         project_layouts_map[composer_id] = load_project_layouts_for_composer(
             global_db, composer_id,
         )
         if invalid_workspace_ids:
-            # Alias resolution still needs the composer roster, but project layouts
-            # are intentionally limited to this composer (single-tab scope).
             composer_rows_for_aliases = safe_fetchall(global_db, COMPOSER_ROWS_WITH_HEADERS_SQL)
             invalid_workspace_aliases = infer_invalid_workspace_aliases(
                 composer_rows=composer_rows_for_aliases,
@@ -620,23 +599,24 @@ def assemble_single_tab(
                 invalid_workspace_ids=invalid_workspace_ids,
             )
 
-        pid = determine_project_for_conversation(
-            composer, composer_id, project_layouts_map,
-            project_name_map, workspace_path_map,
-            workspace_entries, {}, composer_id_to_ws, invalid_workspace_ids,
+        bubble_map = load_bubbles_for_composer(
+            global_db, composer_id, parse_warnings=parse_warnings,
         )
-        mapped_ws = composer_id_to_ws.get(composer_id)
-        if not pid and mapped_ws in invalid_workspace_ids:
-            pid = invalid_workspace_aliases.get(mapped_ws)
-        assigned = pid if pid else "global"
+        assigned = assign_composer_workspace(
+            composer,
+            project_layouts_map=project_layouts_map,
+            project_name_map=project_name_map,
+            workspace_path_map=workspace_path_map,
+            workspace_entries=workspace_entries,
+            bubble_map=bubble_map,
+            composer_id_to_ws=composer_id_to_ws,
+            invalid_workspace_ids=invalid_workspace_ids,
+            invalid_workspace_aliases=invalid_workspace_aliases,
+        )
 
         if assigned not in matching_ws_ids:
             return {"error": "Conversation not found"}, 404
 
-        # Scoped loads — only rows for this composer_id.
-        bubble_map = load_bubbles_for_composer(
-            global_db, composer_id, parse_warnings=parse_warnings
-        )
         contexts = load_message_request_context_for_composer(global_db, composer_id)
         code_block_diffs = load_code_block_diffs_for_composer(global_db, composer_id)
 
@@ -743,16 +723,18 @@ def assemble_workspace_tabs(
         # Get composer data entries with conversations
         composer_rows = safe_fetchall(global_db, COMPOSER_ROWS_WITH_HEADERS_SQL)
 
-        invalid_workspace_aliases = infer_invalid_workspace_aliases(
-            composer_rows=composer_rows,
-            project_layouts_map=project_layouts_map,
-            project_name_map=project_name_map,
-            workspace_path_map=workspace_path_map,
-            workspace_entries=workspace_entries,
-            bubble_map=bubble_map,
-            composer_id_to_ws=composer_id_to_ws,
-            invalid_workspace_ids=invalid_workspace_ids,
-        )
+        invalid_workspace_aliases: dict[str, str] = {}
+        if invalid_workspace_ids:
+            invalid_workspace_aliases = infer_invalid_workspace_aliases(
+                composer_rows=composer_rows,
+                project_layouts_map=project_layouts_map,
+                project_name_map=project_name_map,
+                workspace_path_map=workspace_path_map,
+                workspace_entries=workspace_entries,
+                bubble_map=bubble_map,
+                composer_id_to_ws=composer_id_to_ws,
+                invalid_workspace_ids=invalid_workspace_ids,
+            )
 
         for row in composer_rows:
             composer = parse_composer_data_row(
@@ -762,16 +744,18 @@ def assemble_workspace_tabs(
                 continue
             composer_id = composer.composer_id
             try:
-                # Determine project
-                pid = determine_project_for_conversation(
-                    composer, composer_id, project_layouts_map,
-                    project_name_map, workspace_path_map,
-                    workspace_entries, bubble_map, composer_id_to_ws, invalid_workspace_ids,
+                assigned = assign_composer_workspace(
+                    composer,
+                    project_layouts_map=project_layouts_map,
+                    project_name_map=project_name_map,
+                    workspace_path_map=workspace_path_map,
+                    workspace_entries=workspace_entries,
+                    # Assignment matches summary path; bubble_map used only for tab body.
+                    bubble_map={},
+                    composer_id_to_ws=composer_id_to_ws,
+                    invalid_workspace_ids=invalid_workspace_ids,
+                    invalid_workspace_aliases=invalid_workspace_aliases,
                 )
-                mapped_ws = composer_id_to_ws.get(composer_id)
-                if not pid and mapped_ws in invalid_workspace_ids:
-                    pid = invalid_workspace_aliases.get(mapped_ws)
-                assigned = pid if pid else "global"
 
                 if assigned not in matching_ws_ids:
                     continue

--- a/templates/search.html
+++ b/templates/search.html
@@ -16,6 +16,10 @@
       <input type="text" id="search-input" class="input" placeholder="Search across all logs..." autofocus>
       <button class="btn btn-primary" onclick="doSearch()">Search</button>
     </div>
+    <label class="text-sm" style="display:flex;align-items:center;gap:0.5rem;margin-top:0.75rem;cursor:pointer">
+      <input type="checkbox" id="all-history" onchange="doSearch()">
+      Include chats older than 30 days <span class="text-muted">(searches all history — slower)</span>
+    </label>
   </div>
 
   <div id="loading" class="loading" style="display:none">
@@ -35,11 +39,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
   const q = params.get('q');
   const t = params.get('type') || 'all';
+  const allHistory = params.get('all_history') === '1';
+  document.getElementById('all-history').checked = allHistory;
   if (q) {
     document.getElementById('search-input').value = q;
     currentFilter = t;
     updateFilterButtons();
-    performSearch(q, t);
+    performSearch(q, t, allHistory);
   }
 
   document.getElementById('search-input').addEventListener('keydown', e => {
@@ -63,14 +69,20 @@ function updateFilterButtons() {
 function doSearch() {
   const q = document.getElementById('search-input').value.trim();
   if (!q) return;
+  const allHistory = document.getElementById('all-history').checked;
   const url = new URL(window.location);
   url.searchParams.set('q', q);
   url.searchParams.set('type', currentFilter);
+  if (allHistory) {
+    url.searchParams.set('all_history', '1');
+  } else {
+    url.searchParams.delete('all_history');
+  }
   window.history.pushState({}, '', url);
-  performSearch(q, currentFilter);
+  performSearch(q, currentFilter, allHistory);
 }
 
-async function performSearch(query, type) {
+async function performSearch(query, type, allHistory) {
   const loading = document.getElementById('loading');
   const countEl = document.getElementById('result-count');
   const container = document.getElementById('results-container');
@@ -79,7 +91,9 @@ async function performSearch(query, type) {
   container.innerHTML = '';
 
   try {
-    const res = await fetch(`/api/search?q=${encodeURIComponent(query)}&type=${type}`);
+    const params = new URLSearchParams({ q: query, type: type });
+    if (allHistory) params.set('all_history', '1');
+    const res = await fetch(`/api/search?${params.toString()}`);
     if (!res.ok) {
       showIncompleteResultsBanner('parse-warnings-host', []);
       loading.style.display = 'none';
@@ -92,7 +106,10 @@ async function performSearch(query, type) {
 
     loading.style.display = 'none';
     countEl.style.display = 'block';
-    countEl.textContent = `Found ${results.length} results for "${query}"`;
+    const windowNote = data.allHistory
+      ? ' (all history)'
+      : ` (last ${data.searchWindowDays || 30} days)`;
+    countEl.textContent = `Found ${results.length} results for "${query}"${windowNote}`;
 
     let html = '';
     for (const r of results) {

--- a/templates/search.html
+++ b/templates/search.html
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
   const q = params.get('q');
   const t = params.get('type') || 'all';
-  const allHistory = params.get('all_history') === '1';
+  const allHistory = params.get('all_history') === '1' || params.get('all_history') === 'true';
   document.getElementById('all-history').checked = allHistory;
   if (q) {
     document.getElementById('search-input').value = q;

--- a/templates/workspace.html
+++ b/templates/workspace.html
@@ -84,10 +84,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const params = new URLSearchParams(window.location.search);
     const tabParam = params.get('tab');
-    if (tabParam && allTabs.find(t => t.id === tabParam)) {
-      selectTab(tabParam);
+    if (tabParam) {
+      await selectTab(tabParam);
     } else if (allTabs.length > 0) {
-      selectTab(allTabs[0].id);
+      await selectTab(allTabs[0].id);
     }
   } catch (e) {
     const main = document.getElementById('main-content');
@@ -123,8 +123,11 @@ function renderSidebar() {
 
 async function selectTab(id) {
   selectTab._latest = id;
-  const summary = allTabs.find(t => t.id === id);
-  if (!summary) return;
+  let summary = allTabs.find(t => t.id === id);
+  if (!summary) {
+    // Deep link (e.g. from search): fetch even when sidebar list omits this id.
+    summary = { id, title: `Conversation ${id.slice(0, 8)}`, timestamp: 0 };
+  }
 
   const url = new URL(window.location);
   url.searchParams.set('tab', id);
@@ -155,6 +158,10 @@ async function selectTab(id) {
     try {
       const res = await fetch(`/api/workspaces/${WORKSPACE_ID}/tabs/${id}`);
       if (selectTab._latest !== id) return;
+      if (res.status === 404 && WORKSPACE_ID !== 'global') {
+        window.location.href = `/workspace/global?tab=${encodeURIComponent(id)}`;
+        return;
+      }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       if (selectTab._latest !== id) return;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,15 @@ from tests._fixture_ids import (  # noqa: E402,F401  (re-export for legacy impor
     HAPPY_WORKSPACE_ID,
 )
 
+
+@pytest.fixture(autouse=True)
+def _disable_search_index_unless_index_tests(request, monkeypatch):
+    """Avoid background index builds during the main test suite."""
+    if request.module.__name__.endswith("test_search_index"):
+        return
+    monkeypatch.setenv("CURSOR_CHAT_BROWSER_NO_SEARCH_INDEX", "1")
+
+
 def _make_global_state_db(path: str) -> None:
     """globalStorage/state.vscdb with one composerData + one bubbleId row."""
     # contextlib.closing guarantees conn.close() even if an exec/commit raises

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ from tests._fixture_ids import (  # noqa: E402,F401  (re-export for legacy impor
 @pytest.fixture(autouse=True)
 def _disable_search_index_unless_index_tests(request, monkeypatch):
     """Avoid background index builds during the main test suite."""
-    if request.module.__name__.endswith("test_search_index"):
+    if "test_search_index" in request.module.__name__:
         return
     monkeypatch.setenv("CURSOR_CHAT_BROWSER_NO_SEARCH_INDEX", "1")
 

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -23,7 +23,7 @@ def _assert_search_result_shape(hit: dict) -> None:
 
 class TestSearchHappyPath:
     def test_finds_seeded_term_and_result_shape(self, client):
-        response = client.get("/api/search?q=sentinel-grep")
+        response = client.get("/api/search?q=sentinel-grep&all_history=1")
         assert response.status_code == 200
         body = response.get_json()
         assert isinstance(body, dict)
@@ -36,7 +36,7 @@ class TestSearchHappyPath:
         assert "sentinel-grep" in hit["matchingText"].lower()
 
     def test_type_composer_still_finds_global_match(self, client):
-        response = client.get("/api/search?q=sentinel-grep&type=composer")
+        response = client.get("/api/search?q=sentinel-grep&type=composer&all_history=1")
         assert response.status_code == 200
         body = response.get_json()
         assert isinstance(body["results"], list)
@@ -67,7 +67,7 @@ class TestSearchErrorResponses:
             "api.search.search_global_storage",
             side_effect=RuntimeError("simulated DB failure"),
         ):
-            response = client.get("/api/search?q=sentinel-grep")
+            response = client.get("/api/search?q=sentinel-grep&all_history=1")
         assert response.status_code == 500
         body = response.get_json()
         assert body.get("error") == "Search failed"
@@ -83,13 +83,36 @@ class TestSearchEdgeCases:
 
     def test_exclusion_rule_filters_matching_conversation(self, workspace_storage):
         excluded_client = client_with_rules(["Happy"])
-        response = excluded_client.get("/api/search?q=sentinel-grep")
+        response = excluded_client.get("/api/search?q=sentinel-grep&all_history=1")
         assert response.status_code == 200
         assert response.get_json().get("results") == []
 
     def test_workspace_scoped_hit_has_workspace_id(self, client):
-        response = client.get("/api/search?q=sentinel-grep")
+        response = client.get("/api/search?q=sentinel-grep&all_history=1")
         assert response.status_code == 200
         results = response.get_json()["results"]
         workspace_ids = {r["workspaceId"] for r in results}
         assert HAPPY_WORKSPACE_ID in workspace_ids or "global" in workspace_ids
+
+
+class TestSearchWindow:
+    def test_default_window_excludes_old_seeded_composer(self, client):
+        response = client.get("/api/search?q=sentinel-grep")
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body.get("allHistory") is False
+        assert body.get("searchWindowDays") == 30
+        assert body.get("results") == []
+
+    def test_all_history_includes_old_seeded_composer(self, client):
+        response = client.get("/api/search?q=sentinel-grep&all_history=1")
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body.get("allHistory") is True
+        assert body.get("searchWindowDays") is None
+        assert len(body.get("results", [])) >= 1
+
+    def test_all_history_true_string_accepted(self, client):
+        response = client.get("/api/search?q=sentinel-grep&all_history=true")
+        assert response.status_code == 200
+        assert response.get_json().get("allHistory") is True

--- a/tests/test_models_wired_at_read_sites.py
+++ b/tests/test_models_wired_at_read_sites.py
@@ -96,24 +96,23 @@ class TestBubbleWiredAtReadSite(unittest.TestCase):
                 os.environ[key] = prior
         self._tmp.cleanup()
 
-    def test_search_endpoint_calls_bubble_from_dict(self):
+    def test_search_endpoint_finds_bubble_text(self):
+        """Search uses a lightweight bubble text extractor (not Bubble.from_dict)."""
         from app import create_app
-        import services.workspace_db as workspace_db_mod
-        from models import Bubble
         app = create_app()
         app.config["TESTING"] = True
         app.config["EXCLUSION_RULES"] = []
-        with patch.object(
-            workspace_db_mod.Bubble, "from_dict", wraps=Bubble.from_dict
-        ) as spy:
-            client = app.test_client()
-            response = client.get("/api/search?q=sentinel-wired")
-            self.assertEqual(response.status_code, 200)
-            self.assertGreaterEqual(
-                spy.call_count, 1,
-                msg="Bubble.from_dict was never called from /api/search — "
-                    "model is defined but not wired at the production read site",
-            )
+        client = app.test_client()
+        response = client.get("/api/search?q=sentinel-wired&all_history=1")
+        self.assertEqual(response.status_code, 200)
+        results = response.get_json().get("results", [])
+        self.assertGreaterEqual(
+            len(results), 1,
+            msg="/api/search must find bubble text via the lightweight search path",
+        )
+        self.assertTrue(
+            any("sentinel-wired" in (r.get("matchingText") or "").lower() for r in results),
+        )
 
     def test_workspace_tabs_endpoint_calls_bubble_from_dict(self):
         from app import create_app
@@ -154,7 +153,7 @@ class TestBubbleWiredAtReadSite(unittest.TestCase):
         app.config["EXCLUSION_RULES"] = []
         with self.assertLogs("services.workspace_db", level="WARNING") as logs:
             client = app.test_client()
-            response = client.get("/api/search?q=sentinel-wired")
+            response = client.get(f"/api/workspaces/{WORKSPACE_ID}/tabs")
             self.assertEqual(response.status_code, 200)
         messages = "\n".join(logs.output)
         self.assertIn("Schema drift in bubble", messages,

--- a/tests/test_models_wired_at_read_sites.py
+++ b/tests/test_models_wired_at_read_sites.py
@@ -99,20 +99,25 @@ class TestBubbleWiredAtReadSite(unittest.TestCase):
     def test_search_endpoint_finds_bubble_text(self):
         """Search uses a lightweight bubble text extractor (not Bubble.from_dict)."""
         from app import create_app
+        import models.conversation as conversation_mod
         app = create_app()
         app.config["TESTING"] = True
         app.config["EXCLUSION_RULES"] = []
-        client = app.test_client()
-        response = client.get("/api/search?q=sentinel-wired&all_history=1")
-        self.assertEqual(response.status_code, 200)
-        results = response.get_json().get("results", [])
-        self.assertGreaterEqual(
-            len(results), 1,
-            msg="/api/search must find bubble text via the lightweight search path",
-        )
-        self.assertTrue(
-            any("sentinel-wired" in (r.get("matchingText") or "").lower() for r in results),
-        )
+        with patch.object(
+            conversation_mod.Bubble, "from_dict", wraps=conversation_mod.Bubble.from_dict,
+        ) as bubble_spy:
+            client = app.test_client()
+            response = client.get("/api/search?q=sentinel-wired&all_history=1")
+            self.assertEqual(response.status_code, 200)
+            results = response.get_json().get("results", [])
+            self.assertGreaterEqual(
+                len(results), 1,
+                msg="/api/search must find bubble text via the lightweight search path",
+            )
+            self.assertTrue(
+                any("sentinel-wired" in (r.get("matchingText") or "").lower() for r in results),
+            )
+            bubble_spy.assert_not_called()
 
     def test_workspace_tabs_endpoint_calls_bubble_from_dict(self):
         from app import create_app

--- a/tests/test_parse_failure_logging.py
+++ b/tests/test_parse_failure_logging.py
@@ -101,7 +101,7 @@ class TestParseFailureLogging(unittest.TestCase):
     def test_listing_logs_composer_schema_drift(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             ws_root = _seed_listing_with_drifted_composer(tmp)
-            with self.assertLogs("services.workspace_listing", level="WARNING") as cm:
+            with self.assertLogs("services.workspace_composer_scan", level="WARNING") as cm:
                 list_workspace_projects(ws_root, rules=[])
 
         messages = [r.getMessage() for r in cm.records]

--- a/tests/test_parse_failure_logging.py
+++ b/tests/test_parse_failure_logging.py
@@ -156,7 +156,7 @@ class TestParseFailureLogging(unittest.TestCase):
                     ("composerData:cmp-json", bad_composer_value),
                 )
                 conn.commit()
-            with self.assertLogs("services.workspace_tabs", level="WARNING") as cm:
+            with self.assertLogs("services.workspace_composer_scan", level="WARNING") as cm:
                 with app.test_request_context("/api/workspaces/global/tabs"):
                     _payload, _status = assemble_workspace_tabs("global", ws_root, rules=[])
 

--- a/tests/test_project_path_boundary.py
+++ b/tests/test_project_path_boundary.py
@@ -10,7 +10,10 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
-from services.workspace_resolver import get_project_from_file_path
+from services.workspace_resolver import (
+    determine_project_for_conversation,
+    get_project_from_file_path,
+)
 
 
 def _write_workspace_json(parent: str, name: str, folder: str) -> dict:
@@ -58,6 +61,40 @@ class TestPrefixCollision(unittest.TestCase):
 
             inside = os.path.join(app, "src", "main.py")
             self.assertEqual(get_project_from_file_path(inside, entries), "ws-app")
+
+
+class TestDetermineProjectUsesPathHelper(unittest.TestCase):
+    """Regression: determine_project_for_conversation must resolve get_project_from_file_path."""
+
+    def test_newly_created_files_triggers_path_helper(self):
+        from models.conversation import Composer
+
+        with tempfile.TemporaryDirectory() as tmp:
+            app = os.path.join(tmp, "repo", "app")
+            os.makedirs(app, exist_ok=True)
+            entries = [_write_workspace_json(tmp, "ws-app", app)]
+            inside = os.path.join(app, "src", "main.py")
+            composer = Composer.from_dict(
+                {
+                    "name": "Path test",
+                    "createdAt": 1_739_200_000_000,
+                    "fullConversationHeadersOnly": [{"bubbleId": "b1", "type": 1}],
+                    "newlyCreatedFiles": [{"uri": {"path": inside}}],
+                },
+                composer_id="cmp-path",
+            )
+            ws_id = determine_project_for_conversation(
+                composer,
+                "cmp-path",
+                {},
+                {},
+                {},
+                entries,
+                {},
+                None,
+                None,
+            )
+            self.assertEqual(ws_id, "ws-app")
 
 
 if __name__ == "__main__":

--- a/tests/test_search_exclusion_filtering.py
+++ b/tests/test_search_exclusion_filtering.py
@@ -207,7 +207,7 @@ class TestSearchExclusionFiltering(unittest.TestCase):
             os.unlink(path)
 
     def _search(self, query: str, search_type: str = "all"):
-        resp = self.client.get(f"/api/search?q={query}&type={search_type}")
+        resp = self.client.get(f"/api/search?q={query}&type={search_type}&all_history=1")
         self.assertEqual(resp.status_code, 200)
         payload = resp.get_json()
         self.assertIsInstance(payload, dict)

--- a/tests/test_search_helpers.py
+++ b/tests/test_search_helpers.py
@@ -20,11 +20,15 @@ from pathlib import Path
 
 import pytest
 
+from datetime import datetime, timedelta, timezone
+
 from models import ParseWarningCollector
 from services.search import (
     _extract_snippet,
     _find_match,
+    _timestamp_in_search_window,
     rank_results,
+    resolve_search_since_ms,
     search_cli_sessions,
     search_global_storage,
     search_legacy_workspaces,
@@ -165,6 +169,78 @@ class TestRankResults:
             "2025-01 chat must outrank 2024-05 composer; "
             f"got order: {[r['type'] for r in ranked]}"
         )
+
+
+# ---------------------------------------------------------------------------
+# resolve_search_since_ms / window filtering
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSearchSinceMs:
+    def test_all_history_returns_none(self):
+        assert resolve_search_since_ms(all_history=True) is None
+
+    def test_default_window_uses_30_days(self):
+        now = datetime(2026, 6, 23, 12, 0, 0, tzinfo=timezone.utc)
+        since = resolve_search_since_ms(all_history=False, now=now)
+        expected = int((now - timedelta(days=30)).timestamp() * 1000)
+        assert since == expected
+
+    def test_custom_since_days(self):
+        now = datetime(2026, 6, 23, 12, 0, 0, tzinfo=timezone.utc)
+        since = resolve_search_since_ms(all_history=False, since_days=7, now=now)
+        expected = int((now - timedelta(days=7)).timestamp() * 1000)
+        assert since == expected
+
+    def test_zero_or_negative_days_searches_all_history(self):
+        assert resolve_search_since_ms(all_history=False, since_days=0) is None
+        assert resolve_search_since_ms(all_history=False, since_days=-1) is None
+
+
+class TestTimestampInSearchWindow:
+    def test_none_since_ms_always_in_window(self):
+        assert _timestamp_in_search_window(1_715_000_000_000, None) is True
+
+    def test_old_timestamp_excluded(self):
+        since = 1_750_000_000_000  # ~2025-06
+        assert _timestamp_in_search_window(1_715_000_000_000, since) is False
+
+    def test_recent_timestamp_included(self):
+        since = 1_750_000_000_000
+        assert _timestamp_in_search_window(1_760_000_000_000, since) is True
+
+
+class TestSearchGlobalStorageWindow:
+    def test_since_ms_excludes_old_composer(self, tmp_workspace_root):
+        dirs = tmp_workspace_root
+        _make_global_db(dirs["global_root"], "cmp-old", "window-filter-term")
+        _make_workspace_db(dirs["ws_root"], "ws-old", "cmp-old", "/projects/old")
+
+        since = 1_750_000_000_000  # after fixture's May 2024 timestamps
+        results = search_global_storage(
+            workspace_path=dirs["ws_root"],
+            query="window-filter-term",
+            query_lower="window-filter-term",
+            rules=[],
+            parse_warnings=ParseWarningCollector(),
+            since_ms=since,
+        )
+        assert results == []
+
+    def test_since_ms_none_includes_old_composer(self, tmp_workspace_root):
+        dirs = tmp_workspace_root
+        _make_global_db(dirs["global_root"], "cmp-old-2", "window-include-term")
+        _make_workspace_db(dirs["ws_root"], "ws-old-2", "cmp-old-2", "/projects/old2")
+
+        results = search_global_storage(
+            workspace_path=dirs["ws_root"],
+            query="window-include-term",
+            query_lower="window-include-term",
+            rules=[],
+            parse_warnings=ParseWarningCollector(),
+            since_ms=None,
+        )
+        assert any(r["chatId"] == "cmp-old-2" for r in results)
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +422,45 @@ class TestSearchGlobalStorage:
         assert results
         # Workspace folder name is resolved to the basename of the folder path.
         assert results[0]["workspaceFolder"] == "myrepo"
+
+    def test_match_in_bubble_only_not_in_composer_json(self, tmp_workspace_root):
+        """Query only in bubbleId row must still match (SQL bubble prefilter path)."""
+        dirs = tmp_workspace_root
+        db_path = os.path.join(dirs["global_root"], "state.vscdb")
+        composer_id = "cmp-bubble-only"
+        term = "bubble-only-sentinel-abc"
+        with contextlib.closing(sqlite3.connect(db_path)) as conn:
+            conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+            conn.execute(
+                "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+                (
+                    f"bubbleId:{composer_id}:bub-1",
+                    json.dumps({"type": "user", "text": f"answer about {term}"}),
+                ),
+            )
+            conn.execute(
+                "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+                (
+                    f"composerData:{composer_id}",
+                    json.dumps({
+                        "name": "Unrelated title",
+                        "createdAt": 1_715_000_000_000,
+                        "lastUpdatedAt": 1_715_001_000_000,
+                        "fullConversationHeadersOnly": [{"bubbleId": "bub-1"}],
+                    }),
+                ),
+            )
+            conn.commit()
+        _make_workspace_db(dirs["ws_root"], "ws-bubble-only", composer_id, "/projects/x")
+
+        results = search_global_storage(
+            workspace_path=dirs["ws_root"],
+            query=term,
+            query_lower=term,
+            rules=[],
+            parse_warnings=ParseWarningCollector(),
+        )
+        assert any(r["chatId"] == composer_id for r in results)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -134,7 +134,9 @@ class TestSearchIndexBuild:
 class TestSearchGlobalStorageUsesIndex:
     def test_search_global_storage_uses_index(self, indexed_storage):
         patches = _index_patches(indexed_storage["cache_dir"])
-        with patches[0], patches[1], patches[2]:
+        with patches[0], patches[1], patches[2], patch(
+            "services.search._search_global_storage_live_scan",
+        ) as live_scan:
             results = search_global_storage(
                 indexed_storage["ws_root"],
                 indexed_storage["term"],
@@ -144,3 +146,4 @@ class TestSearchGlobalStorageUsesIndex:
                 since_ms=None,
             )
             assert any(r["chatId"] == indexed_storage["composer_id"] for r in results)
+            live_scan.assert_not_called()

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -1,0 +1,146 @@
+"""Tests for services/search_index.py (Phase 2 FTS index)."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import sqlite3
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from models import ParseWarningCollector
+from services.search import search_global_storage
+from services.search_index import (
+    build_search_index,
+    index_is_usable,
+    query_composer_bubble_hits,
+)
+
+
+def _seed_global_db(global_root: str, composer_id: str, bubble_text: str) -> None:
+    db_path = os.path.join(global_root, "state.vscdb")
+    with contextlib.closing(sqlite3.connect(db_path)) as conn:
+        conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+        conn.execute(
+            "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+            (
+                f"composerData:{composer_id}",
+                json.dumps({
+                    "name": "Indexed conversation",
+                    "createdAt": 1_780_000_000_000,
+                    "lastUpdatedAt": 1_780_001_000_000,
+                    "fullConversationHeadersOnly": [{"bubbleId": "b-idx-1"}],
+                    "modelConfig": {"modelName": "gpt-4o"},
+                }),
+            ),
+        )
+        conn.execute(
+            "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+            (
+                f"bubbleId:{composer_id}:b-idx-1",
+                json.dumps({"type": "user", "text": bubble_text}),
+            ),
+        )
+        conn.commit()
+
+
+def _seed_workspace(ws_root: str, workspace_id: str, composer_id: str) -> None:
+    ws_dir = os.path.join(ws_root, workspace_id)
+    os.makedirs(ws_dir, exist_ok=True)
+    with open(os.path.join(ws_dir, "workspace.json"), "w", encoding="utf-8") as fh:
+        json.dump({"folder": "/projects/indexed"}, fh)
+    db_path = os.path.join(ws_dir, "state.vscdb")
+    with contextlib.closing(sqlite3.connect(db_path)) as conn:
+        conn.execute("CREATE TABLE ItemTable ([key] TEXT PRIMARY KEY, value TEXT)")
+        conn.execute(
+            "INSERT INTO ItemTable ([key], value) VALUES (?, ?)",
+            (
+                "composer.composerData",
+                json.dumps({"allComposers": [{"composerId": composer_id}]}),
+            ),
+        )
+        conn.commit()
+
+
+@pytest.fixture
+def indexed_storage(monkeypatch, tmp_path):
+    """Temp Cursor layout + isolated search index path."""
+    ws_root = tmp_path / "workspaceStorage"
+    global_root = tmp_path / "globalStorage"
+    cache_dir = tmp_path / "cache"
+    ws_root.mkdir()
+    global_root.mkdir()
+    cache_dir.mkdir()
+    monkeypatch.setenv("WORKSPACE_PATH", str(ws_root))
+    monkeypatch.setenv("CLI_CHATS_PATH", str(tmp_path / "cli-empty"))
+    monkeypatch.delenv("CURSOR_CHAT_BROWSER_NO_SEARCH_INDEX", raising=False)
+    monkeypatch.delenv("CURSOR_CHAT_BROWSER_NOCACHE", raising=False)
+    os.makedirs(tmp_path / "cli-empty", exist_ok=True)
+
+    composer_id = "cmp-indexed-1"
+    term = "indexed-unique-sentinel-xyz"
+    _seed_global_db(str(global_root), composer_id, f"please find {term}")
+    _seed_workspace(str(ws_root), "ws-indexed-1", composer_id)
+
+    with patch("services.search_index.CACHE_DIR", cache_dir), patch(
+        "services.search_index.SEARCH_INDEX_POINTER_FILE", cache_dir / "search_index.active"
+    ), patch("services.search_index.SEARCH_INDEX_FILE", cache_dir / "search_index.sqlite"):
+        built = build_search_index(str(ws_root), [], force=True)
+        assert built is True
+        pointer = cache_dir / "search_index.active"
+        assert pointer.is_file()
+        index_path = cache_dir / pointer.read_text(encoding="utf-8").strip()
+        assert index_path.is_file()
+        yield {
+            "ws_root": str(ws_root),
+            "cache_dir": cache_dir,
+            "index_path": index_path,
+            "composer_id": composer_id,
+            "term": term,
+        }
+
+
+def _index_patches(cache_dir):
+    return (
+        patch("services.search_index.CACHE_DIR", cache_dir),
+        patch(
+            "services.search_index.SEARCH_INDEX_POINTER_FILE",
+            cache_dir / "search_index.active",
+        ),
+        patch("services.search_index.SEARCH_INDEX_FILE", cache_dir / "search_index.sqlite"),
+    )
+
+
+class TestSearchIndexBuild:
+    def test_index_is_usable_after_build(self, indexed_storage):
+        patches = _index_patches(indexed_storage["cache_dir"])
+        with patches[0], patches[1], patches[2]:
+            assert index_is_usable(indexed_storage["ws_root"], []) is True
+
+    def test_bubble_fts_finds_term(self, indexed_storage):
+        patches = _index_patches(indexed_storage["cache_dir"])
+        with patches[0], patches[1], patches[2]:
+            hits = query_composer_bubble_hits(
+                indexed_storage["term"],
+                since_ms=None,
+            )
+            assert indexed_storage["composer_id"] in hits
+            assert any(indexed_storage["term"] in t for t in hits[indexed_storage["composer_id"]])
+
+
+class TestSearchGlobalStorageUsesIndex:
+    def test_search_global_storage_uses_index(self, indexed_storage):
+        patches = _index_patches(indexed_storage["cache_dir"])
+        with patches[0], patches[1], patches[2]:
+            results = search_global_storage(
+                indexed_storage["ws_root"],
+                indexed_storage["term"],
+                indexed_storage["term"].lower(),
+                [],
+                ParseWarningCollector(),
+                since_ms=None,
+            )
+            assert any(r["chatId"] == indexed_storage["composer_id"] for r in results)

--- a/tests/test_search_index_windows.py
+++ b/tests/test_search_index_windows.py
@@ -1,0 +1,53 @@
+"""Regression: index rebuild must not replace an open SQLite file on Windows."""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from services.search_index import _publish_active_index
+
+
+@pytest.fixture
+def locked_index_layout(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    old_db = cache_dir / "search_index.oldgen.sqlite"
+    with contextlib.closing(sqlite3.connect(old_db)) as conn:
+        conn.execute("CREATE TABLE t (x INTEGER)")
+        conn.execute("INSERT INTO t VALUES (1)")
+        conn.commit()
+    (cache_dir / "search_index.active").write_text(old_db.name, encoding="utf-8")
+
+    ws_root = tmp_path / "workspaceStorage"
+    global_root = tmp_path / "globalStorage"
+    ws_root.mkdir()
+    global_root.mkdir()
+    gdb = global_root / "state.vscdb"
+    with contextlib.closing(sqlite3.connect(gdb)) as conn:
+        conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+        conn.commit()
+
+    monkeypatch.setenv("WORKSPACE_PATH", str(ws_root))
+    return cache_dir, old_db
+
+
+def test_publish_active_index_does_not_replace_open_db(locked_index_layout):
+    cache_dir, old_db = locked_index_layout
+    new_db = cache_dir / "search_index.newgen.sqlite"
+    new_db.write_bytes(b"sqlite placeholder")
+
+    # Simulate an open reader on the old generation (Windows lock).
+    with contextlib.closing(sqlite3.connect(old_db)) as _reader:
+        with patch("services.search_index.CACHE_DIR", cache_dir), patch(
+            "services.search_index.SEARCH_INDEX_POINTER_FILE",
+            cache_dir / "search_index.active",
+        ):
+            _publish_active_index(new_db)
+            pointer = (cache_dir / "search_index.active").read_text(encoding="utf-8").strip()
+            assert pointer == new_db.name
+            assert old_db.is_file()

--- a/tests/test_workspace_list_count_alignment.py
+++ b/tests/test_workspace_list_count_alignment.py
@@ -1,0 +1,125 @@
+"""Regression tests for issue #95 — list/summary count alignment and scan hygiene."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import sqlite3
+
+import pytest
+
+from models import ParseWarningCollector
+from services.workspace_composer_scan import parse_composer_data_row
+from services.workspace_db import build_composer_id_to_workspace_id, collect_workspace_entries
+from services.workspace_listing import list_workspace_projects
+from services.workspace_tabs import list_workspace_tab_summaries
+from tests._fixture_ids import HAPPY_COMPOSER_ID, HAPPY_WORKSPACE_ID
+
+
+def _seed_global_db(path: str, *, extra_rows: list[tuple[str, str | None]] | None = None) -> None:
+    with contextlib.closing(sqlite3.connect(path)) as conn:
+        conn.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+        conn.execute(
+            "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+            (
+                f"composerData:{HAPPY_COMPOSER_ID}",
+                json.dumps({
+                    "name": "Aligned conversation",
+                    "createdAt": 1_715_000_000_000,
+                    "lastUpdatedAt": 1_715_000_500_000,
+                    "fullConversationHeadersOnly": [{"bubbleId": "b1", "type": 1}],
+                    "modelConfig": {"modelName": "gpt-4o"},
+                }),
+            ),
+        )
+        if extra_rows:
+            for key, value in extra_rows:
+                conn.execute(
+                    "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+                    (key, value),
+                )
+        conn.commit()
+
+
+def _seed_workspace(ws_root: str, ws_id: str, project_folder: str, composer_id: str) -> None:
+    ws_dir = os.path.join(ws_root, ws_id)
+    os.makedirs(ws_dir, exist_ok=True)
+    with open(os.path.join(ws_dir, "workspace.json"), "w", encoding="utf-8") as f:
+        json.dump({"folder": project_folder}, f)
+    with contextlib.closing(sqlite3.connect(os.path.join(ws_dir, "state.vscdb"))) as conn:
+        conn.execute("CREATE TABLE ItemTable ([key] TEXT PRIMARY KEY, value TEXT)")
+        conn.execute(
+            "INSERT INTO ItemTable ([key], value) VALUES (?, ?)",
+            (
+                "composer.composerData",
+                json.dumps({"allComposers": [{"composerId": composer_id}]}),
+            ),
+        )
+        conn.commit()
+
+
+def _layout(tmp_path, *, extra_rows: list[tuple[str, str | None]] | None = None) -> str:
+    ws_root = tmp_path / "workspaceStorage"
+    global_root = tmp_path / "globalStorage"
+    ws_root.mkdir()
+    global_root.mkdir()
+    project_folder = tmp_path / "proj"
+    project_folder.mkdir()
+    _seed_workspace(str(ws_root), HAPPY_WORKSPACE_ID, str(project_folder), HAPPY_COMPOSER_ID)
+    _seed_global_db(str(global_root / "state.vscdb"), extra_rows=extra_rows)
+    return str(ws_root)
+
+
+def test_project_card_count_matches_summary_tabs(tmp_path):
+    ws_root = _layout(tmp_path)
+    projects, _ = list_workspace_projects(ws_root, rules=[], nocache=True)
+    card = next(p for p in projects if p["id"] == HAPPY_WORKSPACE_ID)
+
+    payload, status = list_workspace_tab_summaries(
+        HAPPY_WORKSPACE_ID, ws_root, rules=[], nocache=True,
+    )
+    assert status == 200
+    assert card["conversationCount"] == len(payload["tabs"])
+
+
+def test_null_composer_placeholder_skipped_silently():
+    warnings = ParseWarningCollector()
+    assert parse_composer_data_row(
+        "composerData:empty-state-draft",
+        None,
+        parse_warnings=warnings,
+    ) is None
+    assert warnings.to_api_list() == []
+
+
+def test_parallel_composer_registry_covers_all_workspaces(tmp_path):
+    ws_root = tmp_path / "workspaceStorage"
+    ws_root.mkdir()
+    ids = [f"ws-{i}" for i in range(6)]
+    for i, ws_id in enumerate(ids):
+        folder = tmp_path / f"proj-{i}"
+        folder.mkdir()
+        _seed_workspace(str(ws_root), ws_id, str(folder), f"cmp-{i}")
+
+    entries = collect_workspace_entries(str(ws_root))
+    mapping = build_composer_id_to_workspace_id(str(ws_root), entries)
+    assert len(mapping) == len(ids)
+    for i, ws_id in enumerate(ids):
+        assert mapping[f"cmp-{i}"] == ws_id
+
+
+def test_excluded_model_dropped_from_list_and_summary(tmp_path):
+    ws_root = _layout(tmp_path)
+    rules = [["gpt-4o"]]
+
+    projects, _ = list_workspace_projects(ws_root, rules=rules, nocache=True)
+    card = next((p for p in projects if p["id"] == HAPPY_WORKSPACE_ID), None)
+    payload, status = list_workspace_tab_summaries(
+        HAPPY_WORKSPACE_ID, ws_root, rules=rules, nocache=True,
+    )
+    assert status == 200
+    if card is None:
+        assert len(payload["tabs"]) == 0
+    else:
+        assert card["conversationCount"] == len(payload["tabs"])

--- a/tests/test_workspace_list_count_alignment.py
+++ b/tests/test_workspace_list_count_alignment.py
@@ -13,7 +13,11 @@ from models import ParseWarningCollector
 from services.workspace_composer_scan import parse_composer_data_row
 from services.workspace_db import build_composer_id_to_workspace_id, collect_workspace_entries
 from services.workspace_listing import list_workspace_projects
-from services.workspace_tabs import list_workspace_tab_summaries
+from services.workspace_tabs import (
+    assemble_single_tab,
+    assemble_workspace_tabs,
+    list_workspace_tab_summaries,
+)
 from tests._fixture_ids import HAPPY_COMPOSER_ID, HAPPY_WORKSPACE_ID
 
 
@@ -107,6 +111,45 @@ def test_parallel_composer_registry_covers_all_workspaces(tmp_path):
     assert len(mapping) == len(ids)
     for i, ws_id in enumerate(ids):
         assert mapping[f"cmp-{i}"] == ws_id
+
+
+def test_summary_and_full_tabs_share_assignment(tmp_path):
+    """Summary and full /tabs agree on which composers belong after assignment."""
+    ws_root = _layout(tmp_path)
+    global_db = os.path.join(tmp_path, "globalStorage", "state.vscdb")
+    with contextlib.closing(sqlite3.connect(global_db)) as conn:
+        conn.execute(
+            "INSERT INTO cursorDiskKV ([key], value) VALUES (?, ?)",
+            (
+                f"bubbleId:{HAPPY_COMPOSER_ID}:b1",
+                json.dumps({"type": "user", "text": "hello", "bubbleId": "b1"}),
+            ),
+        )
+        conn.commit()
+
+    summary, summary_status = list_workspace_tab_summaries(
+        HAPPY_WORKSPACE_ID, ws_root, rules=[], nocache=True,
+    )
+    full, full_status = assemble_workspace_tabs(
+        HAPPY_WORKSPACE_ID, ws_root, rules=[],
+    )
+    assert summary_status == 200
+    assert full_status == 200
+    summary_ids = {t["id"] for t in summary["tabs"]}
+    full_ids = {t["id"] for t in full["tabs"]}
+    assert summary_ids == full_ids
+
+
+def test_single_tab_null_composer_placeholder_returns_404(tmp_path):
+    ws_root = _layout(
+        tmp_path,
+        extra_rows=[("composerData:empty-state-draft", None)],
+    )
+    payload, status = assemble_single_tab(
+        "global", "empty-state-draft", ws_root, rules=[],
+    )
+    assert status == 404
+    assert "error" in payload
 
 
 def test_excluded_model_dropped_from_list_and_summary(tmp_path):

--- a/tests/test_workspace_list_count_alignment.py
+++ b/tests/test_workspace_list_count_alignment.py
@@ -137,7 +137,10 @@ def test_summary_and_full_tabs_share_assignment(tmp_path):
     assert full_status == 200
     summary_ids = {t["id"] for t in summary["tabs"]}
     full_ids = {t["id"] for t in full["tabs"]}
+    assert summary_ids
+    assert full_ids
     assert summary_ids == full_ids
+    assert HAPPY_COMPOSER_ID in summary_ids
 
 
 def test_single_tab_null_composer_placeholder_returns_404(tmp_path):


### PR DESCRIPTION
CLoses #95 

## Summary

Improves workspace list/navigation performance and makes search fast enough for daily use, while fixing incorrect conversation links from search results.

### Workspace listing & navigation (#95)
- Extract shared composer parsing/assignment into `workspace_composer_scan.py`
- Parallelize `build_composer_id_to_workspace_id` and bulk-load project layouts
- Align `conversationCount` with the same filters used by tab summaries
- Skip null/placeholder `composerData` rows without spurious warnings
- Restore `get_project_from_file_path` (fixes `NameError` that dropped ~66 conversations)

### Search performance
- **30-day default window** with UI checkbox and `all_history=1` API flag
- **Phase 1:** single-pass bubble `LIKE` scan (fixes scoped-query regression that made 30-day search slower than full history)
- **Phase 2:** local `search_index.sqlite` with FTS5, background rebuild on startup + 60s poll, fingerprint invalidation (same mtime scheme as listing cache)
- **Windows:** versioned index files + `search_index.active` pointer (avoids `PermissionError` when replacing an open DB)

### Search correctness
- Search `workspaceId` now uses `assign_composer_workspace` (same as sidebar), not roster map alone
- Workspace page honors `?tab=` deep links; fetches conversation directly instead of opening the first sidebar item; redirects to `global` on 404

## Test plan

- [ ] Restart `python app.py`; confirm log: `Search index rebuilt: N composers, M bubbles -> search_index.*.sqlite`
- [ ] Home page: projects load quickly; counts match sidebar conversation totals
- [ ] Search default (30 days): completes in a few seconds; checkbox searches all history
- [ ] Click a search result: opens the matching thread (not the first conversation in the project)
- [ ] `pytest tests/test_workspace_list_count_alignment.py tests/test_api_search.py tests/test_search_index.py tests/test_search_helpers.py tests/test_project_path_boundary.py`
- [ ] After Cursor adds a new chat, wait ~60s or restart; search finds new content

## Notes

- Index/cache lives under `~/.cache/cursor-chat-browser/`
- Bypass: `CURSOR_CHAT_BROWSER_NOCACHE=1` or `CURSOR_CHAT_BROWSER_NO_SEARCH_INDEX=1`
- Dev-only: `scripts/profile_search*.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added an “Include chats older than 30 days” search mode that expands results to all history.
  * Search API now supports a configurable history window and returns `allHistory` / `searchWindowDays` for accurate result labeling.

* **Performance/Background**
  * Search indexing can now start automatically during app initialization to keep search results current.

* **Bug Fixes**
  * Improved workspace tab navigation: missing tabs now redirect to the global workspace.

* **Tests**
  * Added/updated coverage for search windows, all-history API behavior, and end-to-end search index querying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->