### PR TITLE
test: add summary-cache pytest-benchmark suite with CI regression gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
         # exercise Flask routes via app.test_client(). Only listed files — not
         # `pytest tests/` — to avoid re-collecting unittest.TestCase classes above.
         # -o addopts= avoids inheriting benchmark-only options from pyproject.toml.
-        run: python -m pytest tests/test_api_search.py tests/test_api_workspaces.py tests/test_api_export.py tests/test_pdf_export.py tests/test_search_helpers.py -v --tb=short -o addopts=
+        run: python -m pytest tests/test_api_search.py tests/test_api_workspaces.py tests/test_api_export.py tests/test_pdf_export.py tests/test_search_helpers.py tests/test_check_benchmark_regression.py -v --tb=short -o addopts=
 
       # ── PyInstaller desktop build (Windows only, once per workflow) ────────
       # Closes #44. Builds the onedir bundle and smoke-tests --help so the
@@ -240,6 +240,7 @@ jobs:
         run: >
           python -m pytest tests/benchmarks/
           --benchmark-only
+          --benchmark-min-rounds=5
           --benchmark-json=benchmark-results.json
           --benchmark-columns=min,max,mean,stddev,rounds
           -o addopts=

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-lock.txt
-          python -m pip install 'pytest>=8,<9' 'hypothesis>=6.100,<7'
+          python -m pip install 'pytest>=8,<9' 'pytest-benchmark==4.0.0' 'hypothesis>=6.100,<7'
 
       - name: Run unittest suite
         run: python -m unittest discover tests -v
@@ -218,6 +218,7 @@ jobs:
   # ── Performance benchmarks: summary cache (issue #7) ───────────────────────
   benchmarks:
     name: Performance benchmarks (gated)
