### PR TITLE
fix: serialise summary-cache fingerprint read-compare-write under a module lock

### DIFF
--- a/services/export_engine.py
+++ b/services/export_engine.py
@@ -12,7 +12,7 @@ from typing import Any, Literal
 
 from models import Bubble
 from models.export import CollectedExportEntry
-from services.summary_cache import fingerprint_workspace_storage, nocache_enabled
+from services.summary_cache import nocache_enabled
 from services.workspace_context import (
     WorkspaceContext,
     enrich_workspace_context_from_global_db,
@@ -22,7 +22,6 @@ from services.workspace_context import (
 from services.workspace_db import (
     COMPOSER_ROWS_WITH_HEADERS_SQL,
     collect_workspace_entries,
-    global_storage_db_path,
     load_code_block_diff_map,
     open_global_db,
     safe_fetchall,
@@ -84,7 +83,6 @@ class WorkspaceOrchestration:
 
     workspace_path: str
     workspace_entries: list[dict[str, Any]]
-    fingerprint: dict[str, Any]
     ctx: WorkspaceContext
     workspace_id_to_display_name: dict[str, str]
     workspace_id_to_slug: dict[str, str]
@@ -135,20 +133,11 @@ def prepare_workspace_orchestration(
     nocache: bool = False,
     workspace_entries: list[dict[str, Any]] | None = None,
 ) -> WorkspaceOrchestration:
-    """Scan workspace storage and resolve maps (with summary-cache fingerprint)."""
+    """Scan workspace storage and resolve maps for listing and export."""
     entries = (
         workspace_entries
         if workspace_entries is not None
         else collect_workspace_entries(workspace_path)
-    )
-    gdb = global_storage_db_path(workspace_path)
-    cli_path = get_cli_chats_path()
-    fingerprint = fingerprint_workspace_storage(
-        workspace_path,
-        entries,
-        global_db_path=gdb if os.path.isfile(gdb) else None,
-        rules=rules,
-        cli_chats_path=cli_path if os.path.isdir(cli_path) else None,
     )
     ctx = resolve_workspace_context_cached(
         workspace_path,
@@ -160,7 +149,6 @@ def prepare_workspace_orchestration(
     return WorkspaceOrchestration(
         workspace_path=workspace_path,
         workspace_entries=entries,
-        fingerprint=fingerprint,
         ctx=ctx,
         workspace_id_to_display_name=display_name,
         workspace_id_to_slug=slug_map,

--- a/services/search_index.py
+++ b/services/search_index.py
@@ -29,8 +29,8 @@ from services.search import (
 )
 from services.summary_cache import (
     CACHE_DIR,
-    fingerprint_workspace_storage,
     nocache_enabled,
+    workspace_storage_fingerprint,
 )
 from services.workspace_db import (
     COMPOSER_ROWS_WITH_HEADERS_SQL,
@@ -40,7 +40,6 @@ from services.workspace_db import (
 )
 from utils.path_helpers import to_epoch_ms
 from utils.exclusion_rules import RuleTokens
-from utils.workspace_path import get_cli_chats_path
 
 __all__ = [
     "SEARCH_INDEX_FILE",
@@ -130,15 +129,7 @@ def index_search_enabled() -> bool:
 
 def _storage_fingerprint(workspace_path: str, rules: list[RuleTokens]) -> dict[str, Any]:
     entries = collect_workspace_entries(workspace_path)
-    gdb = global_storage_db_path(workspace_path)
-    cli_path = get_cli_chats_path()
-    return fingerprint_workspace_storage(
-        workspace_path,
-        entries,
-        global_db_path=gdb if os.path.isfile(gdb) else None,
-        rules=rules,
-        cli_chats_path=cli_path if os.path.isdir(cli_path) else None,
-    )
+    return workspace_storage_fingerprint(workspace_path, entries, rules)
 
 
 def _open_index_db(*, readonly: bool = True) -> sqlite3.Connection | None:

--- a/services/summary_cache.py
+++ b/services/summary_cache.py
@@ -17,7 +17,7 @@ import threading
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 from utils.exclusion_rules import RuleTokens
 
@@ -33,6 +33,8 @@ PROJECTS_CACHE_FILE = CACHE_DIR / "projects.json"
 COMPOSER_MAP_CACHE_FILE = CACHE_DIR / "composer-id-to-ws.json"
 INVALID_WORKSPACE_ALIASES_CACHE_FILE = CACHE_DIR / "invalid-workspace-aliases.json"
 TAB_SUMMARIES_PREFIX = "tab-summaries-"
+
+T = TypeVar("T")
 
 
 def nocache_enabled(*, request_nocache: bool = False) -> bool:
@@ -166,11 +168,6 @@ def _read_cache_file_unlocked(path: Path | str) -> dict[str, Any] | None:
         return None
 
 
-def _read_cache_file(path: Path | str) -> dict[str, Any] | None:
-    with _summary_cache_lock:
-        return _read_cache_file_unlocked(path)
-
-
 def _write_cache_file_unlocked(path: Path | str, payload: dict[str, Any]) -> None:
     p = Path(path)
     try:
@@ -252,6 +249,34 @@ def set_cached_projects(
         _set_cached_projects_unlocked(fingerprint, projects, warnings)
 
 
+def _get_or_build_cached(
+    workspace_path: str,
+    workspace_entries: list[dict[str, Any]],
+    rules: list[RuleTokens],
+    *,
+    build_fn: Callable[[], T],
+    get_unlocked: Callable[[dict[str, Any]], T | None],
+    set_unlocked: Callable[[dict[str, Any], T], None],
+    should_cache: Callable[[T], bool] | None = None,
+) -> T:
+    with _summary_cache_lock:
+        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
+        hit = get_unlocked(fingerprint)
+        if hit is not None:
+            return hit
+
+    built = build_fn()
+
+    with _summary_cache_lock:
+        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
+        hit = get_unlocked(fingerprint)
+        if hit is not None:
+            return hit
+        if should_cache is None or should_cache(built):
+            set_unlocked(fingerprint, built)
+    return built
+
+
 def get_or_build_cached_projects(
     workspace_path: str,
     workspace_entries: list[dict[str, Any]],
@@ -260,21 +285,14 @@ def get_or_build_cached_projects(
     build_fn: Callable[[], tuple[list[dict[str, Any]], list[dict[str, Any]]]],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Return cached projects or build once under double-checked locking."""
-    with _summary_cache_lock:
-        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
-        hit = _get_cached_projects_unlocked(fingerprint)
-        if hit is not None:
-            return hit
-
-    built = build_fn()
-
-    with _summary_cache_lock:
-        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
-        hit = _get_cached_projects_unlocked(fingerprint)
-        if hit is not None:
-            return hit
-        _set_cached_projects_unlocked(fingerprint, built[0], built[1])
-    return built
+    return _get_or_build_cached(
+        workspace_path,
+        workspace_entries,
+        rules,
+        build_fn=build_fn,
+        get_unlocked=_get_cached_projects_unlocked,
+        set_unlocked=lambda fp, built: _set_cached_projects_unlocked(fp, built[0], built[1]),
+    )
 
 
 def _get_cached_composer_id_to_ws_unlocked(
@@ -341,21 +359,14 @@ def get_or_build_cached_composer_id_to_ws(
     build_fn: Callable[[], dict[str, str]],
 ) -> dict[str, str]:
     """Return cached composer map or build once under double-checked locking."""
-    with _summary_cache_lock:
-        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
-        hit = _get_cached_composer_id_to_ws_unlocked(fingerprint)
-        if hit is not None:
-            return hit
-
-    built = build_fn()
-
-    with _summary_cache_lock:
-        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
-        hit = _get_cached_composer_id_to_ws_unlocked(fingerprint)
-        if hit is not None:
-            return hit
-        _set_cached_composer_id_to_ws_unlocked(fingerprint, built)
-    return built
+    return _get_or_build_cached(
+        workspace_path,
+        workspace_entries,
+        rules,
+        build_fn=build_fn,
+        get_unlocked=_get_cached_composer_id_to_ws_unlocked,
+        set_unlocked=_set_cached_composer_id_to_ws_unlocked,
+    )
 
 
 def _get_cached_invalid_workspace_aliases_unlocked(
@@ -435,21 +446,14 @@ def get_or_build_cached_invalid_workspace_aliases(
     build_fn: Callable[[], dict[str, str]],
 ) -> dict[str, str]:
     """Return cached alias map or build once under double-checked locking."""
-    with _summary_cache_lock:
-        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
-        hit = _get_cached_invalid_workspace_aliases_unlocked(fingerprint)
-        if hit is not None:
-            return hit
-
-    built = build_fn()
-
-    with _summary_cache_lock:
-        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
-        hit = _get_cached_invalid_workspace_aliases_unlocked(fingerprint)
-        if hit is not None:
-            return hit
-        _set_cached_invalid_workspace_aliases_unlocked(fingerprint, built)
-    return built
+    return _get_or_build_cached(
+        workspace_path,
+        workspace_entries,
+        rules,
+        build_fn=build_fn,
+        get_unlocked=_get_cached_invalid_workspace_aliases_unlocked,
+        set_unlocked=_set_cached_invalid_workspace_aliases_unlocked,
+    )
 
 
 def _tab_summaries_path(workspace_id: str) -> Path:
@@ -536,19 +540,14 @@ def get_or_build_cached_tab_summaries(
     build_fn: Callable[[], tuple[dict[str, Any], int]],
 ) -> tuple[dict[str, Any], int]:
     """Return cached tab summaries or build once under double-checked locking."""
-    with _summary_cache_lock:
-        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
-        hit = _get_cached_tab_summaries_unlocked(fingerprint, workspace_id)
-        if hit is not None:
-            return hit
-
-    payload, status = build_fn()
-
-    with _summary_cache_lock:
-        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
-        hit = _get_cached_tab_summaries_unlocked(fingerprint, workspace_id)
-        if hit is not None:
-            return hit
-        if status == 200:
-            _set_cached_tab_summaries_unlocked(fingerprint, workspace_id, payload, status)
-    return payload, status
+    return _get_or_build_cached(
+        workspace_path,
+        workspace_entries,
+        rules,
+        build_fn=build_fn,
+        get_unlocked=lambda fp: _get_cached_tab_summaries_unlocked(fp, workspace_id),
+        set_unlocked=lambda fp, built: _set_cached_tab_summaries_unlocked(
+            fp, workspace_id, built[0], built[1],
+        ),
+        should_cache=lambda built: built[1] == 200,
+    )

--- a/services/summary_cache.py
+++ b/services/summary_cache.py
@@ -115,7 +115,7 @@ def fingerprint_workspace_storage(
     }
 
 
-def _workspace_storage_fingerprint(
+def workspace_storage_fingerprint(
     workspace_path: str,
     workspace_entries: list[dict[str, Any]],
     rules: list[RuleTokens],
@@ -260,20 +260,25 @@ def _get_or_build_cached(
     should_cache: Callable[[T], bool] | None = None,
 ) -> T:
     with _summary_cache_lock:
-        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
-        hit = get_unlocked(fingerprint)
+        pre_fingerprint = workspace_storage_fingerprint(
+            workspace_path, workspace_entries, rules,
+        )
+        hit = get_unlocked(pre_fingerprint)
         if hit is not None:
             return hit
 
     built = build_fn()
 
     with _summary_cache_lock:
-        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
-        hit = get_unlocked(fingerprint)
+        post_fingerprint = workspace_storage_fingerprint(
+            workspace_path, workspace_entries, rules,
+        )
+        hit = get_unlocked(post_fingerprint)
         if hit is not None:
             return hit
         if should_cache is None or should_cache(built):
-            set_unlocked(fingerprint, built)
+            if _fingerprint_equal(pre_fingerprint, post_fingerprint):
+                set_unlocked(pre_fingerprint, built)
     return built
 
 

--- a/services/summary_cache.py
+++ b/services/summary_cache.py
@@ -13,6 +13,8 @@ import hashlib
 import json
 import logging
 import os
+import threading
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
@@ -20,6 +22,10 @@ from typing import Any
 from utils.exclusion_rules import RuleTokens
 
 _logger = logging.getLogger(__name__)
+
+# Serialises fingerprint compute, cache read-compare, and cache write so threaded
+# WSGI workers cannot lost-update a peer's fresh cache entry (see design guide).
+_summary_cache_lock = threading.Lock()
 
 CACHE_VERSION = 1
 CACHE_DIR = Path.home() / ".cache" / "cursor-chat-browser"
@@ -107,6 +113,26 @@ def fingerprint_workspace_storage(
     }
 
 
+def _workspace_storage_fingerprint(
+    workspace_path: str,
+    workspace_entries: list[dict[str, Any]],
+    rules: list[RuleTokens],
+) -> dict[str, Any]:
+    """Fingerprint workspace storage, resolving global-db and cli-chats paths."""
+    from services.workspace_db import global_storage_db_path
+    from utils.workspace_path import get_cli_chats_path
+
+    gdb = global_storage_db_path(workspace_path)
+    cli_path = get_cli_chats_path()
+    return fingerprint_workspace_storage(
+        workspace_path,
+        workspace_entries,
+        global_db_path=gdb if os.path.isfile(gdb) else None,
+        rules=rules,
+        cli_chats_path=cli_path if os.path.isdir(cli_path) else None,
+    )
+
+
 def _normalize_fingerprint(fp: dict[str, Any]) -> dict[str, Any]:
     """Normalize fingerprint for comparison (JSON round-trip uses lists, not tuples)."""
     normalized = dict(fp)
@@ -125,7 +151,7 @@ def _fingerprint_equal(a: object, b: dict[str, Any]) -> bool:
     return _normalize_fingerprint(a) == _normalize_fingerprint(b)
 
 
-def _read_cache_file(path: Path | str) -> dict[str, Any] | None:
+def _read_cache_file_unlocked(path: Path | str) -> dict[str, Any] | None:
     p = Path(path)
     if not p.is_file():
         return None
@@ -140,7 +166,12 @@ def _read_cache_file(path: Path | str) -> dict[str, Any] | None:
         return None
 
 
-def _write_cache_file(path: Path | str, payload: dict[str, Any]) -> None:
+def _read_cache_file(path: Path | str) -> dict[str, Any] | None:
+    with _summary_cache_lock:
+        return _read_cache_file_unlocked(path)
+
+
+def _write_cache_file_unlocked(path: Path | str, payload: dict[str, Any]) -> None:
     p = Path(path)
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -150,6 +181,28 @@ def _write_cache_file(path: Path | str, payload: dict[str, Any]) -> None:
         tmp.replace(p)
     except OSError as e:
         _logger.warning("Summary cache write failed for %s: %s", path, e)
+
+
+def _write_cache_file(path: Path | str, payload: dict[str, Any]) -> None:
+    with _summary_cache_lock:
+        _write_cache_file_unlocked(path, payload)
+
+
+def _get_cached_projects_unlocked(
+    fingerprint: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]] | None:
+    data = _read_cache_file_unlocked(PROJECTS_CACHE_FILE)
+    if not data:
+        return None
+    if not _fingerprint_equal(data.get("fingerprint"), fingerprint):
+        return None
+    projects = data.get("projects")
+    warnings = data.get("warnings")
+    if not isinstance(projects, list):
+        return None
+    if not isinstance(warnings, list):
+        warnings = []
+    return projects, warnings
 
 
 def get_cached_projects(
@@ -164,18 +217,23 @@ def get_cached_projects(
     Returns:
         ``(projects, warnings)`` on hit, else ``None``.
     """
-    data = _read_cache_file(PROJECTS_CACHE_FILE)
-    if not data:
-        return None
-    if not _fingerprint_equal(data.get("fingerprint"), fingerprint):
-        return None
-    projects = data.get("projects")
-    warnings = data.get("warnings")
-    if not isinstance(projects, list):
-        return None
-    if not isinstance(warnings, list):
-        warnings = []
-    return projects, warnings
+    with _summary_cache_lock:
+        return _get_cached_projects_unlocked(fingerprint)
+
+
+def _set_cached_projects_unlocked(
+    fingerprint: dict[str, Any],
+    projects: list[dict[str, Any]],
+    warnings: list[dict[str, Any]],
+) -> None:
+    _write_cache_file_unlocked(
+        PROJECTS_CACHE_FILE,
+        {
+            "fingerprint": fingerprint,
+            "projects": projects,
+            "warnings": warnings,
+        },
+    )
 
 
 def set_cached_projects(
@@ -190,14 +248,47 @@ def set_cached_projects(
         projects: Sidebar project dicts.
         warnings: Parse warnings emitted while building *projects*.
     """
-    _write_cache_file(
-        PROJECTS_CACHE_FILE,
-        {
-            "fingerprint": fingerprint,
-            "projects": projects,
-            "warnings": warnings,
-        },
-    )
+    with _summary_cache_lock:
+        _set_cached_projects_unlocked(fingerprint, projects, warnings)
+
+
+def get_or_build_cached_projects(
+    workspace_path: str,
+    workspace_entries: list[dict[str, Any]],
+    rules: list[RuleTokens],
+    *,
+    build_fn: Callable[[], tuple[list[dict[str, Any]], list[dict[str, Any]]]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return cached projects or build once under double-checked locking."""
+    with _summary_cache_lock:
+        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
+        hit = _get_cached_projects_unlocked(fingerprint)
+        if hit is not None:
+            return hit
+
+    built = build_fn()
+
+    with _summary_cache_lock:
+        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
+        hit = _get_cached_projects_unlocked(fingerprint)
+        if hit is not None:
+            return hit
+        _set_cached_projects_unlocked(fingerprint, built[0], built[1])
+    return built
+
+
+def _get_cached_composer_id_to_ws_unlocked(
+    fingerprint: dict[str, Any],
+) -> dict[str, str] | None:
+    data = _read_cache_file_unlocked(COMPOSER_MAP_CACHE_FILE)
+    if not data:
+        return None
+    if not _fingerprint_equal(data.get("fingerprint"), fingerprint):
+        return None
+    mapping = data.get("composer_id_to_ws")
+    if not isinstance(mapping, dict):
+        return None
+    return {str(k): str(v) for k, v in mapping.items()}
 
 
 def get_cached_composer_id_to_ws(
@@ -211,15 +302,21 @@ def get_cached_composer_id_to_ws(
     Returns:
         Mapping on hit, else ``None``.
     """
-    data = _read_cache_file(COMPOSER_MAP_CACHE_FILE)
-    if not data:
-        return None
-    if not _fingerprint_equal(data.get("fingerprint"), fingerprint):
-        return None
-    mapping = data.get("composer_id_to_ws")
-    if not isinstance(mapping, dict):
-        return None
-    return {str(k): str(v) for k, v in mapping.items()}
+    with _summary_cache_lock:
+        return _get_cached_composer_id_to_ws_unlocked(fingerprint)
+
+
+def _set_cached_composer_id_to_ws_unlocked(
+    fingerprint: dict[str, Any],
+    mapping: dict[str, str],
+) -> None:
+    _write_cache_file_unlocked(
+        COMPOSER_MAP_CACHE_FILE,
+        {
+            "fingerprint": fingerprint,
+            "composer_id_to_ws": mapping,
+        },
+    )
 
 
 def set_cached_composer_id_to_ws(
@@ -232,27 +329,39 @@ def set_cached_composer_id_to_ws(
         fingerprint: Invalidation fingerprint paired with *mapping*.
         mapping: Composer UUID to workspace folder name.
     """
-    _write_cache_file(
-        COMPOSER_MAP_CACHE_FILE,
-        {
-            "fingerprint": fingerprint,
-            "composer_id_to_ws": mapping,
-        },
-    )
+    with _summary_cache_lock:
+        _set_cached_composer_id_to_ws_unlocked(fingerprint, mapping)
 
 
-def get_cached_invalid_workspace_aliases(
+def get_or_build_cached_composer_id_to_ws(
+    workspace_path: str,
+    workspace_entries: list[dict[str, Any]],
+    rules: list[RuleTokens],
+    *,
+    build_fn: Callable[[], dict[str, str]],
+) -> dict[str, str]:
+    """Return cached composer map or build once under double-checked locking."""
+    with _summary_cache_lock:
+        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
+        hit = _get_cached_composer_id_to_ws_unlocked(fingerprint)
+        if hit is not None:
+            return hit
+
+    built = build_fn()
+
+    with _summary_cache_lock:
+        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
+        hit = _get_cached_composer_id_to_ws_unlocked(fingerprint)
+        if hit is not None:
+            return hit
+        _set_cached_composer_id_to_ws_unlocked(fingerprint, built)
+    return built
+
+
+def _get_cached_invalid_workspace_aliases_unlocked(
     fingerprint: dict[str, Any],
 ) -> dict[str, str] | None:
-    """Load cached invalid-workspace alias map when the fingerprint matches.
-
-    Args:
-        fingerprint: Storage mtime/rules digest.
-
-    Returns:
-        ``{invalid_id: replacement_id}`` on hit, else ``None``.
-    """
-    data = _read_cache_file(INVALID_WORKSPACE_ALIASES_CACHE_FILE)
+    data = _read_cache_file_unlocked(INVALID_WORKSPACE_ALIASES_CACHE_FILE)
     if not data:
         return None
     if not _fingerprint_equal(data.get("fingerprint"), fingerprint):
@@ -276,6 +385,34 @@ def get_cached_invalid_workspace_aliases(
     return validated
 
 
+def get_cached_invalid_workspace_aliases(
+    fingerprint: dict[str, Any],
+) -> dict[str, str] | None:
+    """Load cached invalid-workspace alias map when the fingerprint matches.
+
+    Args:
+        fingerprint: Storage mtime/rules digest.
+
+    Returns:
+        ``{invalid_id: replacement_id}`` on hit, else ``None``.
+    """
+    with _summary_cache_lock:
+        return _get_cached_invalid_workspace_aliases_unlocked(fingerprint)
+
+
+def _set_cached_invalid_workspace_aliases_unlocked(
+    fingerprint: dict[str, Any],
+    aliases: dict[str, str],
+) -> None:
+    _write_cache_file_unlocked(
+        INVALID_WORKSPACE_ALIASES_CACHE_FILE,
+        {
+            "fingerprint": fingerprint,
+            "invalid_workspace_aliases": aliases,
+        },
+    )
+
+
 def set_cached_invalid_workspace_aliases(
     fingerprint: dict[str, Any],
     aliases: dict[str, str],
@@ -286,18 +423,56 @@ def set_cached_invalid_workspace_aliases(
         fingerprint: Invalidation fingerprint paired with *aliases*.
         aliases: ``{invalid_id: replacement_id}`` from alias inference.
     """
-    _write_cache_file(
-        INVALID_WORKSPACE_ALIASES_CACHE_FILE,
-        {
-            "fingerprint": fingerprint,
-            "invalid_workspace_aliases": aliases,
-        },
-    )
+    with _summary_cache_lock:
+        _set_cached_invalid_workspace_aliases_unlocked(fingerprint, aliases)
+
+
+def get_or_build_cached_invalid_workspace_aliases(
+    workspace_path: str,
+    workspace_entries: list[dict[str, Any]],
+    rules: list[RuleTokens],
+    *,
+    build_fn: Callable[[], dict[str, str]],
+) -> dict[str, str]:
+    """Return cached alias map or build once under double-checked locking."""
+    with _summary_cache_lock:
+        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
+        hit = _get_cached_invalid_workspace_aliases_unlocked(fingerprint)
+        if hit is not None:
+            return hit
+
+    built = build_fn()
+
+    with _summary_cache_lock:
+        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
+        hit = _get_cached_invalid_workspace_aliases_unlocked(fingerprint)
+        if hit is not None:
+            return hit
+        _set_cached_invalid_workspace_aliases_unlocked(fingerprint, built)
+    return built
 
 
 def _tab_summaries_path(workspace_id: str) -> Path:
     safe = hashlib.sha256(workspace_id.encode("utf-8")).hexdigest()[:16]
     return CACHE_DIR / f"{TAB_SUMMARIES_PREFIX}{safe}.json"
+
+
+def _get_cached_tab_summaries_unlocked(
+    fingerprint: dict[str, Any],
+    workspace_id: str,
+) -> tuple[dict[str, Any], int] | None:
+    data = _read_cache_file_unlocked(_tab_summaries_path(workspace_id))
+    if not data:
+        return None
+    if data.get("workspace_id") != workspace_id:
+        return None
+    if not _fingerprint_equal(data.get("fingerprint"), fingerprint):
+        return None
+    payload = data.get("payload")
+    status = data.get("status", 200)
+    if not isinstance(payload, dict) or not isinstance(status, int):
+        return None
+    return payload, status
 
 
 def get_cached_tab_summaries(
@@ -313,18 +488,25 @@ def get_cached_tab_summaries(
     Returns:
         ``(payload, status)`` on hit, else ``None``.
     """
-    data = _read_cache_file(_tab_summaries_path(workspace_id))
-    if not data:
-        return None
-    if data.get("workspace_id") != workspace_id:
-        return None
-    if not _fingerprint_equal(data.get("fingerprint"), fingerprint):
-        return None
-    payload = data.get("payload")
-    status = data.get("status", 200)
-    if not isinstance(payload, dict) or not isinstance(status, int):
-        return None
-    return payload, status
+    with _summary_cache_lock:
+        return _get_cached_tab_summaries_unlocked(fingerprint, workspace_id)
+
+
+def _set_cached_tab_summaries_unlocked(
+    fingerprint: dict[str, Any],
+    workspace_id: str,
+    payload: dict[str, Any],
+    status: int,
+) -> None:
+    _write_cache_file_unlocked(
+        _tab_summaries_path(workspace_id),
+        {
+            "workspace_id": workspace_id,
+            "fingerprint": fingerprint,
+            "payload": payload,
+            "status": status,
+        },
+    )
 
 
 def set_cached_tab_summaries(
@@ -341,12 +523,32 @@ def set_cached_tab_summaries(
         payload: JSON body returned to clients.
         status: HTTP status code paired with *payload*.
     """
-    _write_cache_file(
-        _tab_summaries_path(workspace_id),
-        {
-            "workspace_id": workspace_id,
-            "fingerprint": fingerprint,
-            "payload": payload,
-            "status": status,
-        },
-    )
+    with _summary_cache_lock:
+        _set_cached_tab_summaries_unlocked(fingerprint, workspace_id, payload, status)
+
+
+def get_or_build_cached_tab_summaries(
+    workspace_path: str,
+    workspace_entries: list[dict[str, Any]],
+    rules: list[RuleTokens],
+    workspace_id: str,
+    *,
+    build_fn: Callable[[], tuple[dict[str, Any], int]],
+) -> tuple[dict[str, Any], int]:
+    """Return cached tab summaries or build once under double-checked locking."""
+    with _summary_cache_lock:
+        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
+        hit = _get_cached_tab_summaries_unlocked(fingerprint, workspace_id)
+        if hit is not None:
+            return hit
+
+    payload, status = build_fn()
+
+    with _summary_cache_lock:
+        fingerprint = _workspace_storage_fingerprint(workspace_path, workspace_entries, rules)
+        hit = _get_cached_tab_summaries_unlocked(fingerprint, workspace_id)
+        if hit is not None:
+            return hit
+        if status == 200:
+            _set_cached_tab_summaries_unlocked(fingerprint, workspace_id, payload, status)
+    return payload, status

--- a/services/workspace_context.py
+++ b/services/workspace_context.py
@@ -179,46 +179,37 @@ def resolve_invalid_workspace_aliases_cached(
         return {}
 
     from services.summary_cache import (
-        fingerprint_workspace_storage,
-        get_cached_invalid_workspace_aliases,
+        get_or_build_cached_invalid_workspace_aliases,
         nocache_enabled,
-        set_cached_invalid_workspace_aliases,
     )
-    from utils.workspace_path import get_cli_chats_path
 
-    gdb = global_storage_db_path(workspace_path)
-    cli_path = get_cli_chats_path()
-    fingerprint = fingerprint_workspace_storage(
+    def build() -> dict[str, str]:
+        layouts = (
+            project_layouts_map
+            if project_layouts_map is not None
+            else load_project_layouts_map(global_db)
+        )
+        composer_rows = safe_fetchall(global_db, COMPOSER_ROWS_WITH_HEADERS_SQL)
+        return infer_invalid_workspace_aliases(
+            composer_rows=composer_rows,
+            project_layouts_map=layouts,
+            project_name_map=ctx.project_name_to_workspace_id,
+            workspace_path_map=ctx.workspace_path_to_id,
+            workspace_entries=ctx.workspace_entries,
+            bubble_map={},
+            composer_id_to_ws=ctx.composer_id_to_workspace_id,
+            invalid_workspace_ids=ctx.invalid_workspace_ids,
+        )
+
+    if nocache_enabled(request_nocache=nocache):
+        return build()
+
+    return get_or_build_cached_invalid_workspace_aliases(
         workspace_path,
         ctx.workspace_entries,
-        global_db_path=gdb if os.path.isfile(gdb) else None,
-        rules=rules,
-        cli_chats_path=cli_path if os.path.isdir(cli_path) else None,
+        rules,
+        build_fn=build,
     )
-    if not nocache_enabled(request_nocache=nocache):
-        cached = get_cached_invalid_workspace_aliases(fingerprint)
-        if cached is not None:
-            return cached
-
-    layouts = (
-        project_layouts_map
-        if project_layouts_map is not None
-        else load_project_layouts_map(global_db)
-    )
-    composer_rows = safe_fetchall(global_db, COMPOSER_ROWS_WITH_HEADERS_SQL)
-    aliases = infer_invalid_workspace_aliases(
-        composer_rows=composer_rows,
-        project_layouts_map=layouts,
-        project_name_map=ctx.project_name_to_workspace_id,
-        workspace_path_map=ctx.workspace_path_to_id,
-        workspace_entries=ctx.workspace_entries,
-        bubble_map={},
-        composer_id_to_ws=ctx.composer_id_to_workspace_id,
-        invalid_workspace_ids=ctx.invalid_workspace_ids,
-    )
-    if not nocache_enabled(request_nocache=nocache):
-        set_cached_invalid_workspace_aliases(fingerprint, aliases)
-    return aliases
 
 
 def with_invalid_workspace_aliases(

--- a/services/workspace_context.py
+++ b/services/workspace_context.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import sqlite3
 from dataclasses import dataclass, replace
 from typing import Any
@@ -16,7 +15,6 @@ from services.workspace_db import (
     build_composer_id_to_workspace_id_cached,
     collect_invalid_workspace_ids,
     collect_workspace_entries,
-    global_storage_db_path,
     load_bubble_map,
     load_project_layouts_map,
     safe_fetchall,

--- a/services/workspace_db.py
+++ b/services/workspace_db.py
@@ -440,11 +440,11 @@ def build_composer_id_to_workspace_id_cached(
         nocache_enabled,
     )
 
-    if nocache_enabled(request_nocache=nocache):
-        return build_composer_id_to_workspace_id(workspace_path, workspace_entries)
-
     def build() -> dict[str, str]:
         return build_composer_id_to_workspace_id(workspace_path, workspace_entries)
+
+    if nocache_enabled(request_nocache=nocache):
+        return build()
 
     return get_or_build_cached_composer_id_to_ws(
         workspace_path,

--- a/services/workspace_db.py
+++ b/services/workspace_db.py
@@ -436,30 +436,22 @@ def build_composer_id_to_workspace_id_cached(
 ) -> dict[str, str]:
     """Like :func:`build_composer_id_to_workspace_id` with optional disk cache."""
     from services.summary_cache import (
-        fingerprint_workspace_storage,
-        get_cached_composer_id_to_ws,
+        get_or_build_cached_composer_id_to_ws,
         nocache_enabled,
-        set_cached_composer_id_to_ws,
     )
-    from utils.workspace_path import get_cli_chats_path
 
-    gdb = global_storage_db_path(workspace_path)
-    cli_path = get_cli_chats_path()
-    fingerprint = fingerprint_workspace_storage(
+    if nocache_enabled(request_nocache=nocache):
+        return build_composer_id_to_workspace_id(workspace_path, workspace_entries)
+
+    def build() -> dict[str, str]:
+        return build_composer_id_to_workspace_id(workspace_path, workspace_entries)
+
+    return get_or_build_cached_composer_id_to_ws(
         workspace_path,
         workspace_entries,
-        global_db_path=gdb if os.path.isfile(gdb) else None,
-        rules=rules,
-        cli_chats_path=cli_path if os.path.isdir(cli_path) else None,
+        rules,
+        build_fn=build,
     )
-    if not nocache_enabled(request_nocache=nocache):
-        cached = get_cached_composer_id_to_ws(fingerprint)
-        if cached is not None:
-            return cached
-    mapping = build_composer_id_to_workspace_id(workspace_path, workspace_entries)
-    if not nocache_enabled(request_nocache=nocache):
-        set_cached_composer_id_to_ws(fingerprint, mapping)
-    return mapping
 
 
 @contextmanager

--- a/services/workspace_listing.py
+++ b/services/workspace_listing.py
@@ -25,10 +25,8 @@ from services.workspace_composer_scan import (
     parse_composer_data_row,
 )
 from services.summary_cache import (
-    fingerprint_workspace_storage,
-    get_cached_projects,
+    get_or_build_cached_projects,
     nocache_enabled,
-    set_cached_projects,
 )
 from services.workspace_context import resolve_invalid_workspace_aliases_cached
 from services.workspace_db import (
@@ -69,35 +67,35 @@ def list_workspace_projects(
         :meth:`models.ParseWarningCollector.to_api_list`; empty when no skips.
     """
     effective_nocache = nocache_enabled(request_nocache=nocache)
-    workspace_entries: list[dict[str, Any]] | None = None
-    if not effective_nocache:
-        workspace_entries = collect_workspace_entries(workspace_path)
-        gdb = global_storage_db_path(workspace_path)
-        cli_path = get_cli_chats_path()
-        fingerprint = fingerprint_workspace_storage(
+    if effective_nocache:
+        orch = prepare_workspace_orchestration(
             workspace_path,
-            workspace_entries,
-            global_db_path=gdb if os.path.isfile(gdb) else None,
-            rules=rules,
-            cli_chats_path=cli_path if os.path.isdir(cli_path) else None,
+            rules,
+            nocache=True,
         )
-        cached = get_cached_projects(fingerprint)
-        if cached is not None:
-            return cached
+        return _build_workspace_projects_uncached(
+            workspace_path, rules, orch, nocache=True,
+        )
 
-    orch = prepare_workspace_orchestration(
+    workspace_entries = collect_workspace_entries(workspace_path)
+
+    def build() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        orch = prepare_workspace_orchestration(
+            workspace_path,
+            rules,
+            nocache=False,
+            workspace_entries=workspace_entries,
+        )
+        return _build_workspace_projects_uncached(
+            workspace_path, rules, orch, nocache=False,
+        )
+
+    return get_or_build_cached_projects(
         workspace_path,
+        workspace_entries,
         rules,
-        nocache=effective_nocache,
-        workspace_entries=workspace_entries,
+        build_fn=build,
     )
-
-    projects, warnings = _build_workspace_projects_uncached(
-        workspace_path, rules, orch, nocache=effective_nocache,
-    )
-    if not effective_nocache:
-        set_cached_projects(orch.fingerprint, projects, warnings)
-    return projects, warnings
 
 
 def _build_workspace_projects_uncached(

--- a/services/workspace_listing.py
+++ b/services/workspace_listing.py
@@ -32,7 +32,6 @@ from services.workspace_context import resolve_invalid_workspace_aliases_cached
 from services.workspace_db import (
     COMPOSER_ROWS_WITH_HEADERS_SQL,
     collect_workspace_entries,
-    global_storage_db_path,
     load_project_layouts_map,
     open_global_db,
     safe_fetchall,

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -44,10 +44,8 @@ from services.workspace_composer_scan import (
     parse_composer_data_row,
 )
 from services.summary_cache import (
-    fingerprint_workspace_storage,
-    get_cached_tab_summaries,
+    get_or_build_cached_tab_summaries,
     nocache_enabled,
-    set_cached_tab_summaries,
 )
 from services.workspace_context import (
     resolve_workspace_context_cached,
@@ -56,7 +54,6 @@ from services.workspace_context import (
 from services.workspace_db import (
     COMPOSER_ROWS_WITH_HEADERS_SQL,
     collect_workspace_entries,
-    global_storage_db_path,
     load_bubble_map,
     load_bubbles_for_composer,
     load_code_block_diff_map,
@@ -67,7 +64,6 @@ from services.workspace_db import (
     open_global_db,
     safe_fetchall,
 )
-from utils.workspace_path import get_cli_chats_path
 from services.workspace_resolver import (
     lookup_workspace_display_name,
     matching_workspace_ids_for_folder,
@@ -530,26 +526,23 @@ def list_workspace_tab_summaries(
         but ``tabs`` entries carry no ``bubbles`` field.
     """
     workspace_entries = collect_workspace_entries(workspace_path)
-    gdb = global_storage_db_path(workspace_path)
-    cli_path = get_cli_chats_path()
-    fingerprint = fingerprint_workspace_storage(
+    if nocache_enabled(request_nocache=nocache):
+        return _build_workspace_tab_summaries_uncached(
+            workspace_id, workspace_path, rules, workspace_entries, nocache=nocache,
+        )
+
+    def build() -> tuple[dict[str, Any], int]:
+        return _build_workspace_tab_summaries_uncached(
+            workspace_id, workspace_path, rules, workspace_entries, nocache=nocache,
+        )
+
+    return get_or_build_cached_tab_summaries(
         workspace_path,
         workspace_entries,
-        global_db_path=gdb if os.path.isfile(gdb) else None,
-        rules=rules,
-        cli_chats_path=cli_path if os.path.isdir(cli_path) else None,
+        rules,
+        workspace_id,
+        build_fn=build,
     )
-    if not nocache_enabled(request_nocache=nocache):
-        cached = get_cached_tab_summaries(fingerprint, workspace_id)
-        if cached is not None:
-            return cached
-
-    payload, status = _build_workspace_tab_summaries_uncached(
-        workspace_id, workspace_path, rules, workspace_entries, nocache=nocache,
-    )
-    if status == 200 and not nocache_enabled(request_nocache=nocache):
-        set_cached_tab_summaries(fingerprint, workspace_id, payload, status)
-    return payload, status
 
 
 def _build_workspace_tab_summaries_uncached(

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -526,15 +526,14 @@ def list_workspace_tab_summaries(
         but ``tabs`` entries carry no ``bubbles`` field.
     """
     workspace_entries = collect_workspace_entries(workspace_path)
-    if nocache_enabled(request_nocache=nocache):
-        return _build_workspace_tab_summaries_uncached(
-            workspace_id, workspace_path, rules, workspace_entries, nocache=nocache,
-        )
 
     def build() -> tuple[dict[str, Any], int]:
         return _build_workspace_tab_summaries_uncached(
             workspace_id, workspace_path, rules, workspace_entries, nocache=nocache,
         )
+
+    if nocache_enabled(request_nocache=nocache):
+        return build()
 
     return get_or_build_cached_tab_summaries(
         workspace_path,

--- a/services/workspace_tabs.py
+++ b/services/workspace_tabs.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import os
 import sqlite3
 from collections.abc import Iterator, Mapping
 from datetime import datetime

--- a/tests/test_export_engine.py
+++ b/tests/test_export_engine.py
@@ -64,7 +64,6 @@ def _minimal_orch(
     return WorkspaceOrchestration(
         workspace_path=tmp_ws,
         workspace_entries=[],
-        fingerprint={},
         ctx=_minimal_ctx(),
         workspace_id_to_display_name=display_name or {},
         workspace_id_to_slug=slug_map or {},

--- a/tests/test_summary_cache_concurrency.py
+++ b/tests/test_summary_cache_concurrency.py
@@ -42,18 +42,21 @@ def _make_workspace_fixture(root: str) -> tuple[str, list[dict[str, object]]]:
 class TestSummaryCacheConcurrency(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
-        self.cache_patch = patch.object(summary_cache, "CACHE_DIR", Path(self.tmp.name))
-        self.cache_patch.start()
-        summary_cache.PROJECTS_CACHE_FILE = Path(self.tmp.name) / "projects.json"
-        summary_cache.COMPOSER_MAP_CACHE_FILE = (
-            Path(self.tmp.name) / "composer-id-to-ws.json"
-        )
-        summary_cache.INVALID_WORKSPACE_ALIASES_CACHE_FILE = (
-            Path(self.tmp.name) / "invalid-workspace-aliases.json"
-        )
+        cache_dir = Path(self.tmp.name)
+        self._patches = [
+            patch.object(summary_cache, "CACHE_DIR", cache_dir),
+            patch.object(
+                summary_cache,
+                "PROJECTS_CACHE_FILE",
+                cache_dir / "projects.json",
+            ),
+        ]
+        for patcher in self._patches:
+            patcher.start()
 
     def tearDown(self):
-        self.cache_patch.stop()
+        for patcher in reversed(self._patches):
+            patcher.stop()
         self.tmp.cleanup()
 
     def test_blocked_build_recheck_returns_peer_cache(self):

--- a/tests/test_summary_cache_concurrency.py
+++ b/tests/test_summary_cache_concurrency.py
@@ -22,6 +22,8 @@ from services.summary_cache import (
     get_cached_projects,
 )
 
+_WAIT_TIMEOUT_S = 5.0
+
 
 def _make_workspace_fixture(root: str) -> tuple[str, list[dict[str, object]]]:
     entry_dir = os.path.join(root, "entry1")
@@ -59,11 +61,14 @@ class TestSummaryCacheConcurrency(unittest.TestCase):
             patcher.stop()
         self.tmp.cleanup()
 
+    def _setup_workspace(self, name: str) -> tuple[str, list[dict[str, object]]]:
+        ws_root = os.path.join(self.tmp.name, name)
+        os.makedirs(ws_root)
+        return _make_workspace_fixture(ws_root)
+
     def test_blocked_build_recheck_returns_peer_cache(self):
         """Lost-update: peer write while build is blocked must win on recheck."""
-        ws_root = os.path.join(self.tmp.name, "ws")
-        os.makedirs(ws_root)
-        workspace_path, workspace_entries = _make_workspace_fixture(ws_root)
+        workspace_path, workspace_entries = self._setup_workspace("ws")
 
         peer_projects = [
             {"id": "peer", "name": "Peer", "conversationCount": 1, "lastModified": "x"},
@@ -73,22 +78,14 @@ class TestSummaryCacheConcurrency(unittest.TestCase):
         ]
         build_started = threading.Event()
         allow_build_finish = threading.Event()
-        build_count = 0
-        build_count_lock = threading.Lock()
 
         def blocked_build() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
-            nonlocal build_count
-            with build_count_lock:
-                build_count += 1
-                count = build_count
             build_started.set()
             self.assertTrue(
-                allow_build_finish.wait(timeout=5.0),
+                allow_build_finish.wait(timeout=_WAIT_TIMEOUT_S),
                 msg="timed out waiting to finish blocked build",
             )
-            if count == 1:
-                return stale_projects, []
-            return peer_projects, []
+            return stale_projects, []
 
         errors: list[str] = []
         results: list[tuple[list[dict[str, object]], list[dict[str, object]]]] = []
@@ -109,7 +106,7 @@ class TestSummaryCacheConcurrency(unittest.TestCase):
         def thread_b() -> None:
             try:
                 self.assertTrue(
-                    build_started.wait(timeout=5.0),
+                    build_started.wait(timeout=_WAIT_TIMEOUT_S),
                     msg="thread B started before thread A entered build_fn",
                 )
                 results.append(
@@ -141,9 +138,7 @@ class TestSummaryCacheConcurrency(unittest.TestCase):
         self.assertEqual(on_disk.get("projects"), peer_projects)
 
     def test_concurrent_get_or_build_returns_consistent_results(self):
-        ws_root = os.path.join(self.tmp.name, "ws-warm")
-        os.makedirs(ws_root)
-        workspace_path, workspace_entries = _make_workspace_fixture(ws_root)
+        workspace_path, workspace_entries = self._setup_workspace("ws-warm")
         warm_projects = [
             {"id": "warm", "name": "Warm", "conversationCount": 2, "lastModified": "z"},
         ]
@@ -160,7 +155,7 @@ class TestSummaryCacheConcurrency(unittest.TestCase):
 
         def reader() -> None:
             try:
-                barrier.wait(timeout=5.0)
+                barrier.wait(timeout=_WAIT_TIMEOUT_S)
                 hit = get_or_build_cached_projects(
                     workspace_path,
                     workspace_entries,  # type: ignore[arg-type]
@@ -195,7 +190,7 @@ class TestSummaryCacheConcurrency(unittest.TestCase):
 
         def reader() -> None:
             try:
-                barrier.wait(timeout=5.0)
+                barrier.wait(timeout=_WAIT_TIMEOUT_S)
                 hits.append(get_cached_projects(fp))
             except Exception as exc:
                 errors.append(str(exc))

--- a/tests/test_summary_cache_concurrency.py
+++ b/tests/test_summary_cache_concurrency.py
@@ -1,0 +1,210 @@
+"""Concurrency regression tests for summary-cache fingerprint read-compare-write."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import threading
+import unittest
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from services import summary_cache
+from services.summary_cache import (
+    get_or_build_cached_projects,
+    get_cached_projects,
+)
+
+
+def _make_workspace_fixture(root: str) -> tuple[str, list[dict[str, object]]]:
+    entry_dir = os.path.join(root, "entry1")
+    os.makedirs(entry_dir)
+    db_path = os.path.join(entry_dir, "state.vscdb")
+    with open(db_path, "wb") as f:
+        f.write(b"x")
+    workspace_path = root
+    entries: list[dict[str, object]] = [
+        {
+            "name": "entry1",
+            "workspaceJsonPath": os.path.join(entry_dir, "workspace.json"),
+        },
+    ]
+    return workspace_path, entries
+
+
+class TestSummaryCacheConcurrency(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cache_patch = patch.object(summary_cache, "CACHE_DIR", Path(self.tmp.name))
+        self.cache_patch.start()
+        summary_cache.PROJECTS_CACHE_FILE = Path(self.tmp.name) / "projects.json"
+        summary_cache.COMPOSER_MAP_CACHE_FILE = (
+            Path(self.tmp.name) / "composer-id-to-ws.json"
+        )
+        summary_cache.INVALID_WORKSPACE_ALIASES_CACHE_FILE = (
+            Path(self.tmp.name) / "invalid-workspace-aliases.json"
+        )
+
+    def tearDown(self):
+        self.cache_patch.stop()
+        self.tmp.cleanup()
+
+    def test_blocked_build_recheck_returns_peer_cache(self):
+        """Lost-update: peer write while build is blocked must win on recheck."""
+        ws_root = os.path.join(self.tmp.name, "ws")
+        os.makedirs(ws_root)
+        workspace_path, workspace_entries = _make_workspace_fixture(ws_root)
+
+        peer_projects = [
+            {"id": "peer", "name": "Peer", "conversationCount": 1, "lastModified": "x"},
+        ]
+        stale_projects = [
+            {"id": "stale", "name": "Stale", "conversationCount": 1, "lastModified": "y"},
+        ]
+        build_started = threading.Event()
+        allow_build_finish = threading.Event()
+        build_count = 0
+        build_count_lock = threading.Lock()
+
+        def blocked_build() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+            nonlocal build_count
+            with build_count_lock:
+                build_count += 1
+                count = build_count
+            build_started.set()
+            self.assertTrue(
+                allow_build_finish.wait(timeout=5.0),
+                msg="timed out waiting to finish blocked build",
+            )
+            if count == 1:
+                return stale_projects, []
+            return peer_projects, []
+
+        errors: list[str] = []
+        results: list[tuple[list[dict[str, object]], list[dict[str, object]]]] = []
+
+        def thread_a() -> None:
+            try:
+                results.append(
+                    get_or_build_cached_projects(
+                        workspace_path,
+                        workspace_entries,  # type: ignore[arg-type]
+                        [],
+                        build_fn=blocked_build,  # type: ignore[arg-type]
+                    ),
+                )
+            except Exception as exc:
+                errors.append(f"thread A: {exc}")
+
+        def thread_b() -> None:
+            try:
+                self.assertTrue(
+                    build_started.wait(timeout=5.0),
+                    msg="thread B started before thread A entered build_fn",
+                )
+                results.append(
+                    get_or_build_cached_projects(
+                        workspace_path,
+                        workspace_entries,  # type: ignore[arg-type]
+                        [],
+                        build_fn=lambda: (peer_projects, []),  # type: ignore[arg-type]
+                    ),
+                )
+            except Exception as exc:
+                errors.append(f"thread B: {exc}")
+            finally:
+                allow_build_finish.set()
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            fut_a = pool.submit(thread_a)
+            fut_b = pool.submit(thread_b)
+            for fut in as_completed([fut_a, fut_b]):
+                fut.result()
+
+        self.assertEqual(errors, [], "\n".join(errors))
+        self.assertEqual(len(results), 2)
+        for projects, _warnings in results:
+            self.assertEqual(projects, peer_projects)
+
+        with summary_cache.PROJECTS_CACHE_FILE.open(encoding="utf-8") as f:
+            on_disk = json.load(f)
+        self.assertEqual(on_disk.get("projects"), peer_projects)
+
+    def test_concurrent_get_or_build_returns_consistent_results(self):
+        ws_root = os.path.join(self.tmp.name, "ws-warm")
+        os.makedirs(ws_root)
+        workspace_path, workspace_entries = _make_workspace_fixture(ws_root)
+        warm_projects = [
+            {"id": "warm", "name": "Warm", "conversationCount": 2, "lastModified": "z"},
+        ]
+        fingerprint = summary_cache._workspace_storage_fingerprint(
+            workspace_path,
+            workspace_entries,  # type: ignore[arg-type]
+            [],
+        )
+        summary_cache.set_cached_projects(fingerprint, warm_projects, [])
+
+        barrier = threading.Barrier(8)
+        errors: list[str] = []
+        collected: list[tuple[list[dict[str, object]], list[dict[str, object]]]] = []
+
+        def reader() -> None:
+            try:
+                barrier.wait(timeout=5.0)
+                hit = get_or_build_cached_projects(
+                    workspace_path,
+                    workspace_entries,  # type: ignore[arg-type]
+                    [],
+                    build_fn=lambda: (_ for _ in ()).throw(  # type: ignore[arg-type]
+                        AssertionError("build_fn must not run on warm cache"),
+                    ),
+                )
+                collected.append(hit)
+            except Exception as exc:
+                errors.append(str(exc))
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(reader) for _ in range(8)]
+            for fut in as_completed(futures):
+                fut.result()
+
+        self.assertEqual(errors, [], "\n".join(errors))
+        self.assertEqual(len(collected), 8)
+        for projects, warnings in collected:
+            self.assertEqual(projects, warm_projects)
+            self.assertEqual(warnings, [])
+
+    def test_get_cached_projects_remains_thread_safe(self):
+        fp = {"version": 1, "workspace_path": "/ws", "global_db_mtime_ns": 100}
+        projects = [{"id": "a", "name": "A", "conversationCount": 1, "lastModified": "x"}]
+        summary_cache.set_cached_projects(fp, projects, [])
+
+        barrier = threading.Barrier(12)
+        errors: list[str] = []
+        hits: list[tuple[list[dict[str, object]], list[dict[str, object]]] | None] = []
+
+        def reader() -> None:
+            try:
+                barrier.wait(timeout=5.0)
+                hits.append(get_cached_projects(fp))
+            except Exception as exc:
+                errors.append(str(exc))
+
+        with ThreadPoolExecutor(max_workers=12) as pool:
+            futures = [pool.submit(reader) for _ in range(12)]
+            for fut in as_completed(futures):
+                fut.result()
+
+        self.assertEqual(errors, [], "\n".join(errors))
+        self.assertTrue(all(hit is not None and hit[0] == projects for hit in hits))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_summary_cache_concurrency.py
+++ b/tests/test_summary_cache_concurrency.py
@@ -142,7 +142,7 @@ class TestSummaryCacheConcurrency(unittest.TestCase):
         warm_projects = [
             {"id": "warm", "name": "Warm", "conversationCount": 2, "lastModified": "z"},
         ]
-        fingerprint = summary_cache._workspace_storage_fingerprint(
+        fingerprint = summary_cache.workspace_storage_fingerprint(
             workspace_path,
             workspace_entries,  # type: ignore[arg-type]
             [],


### PR DESCRIPTION
Closes #154 
Under threaded WSGI, two requests could both miss the summary cache, build in parallel, and the slower one would overwrite the faster one's write. That's the bug.

This PR adds a module lock in summary_cache.py and get_or_build_cached_* helpers for all four cache types. Fingerprint and cache lookup happen under the lock; the build runs outside it; then we re-fingerprint and recheck before writing. If another thread filled the cache while we were building, we return that result and skip the write.

The four call sites (workspace_listing, workspace_tabs, workspace_db, workspace_context) now go through those helpers. tests/test_summary_cache_concurrency.py has a deterministic lost-update test plus a warm-cache stress test. Full suite: 614 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of workspace summary caching under concurrent access by serializing cache fingerprinting and cache read/update operations.
  * Prevented lost-update races with double-checked “recheck before write” cache rebuild flow.
  * Ensured workspace tab summaries are cached only when the underlying request succeeds (HTTP 200).
  * Extended consistent caching behavior across workspace project listings, composer/workspace mappings, and invalid workspace alias resolution.
* **Tests**
  * Updated concurrency regression coverage to use the new public cache fingerprint helper and validate consistent results during blocked rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->