### PR TITLE
docs: add [0.2.1] changelog for post-0.2.0 merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **highlight.js SRI pins** for script and theme (#145)
-- **Content-Security-Policy** on all served HTML pages — per-response nonce for
+- **Content-Security-Policy** on all served HTML pages: per-response nonce for
   inline bootstrap; `frame-ancestors 'none'` blocks iframe embedding,
   `img-src 'self' data:` blocks remote images (relax in
   `build_content_security_policy`) (#147)
@@ -23,11 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI regression gate excludes `composers-50` export benchmark (#148)
 
 ### Fixed
-- **highlight.js CDN miss** — workspace view skips `hljs.highlightElement` when
+- **highlight.js CDN miss**: workspace view skips `hljs.highlightElement` when
   the script did not load (#145)
-- **Multi-worker set-workspace** — `/api/set-workspace` returns HTTP 409; set
+- **Multi-worker set-workspace**: `/api/set-workspace` returns HTTP 409; set
   `WORKSPACE_PATH` or pass `--base-dir` at startup (#150)
-- **Summary-cache fingerprint lock** — read-compare-write serialised under a
+- **Summary-cache fingerprint lock**: read-compare-write serialised under a
   module lock (#158)
 
 ## [0.2.0] - 2026-07-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2026-07-30
 
 ### Added
-- **Content-Security-Policy header** with nonce for inline bootstrap (#147)
 - **highlight.js SRI pins** for script and theme (#145)
+- **Content-Security-Policy header** on every served HTML page — restrictive
+  default policy with per-response nonce for inline bootstrap; `frame-ancestors
+  'none'` blocks iframe embedding and `img-src 'self' data:` blocks remote images
+  unless operators relax those directives in `build_content_security_policy`
+  (#147)
 - **Playwright XSS tests** for `renderMarkdownSafe` (#151)
 
 ### Changed
-- **Structured `{error, code}` bodies** across all API blueprints (#146)
+- **Structured `{error, code}` bodies** on workspaces, composers, search, export,
+  PDF, and config API routes (#146)
 - CI regression gate excludes `composers-50` export benchmark (#148)
 
 ### Fixed
-- **HTTP 409** from `/api/set-workspace` when multiple WSGI workers are in use (#150)
+- **Workspace page no longer crashes** when highlight.js fails to load (guards
+  `hljs.highlightElement` behind a typeof check) (#145)
+- **HTTP 409** from `/api/set-workspace` when multiple WSGI workers are in use;
+  multi-worker deployments must set `WORKSPACE_PATH` or pass `--base-dir` at
+  startup (#150)
 - **Summary-cache fingerprint read-compare-write** serialised under a module lock (#158)
 
 ## [0.2.0] - 2026-07-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,25 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **highlight.js SRI pins** for script and theme (#145)
-- **Content-Security-Policy header** on every served HTML page — restrictive
-  default policy with per-response nonce for inline bootstrap; `frame-ancestors
-  'none'` blocks iframe embedding and `img-src 'self' data:` blocks remote images
-  unless operators relax those directives in `build_content_security_policy`
-  (#147)
+- **Content-Security-Policy** on all served HTML pages — per-response nonce for
+  inline bootstrap; `frame-ancestors 'none'` blocks iframe embedding,
+  `img-src 'self' data:` blocks remote images (relax in
+  `build_content_security_policy`) (#147)
 - **Playwright XSS tests** for `renderMarkdownSafe` (#151)
 
 ### Changed
 - **Structured `{error, code}` bodies** on workspaces, composers, search, export,
-  PDF, and config API routes (#146)
+  PDF, and config routes (#146)
 - CI regression gate excludes `composers-50` export benchmark (#148)
 
 ### Fixed
-- **Workspace page no longer crashes** when highlight.js fails to load (guards
-  `hljs.highlightElement` behind a typeof check) (#145)
-- **HTTP 409** from `/api/set-workspace` when multiple WSGI workers are in use;
-  multi-worker deployments must set `WORKSPACE_PATH` or pass `--base-dir` at
-  startup (#150)
-- **Summary-cache fingerprint read-compare-write** serialised under a module lock (#158)
+- **highlight.js CDN miss** — workspace view skips `hljs.highlightElement` when
+  the script did not load (#145)
+- **Multi-worker set-workspace** — `/api/set-workspace` returns HTTP 409; set
+  `WORKSPACE_PATH` or pass `--base-dir` at startup (#150)
+- **Summary-cache fingerprint lock** — read-compare-write serialised under a
+  module lock (#158)
 
 ## [0.2.0] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-30
+
+### Added
+- **Content-Security-Policy header** with nonce for inline bootstrap (#147)
+- **highlight.js SRI pins** for script and theme (#145)
+- **Playwright XSS tests** for `renderMarkdownSafe` (#151)
+
+### Changed
+- **Structured `{error, code}` bodies** across all API blueprints (#146)
+- CI regression gate excludes `composers-50` export benchmark (#148)
+
+### Fixed
+- **HTTP 409** from `/api/set-workspace` when multiple WSGI workers are in use (#150)
+- **Summary-cache fingerprint read-compare-write** serialised under a module lock (#158)
+
 ## [0.2.0] - 2026-07-17
 
 ### Added
@@ -110,6 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace silent `except Exception: pass` with structured logging in workspace and bubble load paths (#66, #76)
 - Decouple API handlers from private `_`-prefixed service internals (#73)
 
-[Unreleased]: https://github.com/cppalliance/cppa-cursor-browser/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/cppalliance/cppa-cursor-browser/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/cppalliance/cppa-cursor-browser/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/cppalliance/cppa-cursor-browser/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/cppalliance/cppa-cursor-browser/releases/tag/v0.1.0


### PR DESCRIPTION
Closes #156

CHANGELOG.md had an empty [Unreleased] block and nothing past v0.2.0. 
Seven PRs landed on master since that tag (#145 through #151, plus #158) with no release notes.

This PR adds a [0.2.1] section dated 2026-07-30, grouped into Added, Changed, and Fixed to match the existing format. Security work (#145, #147), Playwright XSS coverage (#151), structured API errors (#146), the composers-50 bench gate change (#148), multi-worker set-workspace 409 (#150), and the summary-cache lock (#158) each get a one-line entry tied to the merge commit.

[Unreleased] is cleared and the footer compare links point at v0.2.1. No pyproject.toml version bump here; that stays in is-10.
o check: git log v0.2.0..HEAD --oneline against the new bullets, and confirm git diff master...HEAD --stat only touches CHANGELOG.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened Content Security Policy with restrictive per-response nonces for inline bootstrapping (including `frame-ancestors 'none'` and limiting images to `self`/`data:`), plus integrity pinning for syntax-highlighting resources.
  * Further improved safe Markdown rendering protections.
* **Bug Fixes**
  * Fixed workspace highlighting when the syntax-highlighting script fails to load due to a CDN miss, preventing skipped `hljs.highlightElement`.
  * Clarified multi-worker conflict handling for `/api/set-workspace` returning HTTP 409.
  * Reduced summary-cache race conditions by serializing the read/compare/write flow under a module lock.
* **API Improvements**
  * Clarified structured `{ error, code }` bodies apply to key routes (workspaces, composers, search, export, PDF, config).
* **Documentation**
  * Updated `v0.2.1` wording and adjusted compare links (including `[Unreleased]` as `v0.2.1...HEAD` and adding a `[0.2.1]` compare link).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->