+    needs: [unittest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -233,7 +234,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-lock.txt
-          python -m pip install 'pytest>=8,<9' 'pytest-benchmark>=4,<5'
+          python -m pip install 'pytest>=8,<9' 'pytest-benchmark==4.0.0'
 
       - name: Run summary-cache benchmarks
         run: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -215,7 +215,7 @@ jobs:
             --redact \
             --exit-code 1
 
-  # ── Performance benchmarks: summary cache (issue #7) ───────────────────────
+  # ── Performance benchmarks: summary cache (issue #115) ─────────────────────
   benchmarks:
     name: Performance benchmarks (gated)
     needs: [unittest]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -213,3 +213,40 @@ jobs:
             --verbose \
             --redact \
             --exit-code 1
+
+  # ── Performance benchmarks: summary cache (issue #7) ───────────────────────
+  benchmarks:
+    name: Performance benchmarks (gated)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install runtime + benchmark dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-lock.txt
+          python -m pip install 'pytest>=8,<9' 'pytest-benchmark>=4,<5'
+
+      - name: Run summary-cache benchmarks
+        run: >
+          python -m pytest tests/benchmarks/
+          --benchmark-only
+          --benchmark-json=benchmark-results.json
+          --benchmark-columns=min,max,mean,stddev,rounds
+          -o addopts=
+
+      - name: Regression gate
+        run: python scripts/check_benchmark_regression.py benchmark-results.json benchmarks/baselines.json
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        if: always()
+        with:
+          name: benchmark-results
+          path: benchmark-results.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,7 +114,8 @@ jobs:
         # Pytest fixtures (tests/conftest.py) build a temp workspaceStorage and
         # exercise Flask routes via app.test_client(). Only listed files — not
         # `pytest tests/` — to avoid re-collecting unittest.TestCase classes above.
-        run: python -m pytest tests/test_api_search.py tests/test_api_workspaces.py tests/test_api_export.py tests/test_pdf_export.py tests/test_search_helpers.py -v --tb=short
+        # -o addopts= avoids inheriting benchmark-only options from pyproject.toml.
+        run: python -m pytest tests/test_api_search.py tests/test_api_workspaces.py tests/test_api_export.py tests/test_pdf_export.py tests/test_search_helpers.py -v --tb=short -o addopts=
 
       # ── PyInstaller desktop build (Windows only, once per workflow) ────────
       # Closes #44. Builds the onedir bundle and smoke-tests --help so the

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ Thumbs.db
 htmlcov/
 coverage.xml
 .hypothesis/
+benchmark-results.json
+benchmarks/_raw.json

--- a/benchmarks/baselines.json
+++ b/benchmarks/baselines.json
@@ -1,6 +1,6 @@
 {
-  "_note": "Gated means from ubuntu-latest CI benchmark-results.json (PR #7 summary-cache benchmarks). Refresh via: pytest tests/benchmarks/ --benchmark-only --benchmark-json=benchmark-results.json -o addopts= then update these values.",
-  "updated": "2026-06-25T12:00:00Z",
+  "_note": "Gated means from ubuntu-latest CI benchmark-results.json (PR #120, run 28123677675). Refresh: pytest tests/benchmarks/ --benchmark-only --benchmark-json=benchmark-results.json -o addopts=",
+  "updated": "2026-06-24T19:20:27Z",
   "machine": "Linux",
   "groups": {
     "summary-cache": {

--- a/benchmarks/baselines.json
+++ b/benchmarks/baselines.json
@@ -1,0 +1,15 @@
+{
+  "_note": "Gated means from local reference run with 1.5x slack (Windows dev host). Refresh from ubuntu-latest CI artifact after first green benchmark job.",
+  "updated": "2026-06-25T00:00:00Z",
+  "machine": "Windows",
+  "groups": {
+    "summary-cache": {
+      "test_summary_cache_hit": 8.91e-05,
+      "test_summary_cache_miss": 8.13e-05,
+      "test_fingerprint_workspace_entries[10]": 0.001708,
+      "test_fingerprint_workspace_entries[50]": 0.005457,
+      "test_fingerprint_workspace_entries[200]": 0.01715,
+      "test_summary_cache_round_trip": 0.001667
+    }
+  }
+}

--- a/benchmarks/baselines.json
+++ b/benchmarks/baselines.json
@@ -1,5 +1,5 @@
 {
-  "_note": "Gated means from ubuntu-latest CI benchmark-results.json (PR #120, run 28123677675). Refresh: pytest tests/benchmarks/ --benchmark-only --benchmark-json=benchmark-results.json -o addopts=",
+  "_note": "Gated means from ubuntu-latest CI benchmark-results.json (PR #120, run 28123677675). Refresh after intentional perf changes: download benchmark-results.json from the CI artifacts job, then `python scripts/check_benchmark_regression.py benchmark-results.json benchmarks/baselines.json` (re-seed with reduce_baselines or edit means). Local capture: `pytest tests/benchmarks/ --benchmark-only --benchmark-json=benchmark-results.json -o addopts=` on ubuntu-latest.",
   "updated": "2026-06-24T19:20:27Z",
   "machine": "Linux",
   "groups": {

--- a/benchmarks/baselines.json
+++ b/benchmarks/baselines.json
@@ -1,15 +1,15 @@
 {
-  "_note": "Gated means from local reference run with 1.5x slack (Windows dev host). Refresh from ubuntu-latest CI artifact after first green benchmark job.",
-  "updated": "2026-06-25T00:00:00Z",
-  "machine": "Windows",
+  "_note": "Gated means from ubuntu-latest CI benchmark-results.json (PR #7 summary-cache benchmarks). Refresh via: pytest tests/benchmarks/ --benchmark-only --benchmark-json=benchmark-results.json -o addopts= then update these values.",
+  "updated": "2026-06-25T12:00:00Z",
+  "machine": "Linux",
   "groups": {
     "summary-cache": {
-      "test_summary_cache_hit": 8.91e-05,
-      "test_summary_cache_miss": 8.13e-05,
-      "test_fingerprint_workspace_entries[10]": 0.001708,
-      "test_fingerprint_workspace_entries[50]": 0.005457,
-      "test_fingerprint_workspace_entries[200]": 0.01715,
-      "test_summary_cache_round_trip": 0.001667
+      "test_summary_cache_hit": 6.3e-05,
+      "test_summary_cache_miss": 6.3e-05,
+      "test_fingerprint_workspace_entries[10]": 0.001844,
+      "test_fingerprint_workspace_entries[50]": 0.007759,
+      "test_fingerprint_workspace_entries[200]": 0.022231,
+      "test_summary_cache_round_trip": 0.000351
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
+pythonpath = ["."]
+addopts = "--benchmark-disable"
 testpaths = ["tests"]
 markers = [
     "benchmark: performance benchmarks (pytest-benchmark)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--benchmark-skip"
 testpaths = ["tests"]
 markers = [
     "benchmark: performance benchmarks (pytest-benchmark)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,9 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
+# Requires pytest-benchmark (pip install -e ".[dev]") for default `pytest` invocations.
 pythonpath = ["."]
-addopts = "--benchmark-disable"
+addopts = "--benchmark-skip"
 testpaths = ["tests"]
 markers = [
     "benchmark: performance benchmarks (pytest-benchmark)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,16 @@ desktop = ["pywebview>=5.0,<6"]
 # Development tooling: testing + type checking.
 dev = [
     "pytest>=8,<9",
+    "pytest-benchmark>=4,<5",
     "mypy>=1.10,<2",
     "hypothesis>=6.100,<7",
+]
+
+[tool.pytest.ini_options]
+addopts = "--benchmark-skip"
+testpaths = ["tests"]
+markers = [
+    "benchmark: performance benchmarks (pytest-benchmark)",
 ]
 
 [project.scripts]

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -6,7 +6,7 @@
 # Lock is generated on Linux (CI / update-lock.yml). Windows-only transitives (e.g.
 # colorama via click) are omitted — pip still installs them on Windows when needed.
 blinker==1.9.0            # via flask
-click==8.4.1              # via flask
+click==8.4.2              # via flask
 defusedxml==0.7.1         # via fpdf2
 flask==3.1.3              # via -r requirements.txt
 fonttools==4.63.0         # via fpdf2

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -6,7 +6,7 @@
 # Lock is generated on Linux (CI / update-lock.yml). Windows-only transitives (e.g.
 # colorama via click) are omitted — pip still installs them on Windows when needed.
 blinker==1.9.0            # via flask
-click==8.4.2              # via flask
+click==8.4.2              # via flask; 8.4.1→8.4.2: pip-compile lockfile CI sync (not benchmark-related)
 defusedxml==0.7.1         # via fpdf2
 flask==3.1.3              # via -r requirements.txt
 fonttools==4.63.0         # via fpdf2

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -6,7 +6,7 @@
 # Lock is generated on Linux (CI / update-lock.yml). Windows-only transitives (e.g.
 # colorama via click) are omitted — pip still installs them on Windows when needed.
 blinker==1.9.0            # via flask
-click==8.4.2              # via flask; 8.4.1→8.4.2: pip-compile lockfile CI sync (not benchmark-related)
+click==8.4.2              # via flask
 defusedxml==0.7.1         # via fpdf2
 flask==3.1.3              # via -r requirements.txt
 fonttools==4.63.0         # via fpdf2

--- a/scripts/check_benchmark_regression.py
+++ b/scripts/check_benchmark_regression.py
@@ -92,10 +92,12 @@ def check_regression(
     baseline_means = load_baseline_means(baselines_path)
 
     failures: list[str] = []
+    missing: list[str] = []
     for name, base in baseline_means.items():
         cur = flat.get(name)
         if cur is None:
-            print(f"WARN: no current result for baseline {name!r}; skipping")
+            print(f"FAIL: no current result for gated baseline {name!r}")
+            missing.append(name)
             continue
         if base == 0:
             print(f"WARN: baseline for {name!r} is zero; skipping ratio check")
@@ -112,6 +114,9 @@ def check_regression(
 
     if failures:
         print(f"\nREGRESSION: {len(failures)} benchmark(s) exceeded {threshold:.0%}")
+    if missing:
+        print(f"\nMISSING: {len(missing)} gated benchmark(s) absent from current results")
+    if failures or missing:
         return 1
     return 0
 

--- a/scripts/check_benchmark_regression.py
+++ b/scripts/check_benchmark_regression.py
@@ -15,8 +15,15 @@ class BenchmarkDataError(ValueError):
 
 
 def normalize_benchmark_name(name: str) -> str:
-    """Strip pytest node prefix so baselines match short or full benchmark names."""
-    return str(name).rsplit("::", 1)[-1]
+    """Strip pytest file node prefix so baselines match short or full benchmark names."""
+    text = str(name)
+    if "::" not in text:
+        return text
+    prefix, _, suffix = text.partition("::")
+    # Only strip module paths (…/test_foo.py::test_name); leave "::" inside [param::value] intact.
+    if prefix.endswith(".py"):
+        return suffix
+    return text
 
 
 def load_results(results_path: str | Path) -> dict[str, float]:

--- a/scripts/check_benchmark_regression.py
+++ b/scripts/check_benchmark_regression.py
@@ -14,6 +14,11 @@ class BenchmarkDataError(ValueError):
     """Raised when benchmark JSON input is malformed or missing required fields."""
 
 
+def normalize_benchmark_name(name: str) -> str:
+    """Strip pytest node prefix so baselines match short or full benchmark names."""
+    return str(name).rsplit("::", 1)[-1]
+
+
 def load_results(results_path: str | Path) -> dict[str, float]:
     path = Path(results_path)
     try:
@@ -34,13 +39,13 @@ def load_results(results_path: str | Path) -> dict[str, float]:
         if not isinstance(entry, dict):
             raise BenchmarkDataError(f"{path} benchmarks[{index}] must be an object")
         try:
-            name = entry["name"]
+            raw_name = entry["name"]
             mean = float(entry["stats"]["mean"])
         except (KeyError, TypeError, ValueError) as exc:
             raise BenchmarkDataError(
                 f"{path} benchmarks[{index}] missing 'name' or 'stats.mean'"
             ) from exc
-        name = str(name)
+        name = normalize_benchmark_name(str(raw_name))
         if name in results:
             raise BenchmarkDataError(f"{path} duplicate benchmark name {name!r}")
         results[name] = mean
@@ -67,13 +72,17 @@ def load_baseline_means(baselines_path: str | Path) -> dict[str, float]:
     means: dict[str, float] = {}
     for group_name, value in groups.items():
         if not isinstance(value, dict):
-            continue
+            raise BenchmarkDataError(
+                f"{path} groups[{group_name!r}] must be an object of benchmark means"
+            )
         for name, mean in value.items():
-            name = str(name)
-            if name in means:
-                raise BenchmarkDataError(f"{path} duplicate benchmark name {name!r} across groups")
+            bench_name = normalize_benchmark_name(str(name))
+            if bench_name in means:
+                raise BenchmarkDataError(
+                    f"{path} duplicate benchmark name {bench_name!r} across groups"
+                )
             try:
-                means[name] = float(mean)
+                means[bench_name] = float(mean)
             except (TypeError, ValueError) as exc:
                 raise BenchmarkDataError(
                     f"{path} groups[{group_name!r}][{name!r}] is not a numeric mean"

--- a/scripts/check_benchmark_regression.py
+++ b/scripts/check_benchmark_regression.py
@@ -1,0 +1,142 @@
+"""Compare pytest-benchmark JSON output against stored baselines."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+THRESHOLD = 1.20
+
+
+class BenchmarkDataError(ValueError):
+    """Raised when benchmark JSON input is malformed or missing required fields."""
+
+
+def load_results(results_path: str | Path) -> dict[str, float]:
+    path = Path(results_path)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise BenchmarkDataError(f"cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise BenchmarkDataError(f"invalid JSON in {path}: {exc}") from exc
+    try:
+        benchmarks = data["benchmarks"]
+    except (KeyError, TypeError) as exc:
+        raise BenchmarkDataError(f"{path} missing top-level 'benchmarks' array") from exc
+    if not isinstance(benchmarks, list):
+        raise BenchmarkDataError(f"{path} 'benchmarks' must be an array")
+
+    results: dict[str, float] = {}
+    for index, entry in enumerate(benchmarks):
+        if not isinstance(entry, dict):
+            raise BenchmarkDataError(f"{path} benchmarks[{index}] must be an object")
+        try:
+            name = entry["name"]
+            mean = float(entry["stats"]["mean"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BenchmarkDataError(
+                f"{path} benchmarks[{index}] missing 'name' or 'stats.mean'"
+            ) from exc
+        name = str(name)
+        if name in results:
+            raise BenchmarkDataError(f"{path} duplicate benchmark name {name!r}")
+        results[name] = mean
+    return results
+
+
+def load_baseline_means(baselines_path: str | Path) -> dict[str, float]:
+    path = Path(baselines_path)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise BenchmarkDataError(f"cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise BenchmarkDataError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise BenchmarkDataError(f"{path} root value must be an object")
+
+    if "groups" not in data:
+        raise BenchmarkDataError(f"{path} missing required 'groups' key")
+    groups = data["groups"]
+    if not isinstance(groups, dict):
+        raise BenchmarkDataError(f"{path} 'groups' must be an object")
+
+    means: dict[str, float] = {}
+    for group_name, value in groups.items():
+        if not isinstance(value, dict):
+            continue
+        for name, mean in value.items():
+            name = str(name)
+            if name in means:
+                raise BenchmarkDataError(f"{path} duplicate benchmark name {name!r} across groups")
+            try:
+                means[name] = float(mean)
+            except (TypeError, ValueError) as exc:
+                raise BenchmarkDataError(
+                    f"{path} groups[{group_name!r}][{name!r}] is not a numeric mean"
+                ) from exc
+    return means
+
+
+def check_regression(
+    results_path: str | Path,
+    baselines_path: str | Path,
+    *,
+    threshold: float = THRESHOLD,
+) -> int:
+    """Return 0 when within threshold; 1 when any gated benchmark regresses."""
+    flat = load_results(results_path)
+    baseline_means = load_baseline_means(baselines_path)
+
+    failures: list[str] = []
+    for name, base in baseline_means.items():
+        cur = flat.get(name)
+        if cur is None:
+            print(f"WARN: no current result for baseline {name!r}; skipping")
+            continue
+        if base == 0:
+            print(f"WARN: baseline for {name!r} is zero; skipping ratio check")
+            continue
+        ratio = cur / base
+        tag = "FAIL" if ratio > threshold else "ok"
+        print(f"[{tag}] {name}: {cur:.6f}s vs {base:.6f}s ({ratio:.2f}x)")
+        if ratio > threshold:
+            failures.append(name)
+
+    for name in flat:
+        if name not in baseline_means:
+            print(f"WARN: {name!r} has no baseline yet; not gated")
+
+    if failures:
+        print(f"\nREGRESSION: {len(failures)} benchmark(s) exceeded {threshold:.0%}")
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("results_path", help="pytest-benchmark --benchmark-json output")
+    parser.add_argument("baselines_path", help="path to benchmarks/baselines.json")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=THRESHOLD,
+        help="fail when current mean exceeds baseline by more than this ratio (default: 1.20)",
+    )
+    args = parser.parse_args(argv)
+    try:
+        return check_regression(
+            args.results_path,
+            args.baselines_path,
+            threshold=args.threshold,
+        )
+    except BenchmarkDataError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -36,7 +36,7 @@ def summary_cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
     Patches ``CACHE_DIR`` (also used by tab-summary paths via ``_tab_summaries_path``)
     plus the projects/composer-map file constants used by current benchmarks.
-    Tab-summary cache benchmarks are deferred to issue #8 (unified benchmark suite).
+    Tab-summary cache benchmarks are deferred to issue #110 (unified benchmark suite).
     """
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,89 @@
+"""Synthetic workspace trees for summary-cache performance benchmarks."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from services import summary_cache  # noqa: E402
+from services.summary_cache import fingerprint_workspace_storage  # noqa: E402
+
+
+def make_workspace_entries(workspace_root: Path, count: int) -> list[dict[str, Any]]:
+    """Build *count* synthetic workspace entries with on-disk state files."""
+    entries: list[dict[str, Any]] = []
+    for i in range(count):
+        name = f"ws_{i:04d}"
+        entry_dir = workspace_root / name
+        entry_dir.mkdir(parents=True, exist_ok=True)
+        (entry_dir / "state.vscdb").write_bytes(b"bench")
+        workspace_json = entry_dir / "workspace.json"
+        workspace_json.write_text('{"folder": "/bench"}', encoding="utf-8")
+        entries.append(
+            {
+                "name": name,
+                "workspaceJsonPath": str(workspace_json),
+            }
+        )
+    return entries
+
+
+@pytest.fixture
+def summary_cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect summary-cache files to an isolated temp directory."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(summary_cache, "CACHE_DIR", cache_dir)
+    monkeypatch.setattr(summary_cache, "PROJECTS_CACHE_FILE", cache_dir / "projects.json")
+    monkeypatch.setattr(
+        summary_cache,
+        "COMPOSER_MAP_CACHE_FILE",
+        cache_dir / "composer-id-to-ws.json",
+    )
+    return cache_dir
+
+
+@pytest.fixture
+def sample_projects() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "ws_0000",
+            "name": "Bench Project",
+            "conversationCount": 3,
+            "lastModified": "2026-06-24T00:00:00Z",
+        }
+    ]
+
+
+@pytest.fixture
+def synthetic_workspace(tmp_path: Path, request: pytest.FixtureRequest) -> tuple[str, list[dict[str, Any]]]:
+    """Workspace path + entries. Parametrize via indirect ``workspace_entry_count``."""
+    count = getattr(request, "param", 10)
+    workspace_root = tmp_path / "workspaceStorage"
+    workspace_root.mkdir()
+    entries = make_workspace_entries(workspace_root, count)
+    return str(workspace_root), entries
+
+
+@pytest.fixture
+def workspace_fingerprint(synthetic_workspace: tuple[str, list[dict[str, Any]]]) -> dict[str, Any]:
+    workspace_path, entries = synthetic_workspace
+    return fingerprint_workspace_storage(
+        workspace_path,
+        entries,
+        global_db_path=None,
+        rules=[],
+    )
+
+
+@pytest.fixture
+def stale_fingerprint(workspace_fingerprint: dict[str, Any]) -> dict[str, Any]:
+    return {**workspace_fingerprint, "global_db_mtime_ns": 9_999_999_999}

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -2,19 +2,13 @@
 
 from __future__ import annotations
 
-import os
-import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-if REPO_ROOT not in sys.path:
-    sys.path.insert(0, REPO_ROOT)
-
-from services import summary_cache  # noqa: E402
-from services.summary_cache import fingerprint_workspace_storage  # noqa: E402
+from services import summary_cache
+from services.summary_cache import fingerprint_workspace_storage
 
 
 def make_workspace_entries(workspace_root: Path, count: int) -> list[dict[str, Any]]:
@@ -38,7 +32,11 @@ def make_workspace_entries(workspace_root: Path, count: int) -> list[dict[str, A
 
 @pytest.fixture
 def summary_cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Redirect summary-cache files to an isolated temp directory."""
+    """Redirect summary-cache files to an isolated temp directory.
+
+    Patches ``CACHE_DIR`` (also used by tab-summary paths via ``_tab_summaries_path``)
+    plus the projects/composer-map file constants used by current benchmarks.
+    """
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
     monkeypatch.setattr(summary_cache, "CACHE_DIR", cache_dir)
@@ -86,4 +84,5 @@ def workspace_fingerprint(synthetic_workspace: tuple[str, list[dict[str, Any]]])
 
 @pytest.fixture
 def stale_fingerprint(workspace_fingerprint: dict[str, Any]) -> dict[str, Any]:
-    return {**workspace_fingerprint, "global_db_mtime_ns": 9_999_999_999}
+    """Return a fingerprint guaranteed to differ from the stored one."""
+    return {**workspace_fingerprint, "rules_digest": "deadbeefdeadbeef"}

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -36,6 +36,7 @@ def summary_cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
     Patches ``CACHE_DIR`` (also used by tab-summary paths via ``_tab_summaries_path``)
     plus the projects/composer-map file constants used by current benchmarks.
+    Tab-summary cache benchmarks are deferred to issue #8 (unified benchmark suite).
     """
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()

--- a/tests/benchmarks/test_summary_cache_bench.py
+++ b/tests/benchmarks/test_summary_cache_bench.py
@@ -1,4 +1,8 @@
-"""pytest-benchmark coverage for services/summary_cache.py hot paths."""
+"""pytest-benchmark coverage for services/summary_cache.py hot paths.
+
+``test_summary_cache_hit`` and ``test_summary_cache_miss`` both time ``get_cached_projects``
+only. Miss means fingerprint mismatch (cache not used), not a full cache rebuild.
+"""
 
 from __future__ import annotations
 

--- a/tests/benchmarks/test_summary_cache_bench.py
+++ b/tests/benchmarks/test_summary_cache_bench.py
@@ -13,6 +13,7 @@ from services.summary_cache import (
     set_cached_projects,
 )
 
+
 @pytest.mark.benchmark(group="summary-cache")
 def test_summary_cache_hit(
     benchmark,

--- a/tests/benchmarks/test_summary_cache_bench.py
+++ b/tests/benchmarks/test_summary_cache_bench.py
@@ -1,0 +1,73 @@
+"""pytest-benchmark coverage for services/summary_cache.py hot paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from services.summary_cache import (
+    fingerprint_workspace_storage,
+    get_cached_projects,
+    set_cached_projects,
+)
+
+@pytest.mark.benchmark(group="summary-cache")
+def test_summary_cache_hit(
+    benchmark,
+    summary_cache_dir: Path,
+    workspace_fingerprint: dict[str, Any],
+    sample_projects: list[dict[str, Any]],
+) -> None:
+    set_cached_projects(workspace_fingerprint, sample_projects, [])
+    benchmark(get_cached_projects, workspace_fingerprint)
+
+
+@pytest.mark.benchmark(group="summary-cache")
+def test_summary_cache_miss(
+    benchmark,
+    summary_cache_dir: Path,
+    workspace_fingerprint: dict[str, Any],
+    stale_fingerprint: dict[str, Any],
+    sample_projects: list[dict[str, Any]],
+) -> None:
+    set_cached_projects(workspace_fingerprint, sample_projects, [])
+    benchmark(get_cached_projects, stale_fingerprint)
+
+
+@pytest.mark.benchmark(group="summary-cache")
+@pytest.mark.parametrize(
+    "synthetic_workspace",
+    [10, 50, 200],
+    indirect=True,
+)
+def test_fingerprint_workspace_entries(
+    benchmark,
+    synthetic_workspace: tuple[str, list[dict[str, Any]]],
+) -> None:
+    workspace_path, entries = synthetic_workspace
+    benchmark(
+        fingerprint_workspace_storage,
+        workspace_path,
+        entries,
+        global_db_path=None,
+        rules=[],
+    )
+
+
+@pytest.mark.benchmark(group="summary-cache")
+def test_summary_cache_round_trip(
+    benchmark,
+    summary_cache_dir: Path,
+    workspace_fingerprint: dict[str, Any],
+    sample_projects: list[dict[str, Any]],
+) -> None:
+    fp = workspace_fingerprint
+    projects = sample_projects
+
+    def _run() -> None:
+        set_cached_projects(fp, projects, [])
+        get_cached_projects(fp)
+
+    benchmark(_run)

--- a/tests/test_check_benchmark_regression.py
+++ b/tests/test_check_benchmark_regression.py
@@ -37,6 +37,13 @@ def test_normalize_benchmark_name_strips_module_prefix() -> None:
     assert normalize_benchmark_name("test_summary_cache_hit") == "test_summary_cache_hit"
 
 
+def test_normalize_benchmark_name_preserves_colons_in_param_values() -> None:
+    short = "test_x[param::v]"
+    full = f"tests/benchmarks/test_x.py::{short}"
+    assert normalize_benchmark_name(short) == short
+    assert normalize_benchmark_name(full) == short
+
+
 def test_load_results_normalizes_full_node_id(tmp_path) -> None:
     path = tmp_path / "results.json"
     _write_results(

--- a/tests/test_check_benchmark_regression.py
+++ b/tests/test_check_benchmark_regression.py
@@ -1,0 +1,208 @@
+"""Tests for scripts/check_benchmark_regression.py."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.check_benchmark_regression import (
+    BenchmarkDataError,
+    check_regression,
+    load_baseline_means,
+    load_results,
+    normalize_benchmark_name,
+)
+
+GATED_BENCH = "test_summary_cache_hit"
+
+
+def _write_results(path, benchmarks: list[dict]) -> None:
+    path.write_text(
+        json.dumps({"benchmarks": benchmarks}, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _write_baselines(path, groups: dict[str, dict[str, float]]) -> None:
+    path.write_text(
+        json.dumps({"groups": groups}, indent=2),
+        encoding="utf-8",
+    )
+
+
+def test_normalize_benchmark_name_strips_module_prefix() -> None:
+    full = "tests/benchmarks/test_summary_cache_bench.py::test_summary_cache_hit"
+    assert normalize_benchmark_name(full) == "test_summary_cache_hit"
+    assert normalize_benchmark_name("test_summary_cache_hit") == "test_summary_cache_hit"
+
+
+def test_load_results_normalizes_full_node_id(tmp_path) -> None:
+    path = tmp_path / "results.json"
+    _write_results(
+        path,
+        [
+            {
+                "name": "tests/benchmarks/test_summary_cache_bench.py::test_summary_cache_hit",
+                "stats": {"mean": 0.0001},
+            }
+        ],
+    )
+
+    assert load_results(path)["test_summary_cache_hit"] == pytest.approx(0.0001)
+
+
+def test_missing_baseline_warns_without_failing(
+    tmp_path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    results = tmp_path / "results.json"
+    baselines = tmp_path / "baselines.json"
+    _write_results(
+        results,
+        [
+            {"name": "test_new_bench", "stats": {"mean": 0.01}},
+            {"name": GATED_BENCH, "stats": {"mean": 0.0001}},
+        ],
+    )
+    _write_baselines(
+        baselines,
+        {"summary-cache": {GATED_BENCH: 0.0001}},
+    )
+
+    assert check_regression(results, baselines) == 0
+    out = capsys.readouterr().out
+    assert "WARN: 'test_new_bench' has no baseline yet" in out
+
+
+def test_regression_over_threshold_fails(tmp_path, capsys: pytest.CaptureFixture[str]) -> None:
+    results = tmp_path / "results.json"
+    baselines = tmp_path / "baselines.json"
+    _write_results(
+        results,
+        [{"name": GATED_BENCH, "stats": {"mean": 0.00025}}],
+    )
+    _write_baselines(
+        baselines,
+        {"summary-cache": {GATED_BENCH: 0.0002}},
+    )
+
+    assert check_regression(results, baselines) == 1
+    out = capsys.readouterr().out
+    assert "REGRESSION" in out
+
+
+def test_within_threshold_passes(tmp_path) -> None:
+    results = tmp_path / "results.json"
+    baselines = tmp_path / "baselines.json"
+    _write_results(
+        results,
+        [{"name": GATED_BENCH, "stats": {"mean": 0.00022}}],
+    )
+    _write_baselines(
+        baselines,
+        {"summary-cache": {GATED_BENCH: 0.0002}},
+    )
+
+    assert check_regression(results, baselines) == 0
+
+
+def test_load_results_rejects_malformed_json(tmp_path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(BenchmarkDataError, match="invalid JSON"):
+        load_results(path)
+
+
+def test_load_results_requires_benchmarks_array(tmp_path) -> None:
+    path = tmp_path / "results.json"
+    path.write_text("{}", encoding="utf-8")
+    with pytest.raises(BenchmarkDataError, match="'benchmarks' array"):
+        load_results(path)
+
+
+def test_load_results_rejects_missing_file(tmp_path) -> None:
+    with pytest.raises(BenchmarkDataError, match="cannot read"):
+        load_results(tmp_path / "missing.json")
+
+
+def test_zero_baseline_skips_ratio_check(tmp_path, capsys: pytest.CaptureFixture[str]) -> None:
+    results = tmp_path / "results.json"
+    baselines = tmp_path / "baselines.json"
+    _write_results(
+        results,
+        [{"name": GATED_BENCH, "stats": {"mean": 0.00025}}],
+    )
+    _write_baselines(
+        baselines,
+        {"summary-cache": {GATED_BENCH: 0.0}},
+    )
+
+    assert check_regression(results, baselines) == 0
+    assert f"baseline for '{GATED_BENCH}' is zero" in capsys.readouterr().out
+
+
+def test_exactly_at_threshold_passes(tmp_path) -> None:
+    results = tmp_path / "results.json"
+    baselines = tmp_path / "baselines.json"
+    _write_results(
+        results,
+        [{"name": GATED_BENCH, "stats": {"mean": 0.00024}}],
+    )
+    _write_baselines(
+        baselines,
+        {"summary-cache": {GATED_BENCH: 0.0002}},
+    )
+
+    assert check_regression(results, baselines) == 0
+
+
+def test_missing_current_result_fails(tmp_path, capsys: pytest.CaptureFixture[str]) -> None:
+    results = tmp_path / "results.json"
+    baselines = tmp_path / "baselines.json"
+    _write_results(results, [])
+    _write_baselines(
+        baselines,
+        {"summary-cache": {GATED_BENCH: 0.0002}},
+    )
+
+    assert check_regression(results, baselines) == 1
+    out = capsys.readouterr().out
+    assert "MISSING" in out
+    assert "no current result for gated baseline" in out
+
+
+def test_main_reports_benchmark_data_error(tmp_path, capsys: pytest.CaptureFixture[str]) -> None:
+    from scripts.check_benchmark_regression import main
+
+    bad = tmp_path / "bad.json"
+    bad.write_text("{}", encoding="utf-8")
+    baselines = tmp_path / "baselines.json"
+    _write_baselines(baselines, {"summary-cache": {GATED_BENCH: 0.0002}})
+
+    assert main([str(bad), str(baselines)]) == 2
+    assert "ERROR:" in capsys.readouterr().err
+
+
+def test_duplicate_baseline_name_raises(tmp_path) -> None:
+    baselines = tmp_path / "baselines.json"
+    _write_baselines(
+        baselines,
+        {
+            "summary-cache": {GATED_BENCH: 0.0002},
+            "export": {GATED_BENCH: 0.0003},
+        },
+    )
+
+    with pytest.raises(BenchmarkDataError, match="duplicate benchmark name"):
+        load_baseline_means(baselines)
+
+
+def test_load_baseline_means_rejects_non_dict_group(tmp_path) -> None:
+    baselines = tmp_path / "baselines.json"
+    baselines.write_text(
+        json.dumps({"groups": {"summary-cache": "not-a-dict"}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(BenchmarkDataError, match="must be an object"):
+        load_baseline_means(baselines)


### PR DESCRIPTION
Closes #115 

## Summary

Adds a `pytest-benchmark` suite for `services/summary_cache.py` with synthetic fixtures and a CI regression gate. No production code changes.

- New `tests/benchmarks/test_summary_cache_bench.py` measures cache hit, cache miss, fingerprint cost (10/50/200 workspace entries), and round-trip write+read latency
- New `tests/benchmarks/conftest.py` builds synthetic workspace trees and isolates cache files to temp dirs (no real Cursor storage)
- `benchmarks/baselines.json` records initial gated means (1.5× slack from local reference run; refresh from ubuntu-latest CI artifact after first green job)
- `scripts/check_benchmark_regression.py` fails CI when any benchmark mean exceeds baseline by >20%
- `pyproject.toml`: add `pytest-benchmark` dev dep; default `--benchmark-skip` so normal `pytest` stays fast
- `.github/workflows/tests.yml`: new `benchmarks` job on ubuntu-latest

Sprint item **#7** (June Week 4, Wednesday). Sequences before Thursday **#8** (unified perf benchmark suite).

## Test plan

- [ ] `pytest tests/benchmarks/test_summary_cache_bench.py --benchmark-only -o addopts=`
- [ ] `python scripts/check_benchmark_regression.py benchmark-results.json benchmarks/baselines.json`
- [ ] `pytest tests/benchmarks/test_summary_cache_bench.py -o addopts=` (benchmarks skipped via `--benchmark-skip`)
- [ ] `python -m unittest discover tests -q`
- [ ] Confirm `benchmarks` CI job is green on ubuntu-latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI performance benchmarking for summary-cache (cache hit/miss, workspace fingerprinting, and cache round-trips).
* **Bug Fixes**
  * Updated test execution to avoid inheriting unrelated pytest options.
* **Chores**
  * Introduced a benchmark regression gate with updated baselines and CI artifact handling; refreshed benchmark baseline data and ignored generated benchmark outputs.
  * Enabled `pytest-benchmark` in dev tooling and configured pytest benchmark defaults.
* **Tests**
  * Added new benchmark test coverage and a dedicated unit test suite for the regression gate logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->