### PR TITLE
refactor: trim over-broad models/init.py exports

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,4 +1,4 @@
-from models.bubble_display import BubbleMetadata, BubbleRole, DisplayBubble
+from models.bubble_display import DisplayBubble
 from models.cli_session import CliSessionMeta
 from models.conversation import Bubble, Composer, Conversation, WorkspaceLocalComposer
 from models.errors import SchemaError
@@ -9,8 +9,6 @@ from models.workspace import Workspace
 
 __all__ = [
     "Bubble",
-    "BubbleMetadata",
-    "BubbleRole",
     "CliSessionMeta",
     "DisplayBubble",
     "Composer",

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -26,13 +26,12 @@ from utils.text_extract import extract_text_from_bubble
 from utils.workspace_descriptor import read_json_file
 from models import (
     Bubble,
-    BubbleMetadata,
-    BubbleRole,
     Composer,
     DisplayBubble,
     ParseWarningCollector,
     SchemaError,
 )
+from models.bubble_display import BubbleMetadata, BubbleRole
 from models.raw_access import (
     conversation_header_bubble_id,
     message_request_context_project_layouts,

--- a/utils/cursor_md_exporter.py
+++ b/utils/cursor_md_exporter.py
@@ -21,7 +21,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from models import Bubble, BubbleRole, DisplayBubble
+from models import Bubble, DisplayBubble
+from models.bubble_display import BubbleRole
 from utils.cli_chat_reader import traverse_blobs, messages_to_bubbles
 from utils.display_bubble import (
     annotate_response_times,

--- a/utils/display_bubble.py
+++ b/utils/display_bubble.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, cast
 
-from models import Bubble, BubbleMetadata, BubbleRole, DisplayBubble
+from models import Bubble, DisplayBubble
+from models.bubble_display import BubbleMetadata, BubbleRole
 from utils.path_helpers import to_epoch_ms
 from utils.text_extract import extract_text_from_bubble
 from utils.tool_parser import parse_tool_call


### PR DESCRIPTION
Closes #131

models/__init__.py still exported BubbleRole and BubbleMetadata from models.bubble_display, even though they are low-level typed dict / literal types, not domain models. pr #118 dropped one test-only re-export; this finishes the trim so the package surface is Bubble, Composer, Workspace, SearchResult, SchemaError, and the rest of the domain types.

this pr removes BubbleRole and BubbleMetadata from __all__ (15 names down to 13) and repoints the three in-repo callers to from models.bubble_display import .... DisplayBubble stays on the public models surface. no code moves, no runtime change.

to verify, run pytest -q and mypy --strict .. from models import BubbleRole should raise ImportError; from models.bubble_display import BubbleRole should work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted how bubble-related metadata and role types are imported within the project to better align with their dedicated locations.
  * Reduced package-level public exports for bubble metadata and role types.
  * Retained existing application behavior and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->